### PR TITLE
feat: security tests done

### DIFF
--- a/authentication-service/pom.xml
+++ b/authentication-service/pom.xml
@@ -141,8 +141,93 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <version>3.27.7</version>
             <scope>test</scope>
         </dependency>
+        <!-- Source: https://mvnrepository.com/artifact/io.rest-assured/rest-assured -->
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <version>5.5.6</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Testcontainers — real PostgreSQL for integration tests -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>1.21.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>1.21.4</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Flyway PostgreSQL dialect (required for Flyway 10+) -->
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-database-postgresql</artifactId>
+            <version>11.7.2</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- ===== TEST SCOPE ===== -->
+        <!-- Testcontainers — MongoDB for integration tests -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>2.0.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mongodb</artifactId>
+            <version>1.21.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-openfeign-core</artifactId>
+        </dependency>
+
+        <!-- Cucumber for BDD -->
+        <dependency>
+            <groupId>io.cucumber</groupId>
+            <artifactId>cucumber-java</artifactId>
+            <version>7.15.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.cucumber</groupId>
+            <artifactId>cucumber-spring</artifactId>
+            <version>7.15.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.cucumber</groupId>
+            <artifactId>cucumber-junit-platform-engine</artifactId>
+            <version>7.15.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-suite</artifactId>
+            <version>1.10.2</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <dependencyManagement>
@@ -151,6 +236,13 @@
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-dependencies</artifactId>
                 <version>${spring-cloud.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-bom</artifactId>
+                <version>2.0.2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/authentication-service/src/main/java/code/with/vanilson/authentication/AuthenticationApplication.java
+++ b/authentication-service/src/main/java/code/with/vanilson/authentication/AuthenticationApplication.java
@@ -1,5 +1,6 @@
 package code.with.vanilson.authentication;
 
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;

--- a/authentication-service/src/main/java/code/with/vanilson/authentication/application/AuthService.java
+++ b/authentication-service/src/main/java/code/with/vanilson/authentication/application/AuthService.java
@@ -151,9 +151,20 @@ public class AuthService {
     public void logout(HttpServletRequest httpRequest) {
         String authHeader = httpRequest.getHeader(HttpHeaders.AUTHORIZATION);
         if (!StringUtils.hasText(authHeader) || !authHeader.startsWith("Bearer ")) {
-            return;
+            // No token at all → 401, not silent 204
+            throw new InvalidTokenException(msg("auth.jwt.invalid"), "auth.jwt.invalid");
         }
         String jwt = authHeader.substring(7);
+
+        // Reject revoked / unknown tokens — prevents silent 204 on reuse after logout
+        String  jti        = jwtService.extractJti(jwt);
+        boolean tokenValid = tokenRepository.findByJti(jti)
+                .map(t -> !t.isExpired() && !t.isRevoked())
+                .orElse(false);
+        if (!tokenValid) {
+            throw new InvalidTokenException(msg("auth.jwt.invalid"), "auth.jwt.invalid");
+        }
+
         Long userId = jwtService.extractUserId(jwt);
         log.info(msg("auth.log.logout.attempt", userId));
         tokenRepository.revokeAllUserTokens(userId);

--- a/authentication-service/src/main/java/code/with/vanilson/authentication/config/JpaConfig.java
+++ b/authentication-service/src/main/java/code/with/vanilson/authentication/config/JpaConfig.java
@@ -1,0 +1,26 @@
+package code.with.vanilson.authentication.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+/**
+ * JpaConfig — isolated @Configuration for JPA cross-cutting concerns.
+ * <p>
+ * @EnableJpaAuditing was previously on SecurityConfig. That caused every
+ * @WebMvcTest slice to fail loading SecurityConfig (JPA infrastructure is
+ * not available in the web slice), which made Spring Boot fall back to its
+ * default security configuration — CSRF enabled, all endpoints protected —
+ * returning HTTP 403 for every request in controller tests.
+ * <p>
+ * Placing @EnableJpaAuditing here (a plain @Configuration picked up only
+ * when the full application context is present) keeps the JPA auditing
+ * behaviour intact in production while allowing @WebMvcTest to load
+ * SecurityConfig cleanly.
+ *
+ * @author vamuhong
+ * @version 1.0
+ */
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}

--- a/authentication-service/src/main/java/code/with/vanilson/authentication/config/JwtAuthFilter.java
+++ b/authentication-service/src/main/java/code/with/vanilson/authentication/config/JwtAuthFilter.java
@@ -49,9 +49,9 @@ public class JwtAuthFilter extends OncePerRequestFilter {
     private final ObjectMapper           objectMapper;
 
     @Override
-    protected void doFilterInternal(@NonNull HttpServletRequest request,
-                                    @NonNull HttpServletResponse response,
-                                    @NonNull FilterChain filterChain)
+    public void doFilterInternal(@NonNull HttpServletRequest request,
+                                 @NonNull HttpServletResponse response,
+                                 @NonNull FilterChain filterChain)
             throws ServletException, IOException {
 
         String authHeader = request.getHeader("Authorization");

--- a/authentication-service/src/main/java/code/with/vanilson/authentication/config/MessageSourceConfig.java
+++ b/authentication-service/src/main/java/code/with/vanilson/authentication/config/MessageSourceConfig.java
@@ -1,0 +1,36 @@
+package code.with.vanilson.authentication.config;
+
+import org.springframework.context.MessageSource;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.ResourceBundleMessageSource;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * MessageSourceConfig — isolated @Configuration for the MessageSource bean.
+ * <p>
+ * Extracted from SecurityConfig to break the circular dependency:
+ *   SecurityConfig → JwtAuthFilter → JwtService → MessageSource
+ *                                                       ↑
+ *                                          (was defined inside SecurityConfig)
+ * <p>
+ * By living in its own @Configuration, MessageSource is created before any
+ * of the security beans attempt to initialise, so no circular reference exists.
+ * </p>
+ *
+ * @author vamuhong
+ * @version 1.0
+ */
+@Configuration
+public class MessageSourceConfig {
+
+    @Bean
+    public MessageSource messageSource() {
+        ResourceBundleMessageSource source = new ResourceBundleMessageSource();
+        source.setBasenames("messages");
+        source.setDefaultEncoding(StandardCharsets.UTF_8.name());
+        source.setUseCodeAsDefaultMessage(false);
+        return source;
+    }
+}

--- a/authentication-service/src/main/java/code/with/vanilson/authentication/config/SecurityConfig.java
+++ b/authentication-service/src/main/java/code/with/vanilson/authentication/config/SecurityConfig.java
@@ -1,16 +1,18 @@
 package code.with.vanilson.authentication.config;
 
 import code.with.vanilson.authentication.infrastructure.UserDetailsServiceImpl;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
-import org.springframework.context.MessageSource;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.support.ResourceBundleMessageSource;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
@@ -27,39 +29,51 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
-import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * SecurityConfig — Infrastructure Layer (Security)
  * <p>
  * Configures the Spring Security filter chain with:
  * - STATELESS session (JWT-based)
+ * - AuthenticationEntryPoint: returns 401 JSON + WWW-Authenticate for unauthenticated requests
  * - Actuator restricted to /health only (not /env, /heapdump, /beans)
  * - Explicit CORS configuration
  * - BCrypt password encoder (cost factor 12)
  * - DaoAuthenticationProvider backed by UserDetailsServiceImpl
  * - OpenAPI Swagger with Bearer auth scheme
+ * <p>
+ * NOTE — @EnableJpaAuditing was intentionally moved to JpaConfig so that
+ * @WebMvcTest slices can load SecurityConfig without JPA infrastructure.
  * </p>
  *
  * @author vamuhong
- * @version 2.0
+ * @version 2.1
  */
 @Configuration
 @EnableWebSecurity
-@EnableJpaAuditing
 public class SecurityConfig {
 
     private final JwtAuthFilter          jwtAuthFilter;
     private final UserDetailsServiceImpl userDetailsService;
+    private final ObjectMapper           objectMapper;
 
     public SecurityConfig(JwtAuthFilter jwtAuthFilter,
-                          UserDetailsServiceImpl userDetailsService) {
+                          UserDetailsServiceImpl userDetailsService,
+                          ObjectMapper objectMapper) {
         this.jwtAuthFilter      = jwtAuthFilter;
         this.userDetailsService = userDetailsService;
+        this.objectMapper       = objectMapper;
     }
 
+    // @Order(1) ensures this chain is matched by FilterChainProxy before Spring Boot's
+    // auto-configured default chain (@Order(Integer.MAX_VALUE - 5)), which otherwise wins
+    // in @WebMvcTest when both chains coexist (conditional evaluated before our bean exists).
     @Bean
+    @Order(1)
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
             .csrf(AbstractHttpConfigurer::disable)
@@ -68,15 +82,37 @@ public class SecurityConfig {
                 .requestMatchers(
                     "/api/v1/auth/register",
                     "/api/v1/auth/login",
+                    // /refresh is permit-all: a revoked refresh token must reach
+                    // RefreshTokenService.rotate() so it can return the specific
+                    // "auth.token.refresh.invalid" error code. JwtAuthFilter handles
+                    // cryptographically invalid / expired tokens before the controller.
+                    "/api/v1/auth/refresh",
                     "/swagger-ui/**",
                     "/swagger-ui.html",
                     "/api-docs/**",
                     "/actuator/health",
-                    "/actuator/health/**"   // public: only health check, not env/heapdump/beans
+                    "/actuator/health/**"
                 ).permitAll()
                 .anyRequest().authenticated()
             )
             .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .exceptionHandling(ex -> ex
+                // Return 401 JSON + WWW-Authenticate instead of Spring Security's default 403
+                // for every unauthenticated request to a protected endpoint (e.g. /logout).
+                .authenticationEntryPoint((request, response, authException) -> {
+                    response.setStatus(HttpStatus.UNAUTHORIZED.value());
+                    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+                    response.setHeader(HttpHeaders.WWW_AUTHENTICATE,
+                            "Bearer realm=\"Authentication API\"");
+                    Map<String, Object> body = new LinkedHashMap<>();
+                    body.put("timestamp",  Instant.now().toString());
+                    body.put("status",     401);
+                    body.put("errorCode",  "auth.unauthorized");
+                    body.put("message",    "Authentication required. Please provide a valid Bearer token.");
+                    body.put("path",       request.getRequestURI());
+                    objectMapper.writeValue(response.getOutputStream(), body);
+                })
+            )
             .authenticationProvider(authenticationProvider())
             .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
 
@@ -112,15 +148,6 @@ public class SecurityConfig {
     public AuthenticationManager authenticationManager(AuthenticationConfiguration config)
             throws Exception {
         return config.getAuthenticationManager();
-    }
-
-    @Bean
-    public MessageSource messageSource() {
-        ResourceBundleMessageSource source = new ResourceBundleMessageSource();
-        source.setBasenames("messages");
-        source.setDefaultEncoding(StandardCharsets.UTF_8.name());
-        source.setUseCodeAsDefaultMessage(false);
-        return source;
     }
 
     @Bean

--- a/authentication-service/src/main/java/code/with/vanilson/authentication/infrastructure/JwtService.java
+++ b/authentication-service/src/main/java/code/with/vanilson/authentication/infrastructure/JwtService.java
@@ -2,6 +2,7 @@ package code.with.vanilson.authentication.infrastructure;
 
 import code.with.vanilson.authentication.domain.User;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import lombok.extern.slf4j.Slf4j;
@@ -106,7 +107,13 @@ public class JwtService {
     }
 
     public boolean isTokenExpired(String token) {
-        return extractExpiration(token).before(new Date());
+        try {
+            return extractExpiration(token).before(new Date());
+        } catch (ExpiredJwtException ex) {
+            // JJWT 0.12+ throws ExpiredJwtException during parsing when exp < now.
+            // Treat that as "yes, expired" instead of propagating as a parse error.
+            return true;
+        }
     }
 
     public String extractSubject(String token) {

--- a/authentication-service/src/main/java/code/with/vanilson/authentication/infrastructure/UserDetailsServiceImpl.java
+++ b/authentication-service/src/main/java/code/with/vanilson/authentication/infrastructure/UserDetailsServiceImpl.java
@@ -1,7 +1,6 @@
 package code.with.vanilson.authentication.infrastructure;
 
 import code.with.vanilson.authentication.domain.UserDetailsAdapter;
-import code.with.vanilson.authentication.exception.AuthUserNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.MessageSource;
@@ -41,7 +40,10 @@ public class UserDetailsServiceImpl implements UserDetailsService {
                             "auth.user.not.found", new Object[]{email},
                             LocaleContextHolder.getLocale());
                     log.warn("[UserDetailsService] User not found: email=[{}]", email);
-                    return new AuthUserNotFoundException(message, "auth.user.not.found");
+                    // Must throw UsernameNotFoundException (not a custom subclass) so that
+                    // DaoAuthenticationProvider.hideUserNotFoundExceptions converts it to
+                    // BadCredentialsException — preventing user enumeration and 500 errors.
+                    return new UsernameNotFoundException(message);
                 });
     }
 }

--- a/authentication-service/src/test/java/code/with/vanilson/authentication/bdd/CucumberIntegrationTest.java
+++ b/authentication-service/src/test/java/code/with/vanilson/authentication/bdd/CucumberIntegrationTest.java
@@ -1,0 +1,32 @@
+/**
+ * Author: vanilson muhongo
+ * Date:05/04/2026
+ * Time:15:25
+ * Version:1
+ */
+
+package code.with.vanilson.authentication.bdd;
+import org.junit.platform.suite.api.ConfigurationParameter;
+import org.junit.platform.suite.api.IncludeEngines;
+import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.Suite;
+
+import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.PLUGIN_PROPERTY_NAME;
+
+/**
+ * CucumberIntegrationTest — JUnit Platform Suite runner for all Cucumber BDD scenarios.
+ *
+ * Discovers feature files from classpath:/features/
+ * Step definitions from code.with.vanilson.authentication.bdd package.
+ * Plugins: pretty console output + HTML report.
+ */
+@Suite
+@IncludeEngines("cucumber")
+@SelectClasspathResource("classpath:features")
+@ConfigurationParameter(key = GLUE_PROPERTY_NAME,
+        value = "code.with.vanilson.authentication.bdd")
+@ConfigurationParameter(key = PLUGIN_PROPERTY_NAME,
+        value = "pretty, html:target/cucumber-reports/auth-bdd-report.html")
+public class CucumberIntegrationTest {
+}

--- a/authentication-service/src/test/java/code/with/vanilson/authentication/bdd/CucumberSpringConfiguration.java
+++ b/authentication-service/src/test/java/code/with/vanilson/authentication/bdd/CucumberSpringConfiguration.java
@@ -1,0 +1,43 @@
+package code.with.vanilson.authentication.bdd;
+
+import io.cucumber.spring.CucumberContextConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+/**
+ * CucumberSpringConfiguration — wires the Spring Boot test context for Cucumber BDD tests.
+ *
+ * The PostgreSQL container is started in a static initializer (not via @Testcontainers)
+ * to guarantee it is running before Spring calls @DynamicPropertySource. Using
+ * @Testcontainers + @Container inside a @CucumberContextConfiguration class is unreliable
+ * because the Testcontainers JUnit 5 extension lifecycle does not align with Cucumber's
+ * context lifecycle.
+ *
+ * Flyway migrations are applied automatically when the Spring context starts.
+ */
+@CucumberContextConfiguration
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+public class CucumberSpringConfiguration {
+
+    static final PostgreSQLContainer<?> POSTGRES;
+
+    static {
+        POSTGRES = new PostgreSQLContainer<>("postgres:16-alpine")
+                .withDatabaseName("auth_bdd")
+                .withUsername("bdd_user")
+                .withPassword("bdd_pass");
+        POSTGRES.start();
+    }
+
+    @DynamicPropertySource
+    static void configureDataSource(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url",                POSTGRES::getJdbcUrl);
+        registry.add("spring.datasource.username",           POSTGRES::getUsername);
+        registry.add("spring.datasource.password",           POSTGRES::getPassword);
+        registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+    }
+}

--- a/authentication-service/src/test/java/code/with/vanilson/authentication/bdd/steps/AuthStepDefinitions.java
+++ b/authentication-service/src/test/java/code/with/vanilson/authentication/bdd/steps/AuthStepDefinitions.java
@@ -1,0 +1,459 @@
+package code.with.vanilson.authentication.bdd.steps;
+
+import io.cucumber.datatable.DataTable;
+import io.cucumber.java.Before;
+import io.cucumber.java.en.And;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * AuthStepDefinitions — step definitions for auth.feature.
+ *
+ * NOT annotated with @Component intentionally:
+ *   cucumber-spring calls AutowireCapableBeanFactory.autowireBean() on each new
+ *   instance it creates per scenario. @Component would make Spring treat this as a
+ *   singleton, preventing @Value("${local.server.port}") from resolving correctly
+ *   at construction time (the server port is only bound after the context starts).
+ *
+ * Port is injected via @Autowired Environment, resolved lazily inside the @Before
+ *   hook — by which point the embedded server is guaranteed to be running.
+ *
+ * Unique-email strategy (duplicate-email test):
+ *   uniqueEmail(seed) caches seed → unique address in an instance-local Map.
+ *   Given "a user already exists with email X" and When "register with email X"
+ *   both call uniqueEmail("X"), so they get the SAME address → real 409.
+ */
+public class AuthStepDefinitions {
+
+    private static final AtomicLong SEQ = new AtomicLong(System.nanoTime());
+    private static final String     BASE = "/api/v1/auth";
+
+    /** Injected by cucumber-spring via autowireBean() — safe to use from @Before onward. */
+    @Autowired
+    private Environment environment;
+
+    // ------------------------------------------------------------------
+    // Per-scenario state — reset in @Before (new instance = clean state,
+    // but explicit reset keeps the @Before readable and intent clear).
+    // ------------------------------------------------------------------
+    private Response            lastResponse;
+    private String              currentAccessToken;
+    private String              currentRefreshToken;
+    private String              originalAccessToken;        // the FIRST token issued this scenario
+    private Map<String, String> emailCache;                 // seed → unique address
+    private Map<String, Object> lifecycleData;              // results of the full lifecycle When step
+
+    @Before
+    public void setUp() {
+        int port = Integer.parseInt(environment.getProperty("local.server.port", "8080"));
+        RestAssured.baseURI = "http://localhost";
+        RestAssured.port    = port;
+
+        lastResponse        = null;
+        currentAccessToken  = null;
+        currentRefreshToken = null;
+        originalAccessToken = null;
+        emailCache          = new HashMap<>();
+        lifecycleData       = new HashMap<>();
+    }
+
+    // ------------------------------------------------------------------
+    // Internal helpers
+    // ------------------------------------------------------------------
+
+    /**
+     * Returns a stable unique e-mail for a seed within this scenario.
+     * First call → creates and caches.  Subsequent calls → returns cached.
+     * Critical: Given and When that reference the same seed get the SAME address.
+     */
+    private String uniqueEmail(String seed) {
+        return emailCache.computeIfAbsent(
+                seed,
+                s -> s.replace("@", "_" + SEQ.incrementAndGet() + "@")
+        );
+    }
+
+    private Response callRegister(String email, String password) {
+        return given()
+                .contentType(ContentType.JSON)
+                .body(String.format(
+                        "{\"firstname\":\"BDD\",\"lastname\":\"User\","
+                        + "\"email\":\"%s\",\"password\":\"%s\"}",
+                        email, password))
+                .when()
+                    .post(BASE + "/register")
+                .then()
+                    .extract().response();
+    }
+
+    private void captureTokens(Response r) {
+        if (r.statusCode() == 200 || r.statusCode() == 201) {
+            currentAccessToken  = r.jsonPath().getString("accessToken");
+            currentRefreshToken = r.jsonPath().getString("refreshToken");
+            if (originalAccessToken == null) {
+                originalAccessToken = currentAccessToken;
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Given
+    // ------------------------------------------------------------------
+
+    @Given("the authentication service is running")
+    public void theAuthenticationServiceIsRunning() {
+        int port = Integer.parseInt(environment.getProperty("local.server.port", "0"));
+        assertThat(port).as("Embedded server port must be positive").isPositive();
+    }
+
+    @Given("no user exists with email {string}")
+    public void noUserExistsWithEmail(String seed) {
+        // Pre-seed the cache so any subsequent When step that references the same
+        // seed resolves to the same unique address (and NOT a new collision).
+        uniqueEmail(seed);
+    }
+
+    @Given("a user already exists with email {string}")
+    public void aUserAlreadyExistsWithEmail(String seed) {
+        String email = uniqueEmail(seed);   // cached — When step will reuse this exact address
+        Response r = callRegister(email, "ExistPass1!");
+        assertThat(r.statusCode())
+                .as("Pre-registration must succeed (201). Got: %s", r.asString())
+                .isEqualTo(201);
+        captureTokens(r);
+    }
+
+    @Given("a user exists with email {string} and password {string}")
+    public void aUserExistsWithEmailAndPassword(String seed, String password) {
+        String email = uniqueEmail(seed);   // cached — login When step reuses this address
+        Response r = callRegister(email, password);
+        assertThat(r.statusCode())
+                .as("Pre-registration must succeed (201). Got: %s", r.asString())
+                .isEqualTo(201);
+        captureTokens(r);
+    }
+
+    @Given("a user is registered and logged in with email {string}")
+    public void aUserIsRegisteredAndLoggedIn(String seed) {
+        String email = uniqueEmail(seed);
+        Response r = callRegister(email, "BddPass1!");
+        assertThat(r.statusCode())
+                .as("Registration must succeed (201). Got: %s", r.asString())
+                .isEqualTo(201);
+        currentAccessToken  = r.jsonPath().getString("accessToken");
+        currentRefreshToken = r.jsonPath().getString("refreshToken");
+        originalAccessToken = currentAccessToken;
+    }
+
+    // ------------------------------------------------------------------
+    // When
+    // ------------------------------------------------------------------
+
+    @When("I register with the following details:")
+    public void iRegisterWithTheFollowingDetails(DataTable table) {
+        List<Map<String, String>> rows = table.asMaps(String.class, String.class);
+        Map<String, String> data = rows.get(0);
+
+        String seedEmail    = data.get("email");
+        // uniqueEmail(seed) returns the cached address if a Given already registered it —
+        // this is how the duplicate-email 409 scenario works correctly.
+        String resolvedEmail = seedEmail != null ? uniqueEmail(seedEmail) : null;
+
+        StringBuilder json = new StringBuilder("{");
+        appendField(json, "firstname", data.get("firstname"));
+        appendField(json, "lastname",  data.get("lastname"));
+        if (resolvedEmail != null) appendField(json, "email", resolvedEmail);
+        appendField(json, "password",  data.get("password"));
+        if (json.charAt(json.length() - 1) == ',') json.deleteCharAt(json.length() - 1);
+        json.append("}");
+
+        lastResponse = given()
+                .contentType(ContentType.JSON)
+                .body(json.toString())
+                .when()
+                    .post(BASE + "/register")
+                .then()
+                    .extract().response();
+
+        captureTokens(lastResponse);
+    }
+
+    @When("I log in with email {string} and password {string}")
+    public void iLogInWithEmailAndPassword(String seed, String password) {
+        // uniqueEmail(seed) returns the same address the Given step registered.
+        String email = uniqueEmail(seed);
+        lastResponse = given()
+                .contentType(ContentType.JSON)
+                .body(String.format("{\"email\":\"%s\",\"password\":\"%s\"}", email, password))
+                .when()
+                    .post(BASE + "/login")
+                .then()
+                    .extract().response();
+
+        if (lastResponse.statusCode() == 200) {
+            currentAccessToken  = lastResponse.jsonPath().getString("accessToken");
+            currentRefreshToken = lastResponse.jsonPath().getString("refreshToken");
+        }
+    }
+
+    @When("I send an empty login request")
+    public void iSendAnEmptyLoginRequest() {
+        lastResponse = given()
+                .contentType(ContentType.JSON)
+                .body("{}")
+                .when()
+                    .post(BASE + "/login")
+                .then()
+                    .extract().response();
+    }
+
+    @When("I refresh the token using the refresh token")
+    public void iRefreshTheTokenUsingTheRefreshToken() {
+        lastResponse = given()
+                .header("Authorization", "Bearer " + currentRefreshToken)
+                .when()
+                    .post(BASE + "/refresh")
+                .then()
+                    .extract().response();
+
+        if (lastResponse.statusCode() == 200) {
+            currentAccessToken = lastResponse.jsonPath().getString("accessToken");
+        }
+    }
+
+    @When("I refresh the token using the access token instead of the refresh token")
+    public void iRefreshTheTokenUsingTheAccessTokenInsteadOfTheRefreshToken() {
+        lastResponse = given()
+                .header("Authorization", "Bearer " + currentAccessToken)
+                .when()
+                    .post(BASE + "/refresh")
+                .then()
+                    .extract().response();
+    }
+
+    @When("I call the refresh endpoint without any authorization header")
+    public void iCallTheRefreshEndpointWithoutAnyAuthorizationHeader() {
+        lastResponse = given()
+                .when()
+                    .post(BASE + "/refresh")
+                .then()
+                    .extract().response();
+    }
+
+    @When("I call the refresh endpoint with token {string}")
+    public void iCallTheRefreshEndpointWithToken(String token) {
+        lastResponse = given()
+                .header("Authorization", "Bearer " + token)
+                .when()
+                    .post(BASE + "/refresh")
+                .then()
+                    .extract().response();
+    }
+
+    @When("I log out using the current access token")
+    public void iLogOutUsingTheCurrentAccessToken() {
+        lastResponse = given()
+                .header("Authorization", "Bearer " + currentAccessToken)
+                .when()
+                    .post(BASE + "/logout")
+                .then()
+                    .extract().response();
+    }
+
+    @When("I call the logout endpoint without any authorization header")
+    public void iCallTheLogoutEndpointWithoutAnyAuthorizationHeader() {
+        lastResponse = given()
+                .when()
+                    .post(BASE + "/logout")
+                .then()
+                    .extract().response();
+    }
+
+    @When("I attempt to log out again with the same access token")
+    public void iAttemptToLogOutAgainWithTheSameAccessToken() {
+        lastResponse = given()
+                .header("Authorization", "Bearer " + originalAccessToken)
+                .when()
+                    .post(BASE + "/logout")
+                .then()
+                    .extract().response();
+    }
+
+    @When("I complete the full auth lifecycle for {string}")
+    public void iCompleteTheFullAuthLifecycleFor(String seed) {
+        String email = uniqueEmail(seed);
+
+        // Step 1 — Register
+        Response reg = callRegister(email, "Lifecycle1!");
+        assertThat(reg.statusCode()).as("lifecycle register").isEqualTo(201);
+        String regRefreshToken = reg.jsonPath().getString("refreshToken");
+
+        // Step 2 — Login (revokes all previous tokens, issues fresh pair)
+        Response login = given()
+                .contentType(ContentType.JSON)
+                .body(String.format("{\"email\":\"%s\",\"password\":\"Lifecycle1!\"}", email))
+                .when().post(BASE + "/login")
+                .then().extract().response();
+        assertThat(login.statusCode()).as("lifecycle login").isEqualTo(200);
+        String loginAccessToken  = login.jsonPath().getString("accessToken");
+        String loginRefreshToken = login.jsonPath().getString("refreshToken");
+
+        // Step 3 — Refresh using the login refresh token
+        Response refresh = given()
+                .header("Authorization", "Bearer " + loginRefreshToken)
+                .when().post(BASE + "/refresh")
+                .then().extract().response();
+        assertThat(refresh.statusCode()).as("lifecycle refresh").isEqualTo(200);
+        String rotatedAccessToken = refresh.jsonPath().getString("accessToken");
+
+        // Step 4 — Logout using the rotated access token
+        Response logout = given()
+                .header("Authorization", "Bearer " + rotatedAccessToken)
+                .when().post(BASE + "/logout")
+                .then().extract().response();
+        assertThat(logout.statusCode()).as("lifecycle logout").isEqualTo(204);
+
+        // Step 5 — Stale registration refresh token must now be rejected
+        Response stale = given()
+                .header("Authorization", "Bearer " + regRefreshToken)
+                .when().post(BASE + "/refresh")
+                .then().extract().response();
+
+        // Persist results for Then assertions
+        lifecycleData.put("logoutStatus",         logout.statusCode());
+        lifecycleData.put("staleStatus",          stale.statusCode());
+        lifecycleData.put("rotatedAccessToken",   rotatedAccessToken);
+        lifecycleData.put("loginAccessToken",     loginAccessToken);
+
+        lastResponse = logout;
+    }
+
+    // ------------------------------------------------------------------
+    // Then / And
+    // ------------------------------------------------------------------
+
+    @Then("the response status is {int}")
+    public void theResponseStatusIs(int expected) {
+        assertThat(lastResponse.statusCode())
+                .as("Expected HTTP %d but was %d. Body: %s",
+                        expected, lastResponse.statusCode(), lastResponse.asString())
+                .isEqualTo(expected);
+    }
+
+    @And("the response contains a valid access token")
+    public void theResponseContainsAValidAccessToken() {
+        String token = lastResponse.jsonPath().getString("accessToken");
+        assertThat(token)
+                .as("accessToken must be a non-blank JWT (header.payload.signature)")
+                .isNotBlank()
+                .matches(".+\\..+\\..+");
+    }
+
+    @And("the response contains a valid refresh token")
+    public void theResponseContainsAValidRefreshToken() {
+        String token = lastResponse.jsonPath().getString("refreshToken");
+        assertThat(token)
+                .as("refreshToken must be a non-blank JWT (header.payload.signature)")
+                .isNotBlank()
+                .matches(".+\\..+\\..+");
+    }
+
+    @And("the response token type is {string}")
+    public void theResponseTokenTypeIs(String expected) {
+        assertThat(lastResponse.jsonPath().getString("tokenType")).isEqualTo(expected);
+    }
+
+    @And("the response role is {string}")
+    public void theResponseRoleIs(String expected) {
+        assertThat(lastResponse.jsonPath().getString("role")).isEqualTo(expected);
+    }
+
+    @And("the response email is {string}")
+    public void theResponseEmailIs(String seed) {
+        // The actual email was uniquified — match on the domain part only.
+        String domain = seed.substring(seed.indexOf('@'));
+        assertThat(lastResponse.jsonPath().getString("email"))
+                .as("email domain should match '%s'", domain)
+                .contains(domain);
+    }
+
+    @And("the error code is {string}")
+    public void theErrorCodeIs(String expected) {
+        assertThat(lastResponse.jsonPath().getString("errorCode"))
+                .as("errorCode in response body")
+                .isEqualTo(expected);
+    }
+
+    @And("the error message is {string}")
+    public void theErrorMessageIs(String expected) {
+        assertThat(lastResponse.jsonPath().getString("message")).isEqualTo(expected);
+    }
+
+    @And("the error message contains {string}")
+    public void theErrorMessageContains(String expected) {
+        assertThat(lastResponse.jsonPath().getString("message")).contains(expected);
+    }
+
+    @And("the field error {string} is present")
+    public void theFieldErrorIsPresent(String field) {
+        Object value = lastResponse.jsonPath().get("fieldErrors." + field);
+        assertThat(value)
+                .as("fieldErrors.%s must be present. Response: %s", field, lastResponse.asString())
+                .isNotNull();
+    }
+
+    @And("the new access token is different from the original access token")
+    public void theNewAccessTokenIsDifferentFromTheOriginalAccessToken() {
+        assertThat(lastResponse.jsonPath().getString("accessToken"))
+                .as("Refreshed access token must differ from the original token")
+                .isNotEqualTo(originalAccessToken);
+    }
+
+    @And("the error response contains field {string}")
+    public void theErrorResponseContainsField(String field) {
+        assertThat((Object) lastResponse.jsonPath().get(field))
+                .as("Error response must contain field '%s'. Response: %s",
+                        field, lastResponse.asString())
+                .isNotNull();
+    }
+
+    @Then("the lifecycle completes without errors")
+    public void theLifecycleCompletesWithoutErrors() {
+        assertThat(lifecycleData.get("logoutStatus"))
+                .as("Lifecycle logout step should return 204")
+                .isEqualTo(204);
+    }
+
+    @And("all tokens are properly rotated and invalidated")
+    public void allTokensAreProperlyRotatedAndInvalidated() {
+        assertThat(lifecycleData.get("staleStatus"))
+                .as("Stale registration refresh token should be rejected (401)")
+                .isEqualTo(401);
+        assertThat(lifecycleData.get("rotatedAccessToken"))
+                .as("Access token must have been rotated during the refresh step")
+                .isNotEqualTo(lifecycleData.get("loginAccessToken"));
+    }
+
+    // ------------------------------------------------------------------
+    // Private helper
+    // ------------------------------------------------------------------
+    private void appendField(StringBuilder sb, String key, String value) {
+        if (value != null) {
+            sb.append('"').append(key).append("\":\"").append(value).append("\",");
+        }
+    }
+}

--- a/authentication-service/src/test/java/code/with/vanilson/authentication/controller/AuthControllerTest.java
+++ b/authentication-service/src/test/java/code/with/vanilson/authentication/controller/AuthControllerTest.java
@@ -1,0 +1,498 @@
+package code.with.vanilson.authentication.controller;
+
+import code.with.vanilson.authentication.application.AuthResponse;
+import code.with.vanilson.authentication.application.AuthService;
+import code.with.vanilson.authentication.config.JwtAuthFilter;
+import code.with.vanilson.authentication.config.SecurityConfig;
+import code.with.vanilson.authentication.exception.InvalidCredentialsException;
+import code.with.vanilson.authentication.exception.InvalidTokenException;
+import code.with.vanilson.authentication.exception.TokenRevokedException;
+import code.with.vanilson.authentication.exception.UserAlreadyExistsException;
+import code.with.vanilson.authentication.infrastructure.JwtService;
+import code.with.vanilson.authentication.infrastructure.TokenRepository;
+import code.with.vanilson.authentication.infrastructure.UserDetailsServiceImpl;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Map;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * AuthControllerTest — @WebMvcTest slice.
+ * Validates HTTP contracts: status codes, response structure, header presence,
+ * validation errors, and security enforcement — without hitting the database.
+ *
+ * <h3>JwtAuthFilter mock strategy</h3>
+ * <p>Mockito 5.x (Spring Boot 3) uses the inline mock maker, which mocks {@code final}
+ * methods. {@code OncePerRequestFilter.doFilter()} is {@code final}, so without setup the
+ * mock is a no-op — the Spring Security {@code VirtualFilterChain} stalls before
+ * {@code ExceptionTranslationFilter} and {@code AuthorizationFilter} can run.</p>
+ *
+ * <p>{@link #setUpFilterPassThrough()} configures {@code doFilter()} to forward every
+ * request to the next filter in the chain, letting Spring Security enforce access
+ * rules (permitAll for public endpoints, authenticated-only for protected ones).</p>
+ *
+ * <h3>SecurityFilterChain ordering</h3>
+ * <p>{@code SecurityConfig.securityFilterChain()} is annotated {@code @Order(1)}, which
+ * guarantees it is matched by {@code FilterChainProxy} before Spring Boot's default
+ * HTTP-Basic chain ({@code @Order(Integer.MAX_VALUE - 5)}). Without that annotation both
+ * chains may coexist in {@code @WebMvcTest} and the wrong one wins.</p>
+ */
+@WebMvcTest(code.with.vanilson.authentication.presentation.AuthController.class)
+@Import(SecurityConfig.class)
+@ActiveProfiles("test")
+@DisplayName("AuthController WebMvc Tests")
+class AuthControllerTest {
+
+    @Autowired MockMvc       mockMvc;
+    @Autowired ObjectMapper  objectMapper;
+
+    @MockBean AuthService            authService;
+    @MockBean JwtService             jwtService;
+    @MockBean TokenRepository        tokenRepository;
+    @MockBean UserDetailsServiceImpl userDetailsService;
+    @MockBean JwtAuthFilter          jwtAuthFilter;
+
+    private static final String BASE = "/api/v1/auth";
+
+    private static final AuthResponse SAMPLE_RESPONSE = AuthResponse.of(
+            "sample.access.token", "sample.refresh.token",
+            "1", "user@example.com", "USER", "default");
+
+    /**
+     * Configure the JwtAuthFilter mock to forward every request to the next filter.
+     * Without this, Mockito's inline mock maker stubs the {@code final doFilter()} as a
+     * no-op, stopping the Spring Security VirtualFilterChain before security rules run.
+     */
+    @BeforeEach
+    void setUpFilterPassThrough() throws Exception {
+        doAnswer(inv -> {
+            FilterChain chain = inv.getArgument(2);
+            chain.doFilter(
+                    inv.<ServletRequest>getArgument(0),
+                    inv.<ServletResponse>getArgument(1));
+            return null;
+        }).when(jwtAuthFilter).doFilter(any(), any(), any());
+    }
+
+    // -------------------------------------------------------
+    // POST /register
+    // -------------------------------------------------------
+    @Nested
+    @DisplayName("POST /register")
+    class Register {
+
+        @Test
+        @DisplayName("201 Created with tokens on valid payload")
+        void validRegisterReturns201() throws Exception {
+            when(authService.register(any())).thenReturn(SAMPLE_RESPONSE);
+
+            mockMvc.perform(post(BASE + "/register")
+                    .with(csrf())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(json("firstname", "Jane", "lastname", "Doe",
+                            "email", "jane@example.com", "password", "password123")))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.accessToken", is("sample.access.token")))
+                    .andExpect(jsonPath("$.refreshToken", is("sample.refresh.token")))
+                    .andExpect(jsonPath("$.tokenType", is("Bearer")))
+                    .andExpect(jsonPath("$.email", is("user@example.com")))
+                    .andExpect(jsonPath("$.role", is("USER")));
+        }
+
+        @Test
+        @DisplayName("409 Conflict when email already registered")
+        void duplicateEmailReturns409() throws Exception {
+            doThrow(new UserAlreadyExistsException(
+                    "A user with email [jane@example.com] already exists.",
+                    "auth.user.already.exists"))
+                    .when(authService).register(any());
+
+            mockMvc.perform(post(BASE + "/register")
+                    .with(csrf())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(json("firstname", "Jane", "lastname", "Doe",
+                            "email", "jane@example.com", "password", "password123")))
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.status", is(409)))
+                    .andExpect(jsonPath("$.errorCode", is("auth.user.already.exists")))
+                    .andExpect(jsonPath("$.message", containsString("already exists")))
+                    .andExpect(jsonPath("$.timestamp", notNullValue()));
+        }
+
+        @Test
+        @DisplayName("400 Bad Request when email is missing")
+        void missingEmailReturns400() throws Exception {
+            mockMvc.perform(post(BASE + "/register")
+                    .with(csrf())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(json("firstname", "Jane", "lastname", "Doe",
+                            "password", "password123")))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status", is(400)))
+                    .andExpect(jsonPath("$.errorCode", is("auth.validation.failed")))
+                    .andExpect(jsonPath("$.fieldErrors", hasKey("email")));
+        }
+
+        @Test
+        @DisplayName("400 Bad Request when email format is invalid")
+        void invalidEmailFormatReturns400() throws Exception {
+            mockMvc.perform(post(BASE + "/register")
+                    .with(csrf())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(json("firstname", "Jane", "lastname", "Doe",
+                            "email", "not-an-email", "password", "password123")))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.fieldErrors.email", notNullValue()));
+        }
+
+        @Test
+        @DisplayName("400 Bad Request when password is too short (< 8 chars)")
+        void shortPasswordReturns400() throws Exception {
+            mockMvc.perform(post(BASE + "/register")
+                    .with(csrf())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(json("firstname", "Jane", "lastname", "Doe",
+                            "email", "jane@example.com", "password", "short")))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.fieldErrors.password", notNullValue()));
+        }
+
+        @Test
+        @DisplayName("400 Bad Request when firstname is blank")
+        void blankFirstnameReturns400() throws Exception {
+            mockMvc.perform(post(BASE + "/register")
+                    .with(csrf())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(json("firstname", "", "lastname", "Doe",
+                            "email", "jane@example.com", "password", "password123")))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.fieldErrors.firstname", notNullValue()));
+        }
+
+        @Test
+        @DisplayName("400 Bad Request when body is completely empty")
+        void emptyBodyReturns400() throws Exception {
+            mockMvc.perform(post(BASE + "/register")
+                    .with(csrf())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{}"))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.fieldErrors", notNullValue()));
+        }
+    }
+
+    // -------------------------------------------------------
+    // POST /login
+    // -------------------------------------------------------
+    @Nested
+    @DisplayName("POST /login")
+    class Login {
+
+        @Test
+        @DisplayName("200 OK with tokens on valid credentials")
+        void validLoginReturns200() throws Exception {
+            when(authService.login(any())).thenReturn(SAMPLE_RESPONSE);
+
+            mockMvc.perform(post(BASE + "/login")
+                    .with(csrf())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(json("email", "user@example.com", "password", "password123")))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.accessToken", is("sample.access.token")))
+                    .andExpect(jsonPath("$.refreshToken", is("sample.refresh.token")))
+                    .andExpect(jsonPath("$.tokenType", is("Bearer")));
+        }
+
+        @Test
+        @DisplayName("401 Unauthorized on wrong credentials")
+        void wrongCredentialsReturns401() throws Exception {
+            doThrow(new InvalidCredentialsException(
+                    "Invalid email or password. Please check and try again.",
+                    "auth.login.invalid.credentials"))
+                    .when(authService).login(any());
+
+            mockMvc.perform(post(BASE + "/login")
+                    .with(csrf())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(json("email", "user@example.com", "password", "wrong")))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.status", is(401)))
+                    .andExpect(jsonPath("$.errorCode", is("auth.login.invalid.credentials")))
+                    .andExpect(jsonPath("$.message",
+                            is("Invalid email or password. Please check and try again.")));
+        }
+
+        @Test
+        @DisplayName("400 Bad Request when email is missing from login body")
+        void missingEmailInLoginReturns400() throws Exception {
+            mockMvc.perform(post(BASE + "/login")
+                    .with(csrf())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(json("password", "password123")))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.fieldErrors.email", notNullValue()));
+        }
+
+        @Test
+        @DisplayName("400 Bad Request when password is missing from login body")
+        void missingPasswordInLoginReturns400() throws Exception {
+            mockMvc.perform(post(BASE + "/login")
+                    .with(csrf())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(json("email", "user@example.com")))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.fieldErrors.password", notNullValue()));
+        }
+    }
+
+    // -------------------------------------------------------
+    // POST /refresh
+    // -------------------------------------------------------
+    @Nested
+    @DisplayName("POST /refresh")
+    class Refresh {
+
+        @Test
+        @DisplayName("401 Unauthorized when no token is provided")
+        void noTokenReturns401() throws Exception {
+            // /refresh is permitAll() — Spring Security lets it through.
+            // The service is responsible for rejecting requests without a Bearer header.
+            doThrow(new InvalidTokenException(
+                    "Invalid or malformed JWT token.", "auth.jwt.invalid"))
+                    .when(authService).refreshToken(any());
+
+            mockMvc.perform(post(BASE + "/refresh")
+                    .with(csrf()))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("200 OK with new token pair when valid Bearer token provided")
+        @WithMockUser(username = "user@example.com", roles = "USER")
+        void validTokenReturns200() throws Exception {
+            when(authService.refreshToken(any())).thenReturn(
+                    AuthResponse.of("newAccess", "newRefresh", "1", "user@example.com", "USER", "default"));
+
+            mockMvc.perform(post(BASE + "/refresh")
+                    .with(csrf())
+                    .header("Authorization", "Bearer valid.refresh.jwt"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.accessToken", is("newAccess")))
+                    .andExpect(jsonPath("$.refreshToken", is("newRefresh")));
+        }
+
+        @Test
+        @DisplayName("401 Unauthorized when revoked token is used")
+        @WithMockUser(username = "user@example.com", roles = "USER")
+        void revokedTokenReturns401() throws Exception {
+            doThrow(new TokenRevokedException(
+                    "Refresh token is invalid or has been revoked. Please log in again.",
+                    "auth.token.refresh.invalid"))
+                    .when(authService).refreshToken(any());
+
+            mockMvc.perform(post(BASE + "/refresh")
+                    .with(csrf())
+                    .header("Authorization", "Bearer revoked.refresh.jwt"))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.errorCode", is("auth.token.refresh.invalid")));
+        }
+
+        @Test
+        @DisplayName("401 Unauthorized when access token used instead of refresh token")
+        @WithMockUser(username = "user@example.com", roles = "USER")
+        void accessTokenAsRefreshReturns401() throws Exception {
+            doThrow(new InvalidTokenException(
+                    "Invalid or malformed JWT token.",
+                    "auth.jwt.invalid"))
+                    .when(authService).refreshToken(any());
+
+            mockMvc.perform(post(BASE + "/refresh")
+                    .with(csrf())
+                    .header("Authorization", "Bearer access.token.misused.as.refresh"))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.errorCode", is("auth.jwt.invalid")));
+        }
+    }
+
+    // -------------------------------------------------------
+    // POST /logout
+    // -------------------------------------------------------
+    @Nested
+    @DisplayName("POST /logout")
+    class Logout {
+
+        @Test
+        @DisplayName("401 Unauthorized when no token is provided")
+        void noTokenReturns401() throws Exception {
+            // /logout is a protected endpoint — Spring Security rejects the unauthenticated
+            // request via the AuthenticationEntryPoint before it reaches the controller.
+            mockMvc.perform(post(BASE + "/logout")
+                    .with(csrf()))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("204 No Content on successful logout with valid token")
+        @WithMockUser(username = "user@example.com", roles = "USER")
+        void validLogoutReturns204() throws Exception {
+            doNothing().when(authService).logout(any());
+
+            mockMvc.perform(post(BASE + "/logout")
+                    .with(csrf())
+                    .header("Authorization", "Bearer valid.access.jwt"))
+                    .andExpect(status().isNoContent());
+        }
+    }
+
+    // -------------------------------------------------------
+    // Security headers
+    // -------------------------------------------------------
+    @Nested
+    @DisplayName("Security Headers")
+    class SecurityHeaders {
+
+        @Test
+        @DisplayName("401 responses include WWW-Authenticate header")
+        void unauthorizedResponseHasWwwAuthenticate() throws Exception {
+            // /logout is protected — entry point returns 401 + WWW-Authenticate header
+            mockMvc.perform(post(BASE + "/logout")
+                    .with(csrf()))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(header().exists("WWW-Authenticate"));
+        }
+
+        @Test
+        @DisplayName("public endpoints are accessible without credentials")
+        void publicEndpointsAccessibleWithoutCredentials() throws Exception {
+            when(authService.login(any())).thenReturn(SAMPLE_RESPONSE);
+            mockMvc.perform(post(BASE + "/login")
+                    .with(csrf())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(json("email", "user@example.com", "password", "password123")))
+                    .andExpect(status().isOk());
+        }
+    }
+
+    // -------------------------------------------------------
+    // RBAC — @WithMockUser role simulation
+    // -------------------------------------------------------
+    @Nested
+    @DisplayName("Role-Based Authorization")
+    class RoleBasedAuthorization {
+
+        @Test
+        @DisplayName("USER role can call /logout")
+        @WithMockUser(username = "user@example.com", roles = "USER")
+        void userRoleCanCallLogout() throws Exception {
+            doNothing().when(authService).logout(any());
+            mockMvc.perform(post(BASE + "/logout")
+                    .with(csrf())
+                    .header("Authorization", "Bearer token"))
+                    .andExpect(status().isNoContent());
+        }
+
+        @Test
+        @DisplayName("ADMIN role can call /logout")
+        @WithMockUser(username = "admin@example.com", roles = "ADMIN")
+        void adminRoleCanCallLogout() throws Exception {
+            doNothing().when(authService).logout(any());
+            mockMvc.perform(post(BASE + "/logout")
+                    .with(csrf())
+                    .header("Authorization", "Bearer token"))
+                    .andExpect(status().isNoContent());
+        }
+    }
+
+    // -------------------------------------------------------
+    // Error response structure contract
+    // -------------------------------------------------------
+    @Nested
+    @DisplayName("Error Response Contract")
+    class ErrorResponseContract {
+
+        @Test
+        @DisplayName("error response contains timestamp, status, errorCode, message, path")
+        void errorResponseContainsAllRequiredFields() throws Exception {
+            doThrow(new InvalidCredentialsException(
+                    "Invalid email or password. Please check and try again.",
+                    "auth.login.invalid.credentials"))
+                    .when(authService).login(any());
+
+            mockMvc.perform(post(BASE + "/login")
+                    .with(csrf())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(json("email", "u@example.com", "password", "wrong")))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.timestamp", notNullValue()))
+                    .andExpect(jsonPath("$.status", is(401)))
+                    .andExpect(jsonPath("$.errorCode", notNullValue()))
+                    .andExpect(jsonPath("$.message", notNullValue()))
+                    .andExpect(jsonPath("$.path", notNullValue()));
+        }
+
+        @Test
+        @DisplayName("validation error response contains fieldErrors map")
+        void validationErrorContainsFieldErrors() throws Exception {
+            mockMvc.perform(post(BASE + "/login")
+                    .with(csrf())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{}"))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.fieldErrors", notNullValue()))
+                    .andExpect(jsonPath("$.errorCode", is("auth.validation.failed")));
+        }
+
+        @Test
+        @DisplayName("unsuccessful request leaves no side effects (server remains clean)")
+        void unsuccessfulRequestLeavesNoSideEffects() throws Exception {
+            // Sending invalid payload — no DB call should be made (no side effects)
+            mockMvc.perform(post(BASE + "/register")
+                    .with(csrf())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{}"))
+                    .andExpect(status().isBadRequest());
+            // AuthService.register was never called
+            org.mockito.Mockito.verify(authService, org.mockito.Mockito.never()).register(any());
+        }
+    }
+
+    // -------------------------------------------------------
+    // Helper
+    // -------------------------------------------------------
+    private String json(String... kvPairs) throws Exception {
+        Map<String, Object> map = new java.util.LinkedHashMap<>();
+        for (int i = 0; i < kvPairs.length - 1; i += 2) {
+            map.put(kvPairs[i], kvPairs[i + 1]);
+        }
+        return objectMapper.writeValueAsString(map);
+    }
+}

--- a/authentication-service/src/test/java/code/with/vanilson/authentication/integration/AuthIntegrationTest.java
+++ b/authentication-service/src/test/java/code/with/vanilson/authentication/integration/AuthIntegrationTest.java
@@ -1,0 +1,429 @@
+package code.with.vanilson.authentication.integration;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * AuthIntegrationTest — full-stack integration tests using:
+ *   - @SpringBootTest: loads complete application context
+ *   - @AutoConfigureMockMvc: provides MockMvc without a running server
+ *   - Testcontainers: real PostgreSQL with Flyway migrations applied
+ *   - @ActiveProfiles("test"): loads application-test.properties
+ *
+ * These tests cover end-to-end authentication flows with real DB persistence.
+ * No mocking of services — exercises the full filter chain and security enforcement.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+@ActiveProfiles("test")
+@DisplayName("Authentication Integration Tests (Testcontainers + MockMvc)")
+class AuthIntegrationTest {
+
+    @Container
+    static PostgreSQLContainer<?> postgres =
+            new PostgreSQLContainer<>("postgres:16-alpine")
+                    .withDatabaseName("auth_test")
+                    .withUsername("auth_user")
+                    .withPassword("auth_pass");
+
+    @DynamicPropertySource
+    static void configureDataSource(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url",      postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+        registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+    }
+
+    @Autowired MockMvc      mockMvc;
+    @Autowired ObjectMapper objectMapper;
+
+    private static final String BASE = "/api/v1/auth";
+
+    // -------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------
+    private String json(Object... pairs) throws Exception {
+        var map = new java.util.LinkedHashMap<>();
+        for (int i = 0; i < pairs.length - 1; i += 2) map.put(pairs[i], pairs[i + 1]);
+        return objectMapper.writeValueAsString(map);
+    }
+
+    private JsonNode bodyOf(MvcResult result) throws Exception {
+        return objectMapper.readTree(result.getResponse().getContentAsString());
+    }
+
+    private String uniqueEmail() {
+        return "user_" + System.nanoTime() + "@example.com";
+    }
+
+    // -------------------------------------------------------
+    // Registration
+    // -------------------------------------------------------
+    @Nested
+    @DisplayName("Registration")
+    class Registration {
+
+        @Test
+        @DisplayName("201 Created: new user returns access + refresh tokens")
+        void registerNewUserReturns201WithTokens() throws Exception {
+            String email = uniqueEmail();
+            mockMvc.perform(post(BASE + "/register")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(json("firstname", "John", "lastname", "Smith",
+                            "email", email, "password", "securePass1")))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.accessToken",  notNullValue()))
+                    .andExpect(jsonPath("$.refreshToken", notNullValue()))
+                    .andExpect(jsonPath("$.tokenType",    is("Bearer")))
+                    .andExpect(jsonPath("$.email",        is(email)))
+                    .andExpect(jsonPath("$.role",         is("USER")));
+        }
+
+        @Test
+        @DisplayName("409 Conflict: duplicate email rejected")
+        void duplicateEmailReturns409() throws Exception {
+            String email = uniqueEmail();
+            String payload = json("firstname", "John", "lastname", "Smith",
+                    "email", email, "password", "securePass1");
+
+            mockMvc.perform(post(BASE + "/register").contentType(MediaType.APPLICATION_JSON).content(payload))
+                    .andExpect(status().isCreated());
+
+            mockMvc.perform(post(BASE + "/register").contentType(MediaType.APPLICATION_JSON).content(payload))
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.errorCode", is("auth.user.already.exists")))
+                    .andExpect(jsonPath("$.message",   notNullValue()));
+        }
+
+        @Test
+        @DisplayName("400 Bad Request: missing required fields")
+        void missingFieldsReturn400() throws Exception {
+            mockMvc.perform(post(BASE + "/register")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{}"))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.fieldErrors", notNullValue()));
+        }
+
+        @Test
+        @DisplayName("400 Bad Request: password shorter than 8 characters")
+        void shortPasswordReturn400() throws Exception {
+            mockMvc.perform(post(BASE + "/register")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(json("firstname", "A", "lastname", "B",
+                            "email", uniqueEmail(), "password", "short")))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.fieldErrors.password", notNullValue()));
+        }
+
+        @Test
+        @DisplayName("400 Bad Request: invalid email format")
+        void invalidEmailFormatReturn400() throws Exception {
+            mockMvc.perform(post(BASE + "/register")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(json("firstname", "A", "lastname", "B",
+                            "email", "not-an-email", "password", "securePass1")))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.fieldErrors.email", notNullValue()));
+        }
+    }
+
+    // -------------------------------------------------------
+    // Login
+    // -------------------------------------------------------
+    @Nested
+    @DisplayName("Login")
+    class LoginFlow {
+
+        @Test
+        @DisplayName("200 OK: valid credentials return tokens")
+        void validLoginReturns200() throws Exception {
+            String email = uniqueEmail();
+            mockMvc.perform(post(BASE + "/register")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(json("firstname", "A", "lastname", "B",
+                            "email", email, "password", "testPass99")))
+                    .andExpect(status().isCreated());
+
+            mockMvc.perform(post(BASE + "/login")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(json("email", email, "password", "testPass99")))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.accessToken",  notNullValue()))
+                    .andExpect(jsonPath("$.refreshToken", notNullValue()))
+                    .andExpect(jsonPath("$.tokenType",    is("Bearer")));
+        }
+
+        @Test
+        @DisplayName("401 Unauthorized: wrong password rejected with correct errorCode")
+        void wrongPasswordReturns401() throws Exception {
+            String email = uniqueEmail();
+            mockMvc.perform(post(BASE + "/register")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(json("firstname", "A", "lastname", "B",
+                            "email", email, "password", "correctPass1")))
+                    .andExpect(status().isCreated());
+
+            mockMvc.perform(post(BASE + "/login")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(json("email", email, "password", "wrongPassword")))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.errorCode", is("auth.login.invalid.credentials")))
+                    .andExpect(jsonPath("$.message",
+                            is("Invalid email or password. Please check and try again.")));
+        }
+
+        @Test
+        @DisplayName("401 Unauthorized: non-existent user rejected")
+        void nonExistentUserReturns401() throws Exception {
+            mockMvc.perform(post(BASE + "/login")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(json("email", "ghost_" + System.nanoTime() + "@example.com",
+                            "password", "anyPassword1")))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.errorCode", is("auth.login.invalid.credentials")));
+        }
+    }
+
+    // -------------------------------------------------------
+    // Token Refresh
+    // -------------------------------------------------------
+    @Nested
+    @DisplayName("Token Refresh")
+    class TokenRefresh {
+
+        @Test
+        @DisplayName("200 OK: valid refresh token returns new token pair")
+        void validRefreshReturns200() throws Exception {
+            String email = uniqueEmail();
+            MvcResult registerResult = mockMvc.perform(post(BASE + "/register")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(json("firstname", "A", "lastname", "B",
+                            "email", email, "password", "testPass99")))
+                    .andExpect(status().isCreated())
+                    .andReturn();
+
+            String refreshToken = bodyOf(registerResult).get("refreshToken").asText();
+
+            mockMvc.perform(post(BASE + "/refresh")
+                    .header("Authorization", "Bearer " + refreshToken))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.accessToken",  notNullValue()))
+                    .andExpect(jsonPath("$.refreshToken", notNullValue()));
+        }
+
+        @Test
+        @DisplayName("401 Unauthorized: access token used as refresh token is rejected")
+        void accessTokenAsRefreshReturns401() throws Exception {
+            String email = uniqueEmail();
+            MvcResult reg = mockMvc.perform(post(BASE + "/register")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(json("firstname", "A", "lastname", "B",
+                            "email", email, "password", "testPass99")))
+                    .andExpect(status().isCreated())
+                    .andReturn();
+
+            String accessToken = bodyOf(reg).get("accessToken").asText();
+
+            mockMvc.perform(post(BASE + "/refresh")
+                    .header("Authorization", "Bearer " + accessToken))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("401 Unauthorized: missing Authorization header on /refresh")
+        void missingHeaderOnRefreshReturns401() throws Exception {
+            mockMvc.perform(post(BASE + "/refresh"))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("401 Unauthorized: completely malformed token on /refresh")
+        void malformedTokenOnRefreshReturns401() throws Exception {
+            // JwtAuthFilter will intercept the malformed token and return 401 JSON
+            mockMvc.perform(post(BASE + "/refresh")
+                    .header("Authorization", "Bearer this.is.garbage"))
+                    .andExpect(status().isUnauthorized());
+        }
+    }
+
+    // -------------------------------------------------------
+    // Logout
+    // -------------------------------------------------------
+    @Nested
+    @DisplayName("Logout")
+    class LogoutFlow {
+
+        @Test
+        @DisplayName("204 No Content: authenticated user can log out")
+        void authenticatedUserCanLogout() throws Exception {
+            String email = uniqueEmail();
+            MvcResult reg = mockMvc.perform(post(BASE + "/register")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(json("firstname", "A", "lastname", "B",
+                            "email", email, "password", "testPass99")))
+                    .andExpect(status().isCreated())
+                    .andReturn();
+
+            String accessToken = bodyOf(reg).get("accessToken").asText();
+
+            mockMvc.perform(post(BASE + "/logout")
+                    .header("Authorization", "Bearer " + accessToken))
+                    .andExpect(status().isNoContent());
+        }
+
+        @Test
+        @DisplayName("401 Unauthorized: /logout requires authentication")
+        void unauthenticatedLogoutReturns401() throws Exception {
+            mockMvc.perform(post(BASE + "/logout"))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("token is revoked after logout — subsequent use rejected")
+        void tokenRevokedAfterLogout() throws Exception {
+            String email = uniqueEmail();
+            MvcResult reg = mockMvc.perform(post(BASE + "/register")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(json("firstname", "A", "lastname", "B",
+                            "email", email, "password", "testPass99")))
+                    .andExpect(status().isCreated())
+                    .andReturn();
+
+            String accessToken = bodyOf(reg).get("accessToken").asText();
+
+            // Logout — revoke all tokens
+            mockMvc.perform(post(BASE + "/logout")
+                    .header("Authorization", "Bearer " + accessToken))
+                    .andExpect(status().isNoContent());
+
+            // Reuse the old access token — must be rejected (token revoked in DB)
+            // JwtAuthFilter checks DB: token is revoked → no authentication set → 401
+            mockMvc.perform(post(BASE + "/logout")
+                    .header("Authorization", "Bearer " + accessToken))
+                    .andExpect(status().isUnauthorized());
+        }
+    }
+
+    // -------------------------------------------------------
+    // Protected endpoint enforcement
+    // -------------------------------------------------------
+    @Nested
+    @DisplayName("Protected endpoint enforcement")
+    class ProtectedEndpoints {
+
+        @Test
+        @DisplayName("unauthenticated request to /refresh returns 401")
+        void unauthenticatedRefreshReturns401() throws Exception {
+            mockMvc.perform(post(BASE + "/refresh"))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("valid access token grants access to protected /logout endpoint")
+        void validAccessTokenGrantsAccess() throws Exception {
+            String email = uniqueEmail();
+            MvcResult reg = mockMvc.perform(post(BASE + "/register")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(json("firstname", "A", "lastname", "B",
+                            "email", email, "password", "mySecurePass1")))
+                    .andExpect(status().isCreated())
+                    .andReturn();
+
+            String accessToken = bodyOf(reg).get("accessToken").asText();
+
+            mockMvc.perform(post(BASE + "/logout")
+                    .header("Authorization", "Bearer " + accessToken))
+                    .andExpect(status().isNoContent());
+        }
+    }
+
+    // -------------------------------------------------------
+    // Full end-to-end flow
+    // -------------------------------------------------------
+    @Nested
+    @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+    @DisplayName("Full Auth Lifecycle: register → login → refresh → logout")
+    class FullAuthLifecycle {
+
+        @Test
+        @Order(1)
+        @DisplayName("full auth lifecycle completes without errors")
+        void fullLifecycle() throws Exception {
+            String email = uniqueEmail();
+
+            // 1. Register
+            MvcResult registerResult = mockMvc.perform(post(BASE + "/register")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(json("firstname", "Life", "lastname", "Cycle",
+                            "email", email, "password", "lifecycle1")))
+                    .andExpect(status().isCreated())
+                    .andReturn();
+
+            JsonNode reg = bodyOf(registerResult);
+            String accessToken  = reg.get("accessToken").asText();
+            String refreshToken = reg.get("refreshToken").asText();
+            assertThat(accessToken).isNotBlank();
+            assertThat(refreshToken).isNotBlank();
+
+            // 2. Login (revokes old tokens, issues new pair)
+            MvcResult loginResult = mockMvc.perform(post(BASE + "/login")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(json("email", email, "password", "lifecycle1")))
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            JsonNode login = bodyOf(loginResult);
+            String loginAccessToken  = login.get("accessToken").asText();
+            String loginRefreshToken = login.get("refreshToken").asText();
+            assertThat(loginAccessToken).isNotBlank();
+
+            // 3. Refresh using the refresh token from login
+            MvcResult refreshResult = mockMvc.perform(post(BASE + "/refresh")
+                    .header("Authorization", "Bearer " + loginRefreshToken))
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            JsonNode refresh = bodyOf(refreshResult);
+            String newAccessToken = refresh.get("accessToken").asText();
+            assertThat(newAccessToken).isNotBlank();
+            assertThat(newAccessToken).isNotEqualTo(loginAccessToken); // rotated
+
+            // 4. Logout using the newest access token
+            mockMvc.perform(post(BASE + "/logout")
+                    .header("Authorization", "Bearer " + newAccessToken))
+                    .andExpect(status().isNoContent());
+
+            // 5. Old access token from step 1 must now be rejected (all revoked on login)
+            mockMvc.perform(post(BASE + "/logout")
+                    .header("Authorization", "Bearer " + accessToken))
+                    .andExpect(status().isUnauthorized());
+        }
+    }
+}

--- a/authentication-service/src/test/java/code/with/vanilson/authentication/integration/AuthRestAssuredIT.java
+++ b/authentication-service/src/test/java/code/with/vanilson/authentication/integration/AuthRestAssuredIT.java
@@ -1,0 +1,512 @@
+package code.with.vanilson.authentication.integration;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+
+/**
+ * AuthRestAssuredIT — API-level integration tests using REST Assured.
+ *
+ * Uses @SpringBootTest(webEnvironment = RANDOM_PORT) to start a real HTTP server
+ * and Testcontainers for a real PostgreSQL database with Flyway migrations.
+ *
+ * These tests validate the full HTTP contract from client perspective:
+ * status codes, JSON body structure, security headers, and response field values.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Testcontainers
+@ActiveProfiles("test")
+@DisplayName("Authentication REST Assured Integration Tests")
+class AuthRestAssuredIT {
+
+    @Container
+    static PostgreSQLContainer<?> postgres =
+            new PostgreSQLContainer<>("postgres:16-alpine")
+                    .withDatabaseName("auth_it")
+                    .withUsername("it_user")
+                    .withPassword("it_pass");
+
+    @DynamicPropertySource
+    static void configureDataSource(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url",      postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+        registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+    }
+
+    @LocalServerPort
+    int port;
+
+    @BeforeEach
+    void configureRestAssured() {
+        RestAssured.port    = port;
+        RestAssured.baseURI = "http://localhost";
+    }
+
+    private static final String BASE = "/api/v1/auth";
+
+    private String uniqueEmail() {
+        return "ra_user_" + System.nanoTime() + "@example.com";
+    }
+
+    // -------------------------------------------------------
+    // Registration
+    // -------------------------------------------------------
+    @Nested
+    @DisplayName("POST /register — REST Assured")
+    class RegisterRA {
+
+        @Test
+        @DisplayName("201 Created with complete AuthResponse body")
+        void returns201WithAuthResponse() {
+            String email = uniqueEmail();
+
+            given()
+                .contentType(ContentType.JSON)
+                .body("""
+                      {"firstname":"John","lastname":"Doe",
+                       "email":"%s","password":"securePass1"}
+                      """.formatted(email))
+            .when()
+                .post(BASE + "/register")
+            .then()
+                .statusCode(201)
+                .body("accessToken",  notNullValue())
+                .body("refreshToken", notNullValue())
+                .body("tokenType",    equalTo("Bearer"))
+                .body("email",        equalTo(email))
+                .body("role",         equalTo("USER"))
+                .body("userId",       notNullValue());
+        }
+
+        @Test
+        @DisplayName("409 Conflict on duplicate email — errorCode matches messages.properties key")
+        void returns409OnDuplicateEmail() {
+            String email = uniqueEmail();
+            String payload = """
+                    {"firstname":"John","lastname":"Doe",
+                     "email":"%s","password":"securePass1"}
+                    """.formatted(email);
+
+            given().contentType(ContentType.JSON).body(payload)
+                    .when().post(BASE + "/register").then().statusCode(201);
+
+            given()
+                .contentType(ContentType.JSON)
+                .body(payload)
+            .when()
+                .post(BASE + "/register")
+            .then()
+                .statusCode(409)
+                .body("errorCode", equalTo("auth.user.already.exists"))
+                .body("status",    equalTo(409))
+                .body("timestamp", notNullValue())
+                .body("path",      notNullValue());
+        }
+
+        @Test
+        @DisplayName("400 Bad Request: all required fields missing → fieldErrors populated")
+        void returns400WithFieldErrors() {
+            given()
+                .contentType(ContentType.JSON)
+                .body("{}")
+            .when()
+                .post(BASE + "/register")
+            .then()
+                .statusCode(400)
+                .body("errorCode",   equalTo("auth.validation.failed"))
+                .body("fieldErrors", notNullValue());
+        }
+
+        @Test
+        @DisplayName("400 Bad Request: invalid email format")
+        void returns400OnInvalidEmail() {
+            given()
+                .contentType(ContentType.JSON)
+                .body("""
+                      {"firstname":"A","lastname":"B",
+                       "email":"not-an-email","password":"securePass1"}
+                      """)
+            .when()
+                .post(BASE + "/register")
+            .then()
+                .statusCode(400)
+                .body("fieldErrors.email", notNullValue());
+        }
+
+        @Test
+        @DisplayName("400 Bad Request: password shorter than 8 chars")
+        void returns400OnShortPassword() {
+            given()
+                .contentType(ContentType.JSON)
+                .body("""
+                      {"firstname":"A","lastname":"B",
+                       "email":"%s","password":"short"}
+                      """.formatted(uniqueEmail()))
+            .when()
+                .post(BASE + "/register")
+            .then()
+                .statusCode(400)
+                .body("fieldErrors.password", notNullValue());
+        }
+    }
+
+    // -------------------------------------------------------
+    // Login
+    // -------------------------------------------------------
+    @Nested
+    @DisplayName("POST /login — REST Assured")
+    class LoginRA {
+
+        @Test
+        @DisplayName("200 OK: correct credentials return token pair")
+        void returns200OnValidCredentials() {
+            String email = uniqueEmail();
+            registerUser(email, "myPass123");
+
+            given()
+                .contentType(ContentType.JSON)
+                .body("""
+                      {"email":"%s","password":"myPass123"}
+                      """.formatted(email))
+            .when()
+                .post(BASE + "/login")
+            .then()
+                .statusCode(200)
+                .body("accessToken",  notNullValue())
+                .body("refreshToken", notNullValue())
+                .body("tokenType",    equalTo("Bearer"));
+        }
+
+        @Test
+        @DisplayName("401 Unauthorized: wrong password — correct message from messages.properties")
+        void returns401OnWrongPassword() {
+            var email = uniqueEmail();
+            registerUser(email, "correctPass1");
+
+            given()
+                .contentType(ContentType.JSON)
+                .body("""
+                      {"email":"%s","password":"wrongPassword"}
+                      """.formatted(email))
+            .when()
+                .post(BASE + "/login")
+            .then()
+                .statusCode(401)
+                .body("errorCode", equalTo("auth.login.invalid.credentials"))
+                .body("message",   equalTo("Invalid email or password. Please check and try again."));
+        }
+
+        @Test
+        @DisplayName("401 Unauthorized: unknown email")
+        void returns401OnUnknownEmail() {
+            given()
+                .contentType(ContentType.JSON)
+                .body("""
+                      {"email":"ghost_%d@example.com","password":"anyPassword"}
+                      """.formatted(System.nanoTime()))
+            .when()
+                .post(BASE + "/login")
+            .then()
+                .statusCode(401)
+                .body("errorCode", equalTo("auth.login.invalid.credentials"));
+        }
+
+        @Test
+        @DisplayName("400 Bad Request: blank email")
+        void returns400OnBlankEmail() {
+            given()
+                .contentType(ContentType.JSON)
+                .body("""
+                      {"email":"","password":"somePass1"}
+                      """)
+            .when()
+                .post(BASE + "/login")
+            .then()
+                .statusCode(400)
+                .body("fieldErrors.email", notNullValue());
+        }
+    }
+
+    // -------------------------------------------------------
+    // Refresh
+    // -------------------------------------------------------
+    @Nested
+    @DisplayName("POST /refresh — REST Assured")
+    class RefreshRA {
+
+        @Test
+        @DisplayName("200 OK: valid refresh token returns new token pair")
+        void returns200WithNewTokenPair() {
+            String email = uniqueEmail();
+            Response reg = registerUser(email, "refPass123");
+            String refreshToken = reg.jsonPath().getString("refreshToken");
+
+            given()
+                .header("Authorization", "Bearer " + refreshToken)
+            .when()
+                .post(BASE + "/refresh")
+            .then()
+                .statusCode(200)
+                .body("accessToken",  notNullValue())
+                .body("refreshToken", notNullValue())
+                .body("tokenType",    equalTo("Bearer"));
+        }
+
+        @Test
+        @DisplayName("401 Unauthorized: access token misused as refresh token")
+        void returns401WhenAccessTokenUsedAsRefresh() {
+            String email = uniqueEmail();
+            Response reg = registerUser(email, "refPass123");
+            String accessToken = reg.jsonPath().getString("accessToken");
+
+            given()
+                .header("Authorization", "Bearer " + accessToken)
+            .when()
+                .post(BASE + "/refresh")
+            .then()
+                .statusCode(401)
+                .body("errorCode", notNullValue());
+        }
+
+        @Test
+        @DisplayName("401 Unauthorized: revoked refresh token after logout")
+        void returns401OnRevokedRefreshToken() {
+            String email = uniqueEmail();
+            Response reg = registerUser(email, "refPass123");
+            String accessToken  = reg.jsonPath().getString("accessToken");
+            String refreshToken = reg.jsonPath().getString("refreshToken");
+
+            // Logout — revokes ALL tokens
+            given()
+                .header("Authorization", "Bearer " + accessToken)
+                .when().post(BASE + "/logout").then().statusCode(204);
+
+            // Try to use the refresh token — must fail
+            given()
+                .header("Authorization", "Bearer " + refreshToken)
+            .when()
+                .post(BASE + "/refresh")
+            .then()
+                .statusCode(401)
+                .body("errorCode", equalTo("auth.token.refresh.invalid"));
+        }
+
+        @Test
+        @DisplayName("401 Unauthorized: completely malformed token string")
+        void returns401OnGarbageToken() {
+            given()
+                .header("Authorization", "Bearer garbage.token.here")
+            .when()
+                .post(BASE + "/refresh")
+            .then()
+                .statusCode(401)
+                .body("errorCode", equalTo("auth.jwt.invalid"));
+        }
+
+        @Test
+        @DisplayName("401 Unauthorized: no Authorization header")
+        void returns401WithNoHeader() {
+            given()
+            .when()
+                .post(BASE + "/refresh")
+            .then()
+                .statusCode(401);
+        }
+    }
+
+    // -------------------------------------------------------
+    // Logout
+    // -------------------------------------------------------
+    @Nested
+    @DisplayName("POST /logout — REST Assured")
+    class LogoutRA {
+
+        @Test
+        @DisplayName("204 No Content: authenticated user can log out")
+        void returns204OnValidLogout() {
+            String email = uniqueEmail();
+            Response reg = registerUser(email, "logoutPass1");
+            String accessToken = reg.jsonPath().getString("accessToken");
+
+            given()
+                .header("Authorization", "Bearer " + accessToken)
+            .when()
+                .post(BASE + "/logout")
+            .then()
+                .statusCode(204);
+        }
+
+        @Test
+        @DisplayName("401 Unauthorized: logout without token")
+        void returns401WithoutToken() {
+            given()
+            .when()
+                .post(BASE + "/logout")
+            .then()
+                .statusCode(401);
+        }
+
+        @Test
+        @DisplayName("token is invalidated after logout — reuse returns 401")
+        void tokenInvalidatedAfterLogout() {
+            String email = uniqueEmail();
+            Response reg = registerUser(email, "logoutPass1");
+            String accessToken = reg.jsonPath().getString("accessToken");
+
+            given().header("Authorization", "Bearer " + accessToken)
+                    .when().post(BASE + "/logout").then().statusCode(204);
+
+            given().header("Authorization", "Bearer " + accessToken)
+                    .when().post(BASE + "/logout").then().statusCode(401);
+        }
+    }
+
+    // -------------------------------------------------------
+    // Security headers & response contract
+    // -------------------------------------------------------
+    @Nested
+    @DisplayName("Security Headers & Response Contract")
+    class SecurityHeadersRA {
+
+        @Test
+        @DisplayName("401 response includes WWW-Authenticate header")
+        void unauthorizedResponseHasWwwAuthenticateHeader() {
+            given()
+            .when()
+                .post(BASE + "/logout")
+            .then()
+                .statusCode(401)
+                .header("WWW-Authenticate", notNullValue());
+        }
+
+        @Test
+        @DisplayName("error response has all required contract fields")
+        void errorResponseHasRequiredFields() {
+            Response resp = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                      {"email":"u@e.com","password":"wrongPass"}
+                      """)
+            .when()
+                .post(BASE + "/login")
+            .then()
+                .statusCode(401)
+                .extract().response();
+
+            assertThat(resp.jsonPath().getString("timestamp")).isNotBlank();
+            assertThat(resp.jsonPath().getInt("status")).isEqualTo(401);
+            assertThat(resp.jsonPath().getString("errorCode")).isNotBlank();
+            assertThat(resp.jsonPath().getString("message")).isNotBlank();
+            assertThat(resp.jsonPath().getString("path")).isNotBlank();
+        }
+
+        @Test
+        @DisplayName("public /register endpoint accessible without auth")
+        void publicRegisterAccessibleWithoutAuth() {
+            given()
+                .contentType(ContentType.JSON)
+                .body("""
+                      {"firstname":"A","lastname":"B",
+                       "email":"%s","password":"pubPass12"}
+                      """.formatted(uniqueEmail()))
+            .when()
+                .post(BASE + "/register")
+            .then()
+                .statusCode(201);
+        }
+
+        @Test
+        @DisplayName("public /login endpoint accessible without auth")
+        void publicLoginAccessibleWithoutAuth() {
+            String email = uniqueEmail();
+            registerUser(email, "pubPass12");
+
+            given()
+                .contentType(ContentType.JSON)
+                .body("""
+                      {"email":"%s","password":"pubPass12"}
+                      """.formatted(email))
+            .when()
+                .post(BASE + "/login")
+            .then()
+                .statusCode(200);
+        }
+    }
+
+    // -------------------------------------------------------
+    // Full lifecycle (end-to-end)
+    // -------------------------------------------------------
+    @Test
+    @DisplayName("Full lifecycle: register → login → refresh → logout → rejected reuse")
+    void fullAuthLifecycle() {
+        String email = uniqueEmail();
+
+        // 1. Register
+        Response reg = registerUser(email, "lifecycle1");
+        String regRefreshToken = reg.jsonPath().getString("refreshToken");
+
+        // 2. Login (rotates all tokens)
+        Response login = given()
+            .contentType(ContentType.JSON)
+            .body("""
+                  {"email":"%s","password":"lifecycle1"}
+                  """.formatted(email))
+            .when().post(BASE + "/login")
+            .then().statusCode(200).extract().response();
+
+        String loginAccess  = login.jsonPath().getString("accessToken");
+        String loginRefresh = login.jsonPath().getString("refreshToken");
+
+        // 3. Refresh with login's refresh token
+        Response refresh = given()
+            .header("Authorization", "Bearer " + loginRefresh)
+            .when().post(BASE + "/refresh")
+            .then().statusCode(200).extract().response();
+
+        String newAccess = refresh.jsonPath().getString("accessToken");
+        assertThat(newAccess).isNotEqualTo(loginAccess); // token was rotated
+
+        // 4. Logout
+        given().header("Authorization", "Bearer " + newAccess)
+                .when().post(BASE + "/logout").then().statusCode(204);
+
+        // 5. Old register refresh token is stale — must be rejected
+        given().header("Authorization", "Bearer " + regRefreshToken)
+                .when().post(BASE + "/refresh").then().statusCode(401);
+    }
+
+    // -------------------------------------------------------
+    // Helper
+    // -------------------------------------------------------
+    private Response registerUser(String email, String password) {
+        return given()
+            .contentType(ContentType.JSON)
+            .body("""
+                  {"firstname":"Test","lastname":"User",
+                   "email":"%s","password":"%s"}
+                  """.formatted(email, password))
+            .when()
+                .post(BASE + "/register")
+            .then()
+                .statusCode(201)
+                .extract().response();
+    }
+}

--- a/authentication-service/src/test/java/code/with/vanilson/authentication/security/JwtAuthFilterTest.java
+++ b/authentication-service/src/test/java/code/with/vanilson/authentication/security/JwtAuthFilterTest.java
@@ -1,0 +1,310 @@
+package code.with.vanilson.authentication.security;
+
+import code.with.vanilson.authentication.config.JwtAuthFilter;
+import code.with.vanilson.authentication.domain.Role;
+import code.with.vanilson.authentication.domain.Token;
+import code.with.vanilson.authentication.domain.User;
+import code.with.vanilson.authentication.domain.UserDetailsAdapter;
+import code.with.vanilson.authentication.infrastructure.JwtService;
+import code.with.vanilson.authentication.infrastructure.TokenRepository;
+import code.with.vanilson.authentication.infrastructure.UserDetailsServiceImpl;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.impl.DefaultClaims;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.Date;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * JwtAuthFilterTest — unit tests for the JWT security filter.
+ * Validates: pass-through with no token, SecurityContext population,
+ * expired/malformed token 401 JSON responses, revoked-token handling.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("JwtAuthFilter Unit Tests")
+class JwtAuthFilterTest {
+
+    @Mock JwtService             jwtService;
+    @Mock UserDetailsServiceImpl userDetailsService;
+    @Mock TokenRepository        tokenRepository;
+
+    @InjectMocks JwtAuthFilter filter;
+
+    private ObjectMapper          objectMapper;
+    private MockFilterChain       chain;
+    private UserDetailsAdapter    userDetails;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        // JwtAuthFilter needs ObjectMapper — inject it manually since @InjectMocks may miss it
+        try {
+            var field = JwtAuthFilter.class.getDeclaredField("objectMapper");
+            field.setAccessible(true);
+            field.set(filter, objectMapper);
+        } catch (Exception e) {
+            throw new RuntimeException("Could not inject ObjectMapper into filter", e);
+        }
+
+        chain = new MockFilterChain();
+        SecurityContextHolder.clearContext();
+
+        User testUser = User.builder()
+                .id(1L)
+                .email("user@example.com")
+                .password("encoded")
+                .role(Role.USER)
+                .tenantId("default")
+                .accountEnabled(true)
+                .accountLocked(false)
+                .build();
+        userDetails = new UserDetailsAdapter(testUser);
+    }
+
+    // -------------------------------------------------------
+    // No Authorization header
+    // -------------------------------------------------------
+    @Nested
+    @DisplayName("No Authorization header")
+    class NoAuthHeader {
+
+        @Test
+        @DisplayName("request without Authorization header passes through filter chain")
+        void noHeaderPassesThrough() throws Exception {
+            MockHttpServletRequest req  = new MockHttpServletRequest();
+            MockHttpServletResponse res = new MockHttpServletResponse();
+
+            filter.doFilterInternal(req, res, chain);
+
+            assertThat(chain.getRequest()).isNotNull(); // filter chain was invoked
+            assertThat(res.getStatus()).isEqualTo(200); // no error written
+            assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        }
+
+        @Test
+        @DisplayName("request with non-Bearer Authorization header passes through")
+        void basicAuthHeaderPassesThrough() throws Exception {
+            MockHttpServletRequest req  = new MockHttpServletRequest();
+            req.addHeader("Authorization", "Basic dXNlcjpwYXNz");
+            MockHttpServletResponse res = new MockHttpServletResponse();
+
+            filter.doFilterInternal(req, res, chain);
+
+            assertThat(chain.getRequest()).isNotNull();
+            assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+            verify(jwtService, never()).extractSubject(anyString());
+        }
+    }
+
+    // -------------------------------------------------------
+    // Valid token — SecurityContext populated
+    // -------------------------------------------------------
+    @Nested
+    @DisplayName("Valid JWT token")
+    class ValidToken {
+
+        @Test
+        @DisplayName("valid active token sets Authentication in SecurityContext")
+        void validTokenSetsSecurityContext() throws Exception {
+            String jwt = "valid.jwt.token";
+            String jti = "aaaa-bbbb-cccc-dddd";
+            Token activeToken = Token.builder()
+                    .jti(jti).tokenType(Token.TokenType.BEARER)
+                    .expired(false).revoked(false).build();
+
+            MockHttpServletRequest req  = new MockHttpServletRequest();
+            req.addHeader("Authorization", "Bearer " + jwt);
+            MockHttpServletResponse res = new MockHttpServletResponse();
+
+            when(jwtService.extractSubject(jwt)).thenReturn("user@example.com");
+            when(userDetailsService.loadUserByUsername("user@example.com")).thenReturn(userDetails);
+            when(jwtService.extractJti(jwt)).thenReturn(jti);
+            when(tokenRepository.findByJti(jti)).thenReturn(Optional.of(activeToken));
+            when(jwtService.isTokenValid(jwt, userDetails)).thenReturn(true);
+
+            filter.doFilterInternal(req, res, chain);
+
+            assertThat(SecurityContextHolder.getContext().getAuthentication()).isNotNull();
+            assertThat(SecurityContextHolder.getContext().getAuthentication().getName())
+                    .isEqualTo("user@example.com");
+            assertThat(res.getStatus()).isEqualTo(200);
+        }
+
+        @Test
+        @DisplayName("token not found in DB (revoked) — passes through but no auth set")
+        void tokenNotInDbNoAuthSet() throws Exception {
+            String jwt = "valid.signature.token";
+            String jti = "not-in-db-jti";
+
+            MockHttpServletRequest req  = new MockHttpServletRequest();
+            req.addHeader("Authorization", "Bearer " + jwt);
+            MockHttpServletResponse res = new MockHttpServletResponse();
+
+            when(jwtService.extractSubject(jwt)).thenReturn("user@example.com");
+            when(userDetailsService.loadUserByUsername("user@example.com")).thenReturn(userDetails);
+            when(jwtService.extractJti(jwt)).thenReturn(jti);
+            when(tokenRepository.findByJti(jti)).thenReturn(Optional.empty()); // not in DB
+
+            filter.doFilterInternal(req, res, chain);
+
+            // Filter should still call chain — it just doesn't set auth
+            assertThat(chain.getRequest()).isNotNull();
+            assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        }
+
+        @Test
+        @DisplayName("revoked DB token — no auth set, chain continues")
+        void revokedDbTokenNoAuthSet() throws Exception {
+            String jwt = "revoked.jwt.token";
+            String jti = "revoked-jti";
+            Token revokedToken = Token.builder()
+                    .jti(jti).tokenType(Token.TokenType.BEARER)
+                    .expired(true).revoked(true).build();
+
+            MockHttpServletRequest req  = new MockHttpServletRequest();
+            req.addHeader("Authorization", "Bearer " + jwt);
+            MockHttpServletResponse res = new MockHttpServletResponse();
+
+            when(jwtService.extractSubject(jwt)).thenReturn("user@example.com");
+            when(userDetailsService.loadUserByUsername("user@example.com")).thenReturn(userDetails);
+            when(jwtService.extractJti(jwt)).thenReturn(jti);
+            when(tokenRepository.findByJti(jti)).thenReturn(Optional.of(revokedToken));
+            when(jwtService.isTokenValid(jwt, userDetails)).thenReturn(false);
+
+            filter.doFilterInternal(req, res, chain);
+
+            assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        }
+    }
+
+    // -------------------------------------------------------
+    // Expired JWT
+    // -------------------------------------------------------
+    @Nested
+    @DisplayName("Expired JWT token")
+    class ExpiredToken {
+
+        @Test
+        @DisplayName("expired JWT returns 401 JSON response with errorCode auth.jwt.expired")
+        void expiredJwtReturns401() throws Exception {
+            MockHttpServletRequest req  = new MockHttpServletRequest();
+            req.addHeader("Authorization", "Bearer expired.token");
+            MockHttpServletResponse res = new MockHttpServletResponse();
+
+            // Build a minimal ExpiredJwtException
+            DefaultClaims claims = new DefaultClaims(Map.of("sub", "user@example.com"));
+            ExpiredJwtException ex = new ExpiredJwtException(null, claims, "JWT expired");
+            when(jwtService.extractSubject("expired.token")).thenThrow(ex);
+
+            filter.doFilterInternal(req, res, chain);
+
+            assertThat(res.getStatus()).isEqualTo(401);
+            assertThat(res.getContentType()).contains("application/json");
+
+            Map<?, ?> body = objectMapper.readValue(res.getContentAsString(), Map.class);
+            assertThat(body.get("status")).isEqualTo(401);
+            assertThat(body.get("errorCode")).isEqualTo("auth.jwt.expired");
+            assertThat(body.get("message")).isEqualTo("The JWT token has expired. Please authenticate again.");
+            assertThat(body.get("timestamp")).isNotNull();
+
+            assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        }
+
+        @Test
+        @DisplayName("expired JWT clears SecurityContext before writing response")
+        void expiredJwtClearsSecurityContext() throws Exception {
+            MockHttpServletRequest req  = new MockHttpServletRequest();
+            req.addHeader("Authorization", "Bearer expired.token");
+            MockHttpServletResponse res = new MockHttpServletResponse();
+
+            DefaultClaims claims = new DefaultClaims(Map.of("sub", "x@x.com"));
+            when(jwtService.extractSubject("expired.token"))
+                    .thenThrow(new ExpiredJwtException(null, claims, "expired"));
+
+            filter.doFilterInternal(req, res, chain);
+
+            assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        }
+    }
+
+    // -------------------------------------------------------
+    // Malformed / tampered JWT
+    // -------------------------------------------------------
+    @Nested
+    @DisplayName("Malformed / tampered JWT token")
+    class MalformedToken {
+
+        @Test
+        @DisplayName("malformed JWT returns 401 JSON with errorCode auth.jwt.invalid")
+        void malformedJwtReturns401() throws Exception {
+            MockHttpServletRequest req  = new MockHttpServletRequest();
+            req.addHeader("Authorization", "Bearer not.a.real.jwt");
+            MockHttpServletResponse res = new MockHttpServletResponse();
+
+            when(jwtService.extractSubject("not.a.real.jwt"))
+                    .thenThrow(new JwtException("Malformed JWT"));
+
+            filter.doFilterInternal(req, res, chain);
+
+            assertThat(res.getStatus()).isEqualTo(401);
+
+            Map<?, ?> body = objectMapper.readValue(res.getContentAsString(), Map.class);
+            assertThat(body.get("status")).isEqualTo(401);
+            assertThat(body.get("errorCode")).isEqualTo("auth.jwt.invalid");
+            assertThat(body.get("message")).isEqualTo("Invalid or malformed JWT token.");
+        }
+
+        @Test
+        @DisplayName("tampered JWT signature throws JwtException and returns 401")
+        void tamperedSignatureReturns401() throws Exception {
+            MockHttpServletRequest req  = new MockHttpServletRequest();
+            req.addHeader("Authorization", "Bearer hdr.payload.TAMPERED");
+            MockHttpServletResponse res = new MockHttpServletResponse();
+
+            when(jwtService.extractSubject("hdr.payload.TAMPERED"))
+                    .thenThrow(new JwtException("Signature mismatch"));
+
+            filter.doFilterInternal(req, res, chain);
+
+            assertThat(res.getStatus()).isEqualTo(401);
+            Map<?, ?> body = objectMapper.readValue(res.getContentAsString(), Map.class);
+            assertThat(body.get("errorCode")).isEqualTo("auth.jwt.invalid");
+        }
+
+        @Test
+        @DisplayName("malformed JWT clears SecurityContext")
+        void malformedJwtClearsSecurityContext() throws Exception {
+            MockHttpServletRequest req  = new MockHttpServletRequest();
+            req.addHeader("Authorization", "Bearer garbage");
+            MockHttpServletResponse res = new MockHttpServletResponse();
+
+            when(jwtService.extractSubject("garbage"))
+                    .thenThrow(new JwtException("invalid"));
+
+            filter.doFilterInternal(req, res, chain);
+
+            assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        }
+    }
+}

--- a/authentication-service/src/test/java/code/with/vanilson/authentication/unit/AuthServiceTest.java
+++ b/authentication-service/src/test/java/code/with/vanilson/authentication/unit/AuthServiceTest.java
@@ -1,0 +1,338 @@
+package code.with.vanilson.authentication.unit;
+
+import code.with.vanilson.authentication.application.AuthResponse;
+import code.with.vanilson.authentication.application.AuthService;
+import code.with.vanilson.authentication.application.LoginRequest;
+import code.with.vanilson.authentication.application.RefreshTokenService;
+import code.with.vanilson.authentication.application.RegisterRequest;
+import code.with.vanilson.authentication.domain.Role;
+import code.with.vanilson.authentication.domain.User;
+import code.with.vanilson.authentication.exception.InvalidCredentialsException;
+import code.with.vanilson.authentication.exception.InvalidTokenException;
+import code.with.vanilson.authentication.exception.UserAlreadyExistsException;
+import code.with.vanilson.authentication.infrastructure.JwtService;
+import code.with.vanilson.authentication.infrastructure.TokenRepository;
+import code.with.vanilson.authentication.infrastructure.UserRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.context.MessageSource;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import code.with.vanilson.authentication.domain.Token;
+
+/**
+ * AuthServiceTest — unit tests for register, login, logout, and refresh delegation.
+ * Uses Mockito; no Spring context.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)   // messageSource stub used by only some tests
+@DisplayName("AuthService Unit Tests")
+class AuthServiceTest {
+
+    @Mock UserRepository        userRepository;
+    @Mock TokenRepository       tokenRepository;
+    @Mock JwtService            jwtService;
+    @Mock PasswordEncoder       passwordEncoder;
+    @Mock AuthenticationManager authManager;
+    @Mock MessageSource         messageSource;
+    @Mock RefreshTokenService   refreshTokenService;
+
+    @InjectMocks AuthService authService;
+
+    private User savedUser;
+
+    @BeforeEach
+    void setUp() {
+        savedUser = User.builder()
+                .id(1L)
+                .firstname("John")
+                .lastname("Doe")
+                .email("john.doe@example.com")
+                .password("$2a$12$encoded")
+                .role(Role.USER)
+                .tenantId("default")
+                .accountEnabled(true)
+                .accountLocked(false)
+                .build();
+
+        // MessageSource returns the key itself in unit tests (no i18n needed)
+        when(messageSource.getMessage(anyString(), any(), any())).thenAnswer(inv -> {
+            Object[] args = inv.getArgument(1);
+            String key = inv.getArgument(0);
+            if (args != null && args.length > 0) return key + ":" + args[0];
+            return key;
+        });
+    }
+
+    // -------------------------------------------------------
+    // register()
+    // -------------------------------------------------------
+    @Nested
+    @DisplayName("register()")
+    class Register {
+
+        @Test
+        @DisplayName("success: new user persisted and tokens returned")
+        void successfulRegistration() {
+            RegisterRequest req = new RegisterRequest("John", "Doe",
+                    "john.doe@example.com", "password123", "default");
+
+            when(userRepository.existsByEmail("john.doe@example.com")).thenReturn(false);
+            when(passwordEncoder.encode("password123")).thenReturn("$2a$12$encoded");
+            when(userRepository.save(any(User.class))).thenReturn(savedUser);
+            when(jwtService.generateAccessToken(any())).thenReturn("access.jwt.token");
+            when(jwtService.generateRefreshToken(any())).thenReturn("refresh.jwt.token");
+            doNothing().when(refreshTokenService).persistTokenPair(any(), anyString(), anyString());
+
+            AuthResponse resp = authService.register(req);
+
+            assertThat(resp.accessToken()).isEqualTo("access.jwt.token");
+            assertThat(resp.refreshToken()).isEqualTo("refresh.jwt.token");
+            assertThat(resp.email()).isEqualTo("john.doe@example.com");
+            assertThat(resp.role()).isEqualTo("USER");
+            assertThat(resp.tokenType()).isEqualTo("Bearer");
+
+            verify(userRepository).save(any(User.class));
+            verify(refreshTokenService).persistTokenPair(any(), anyString(), anyString());
+        }
+
+        @Test
+        @DisplayName("duplicate email throws UserAlreadyExistsException (HTTP 409)")
+        void duplicateEmailThrows() {
+            RegisterRequest req = new RegisterRequest("John", "Doe",
+                    "john.doe@example.com", "password123", "default");
+
+            when(userRepository.existsByEmail("john.doe@example.com")).thenReturn(true);
+
+            assertThatThrownBy(() -> authService.register(req))
+                    .isInstanceOf(UserAlreadyExistsException.class)
+                    .satisfies(ex -> {
+                        UserAlreadyExistsException e = (UserAlreadyExistsException) ex;
+                        assertThat(e.getHttpStatus().value()).isEqualTo(409);
+                        assertThat(e.getMessageKey()).isEqualTo("auth.user.already.exists");
+                    });
+
+            verify(userRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("register with null tenantId defaults to 'default'")
+        void nullTenantIdDefaultsToDefault() {
+            RegisterRequest req = new RegisterRequest("Jane", "Doe",
+                    "jane@example.com", "password123", null);
+
+            when(userRepository.existsByEmail("jane@example.com")).thenReturn(false);
+            when(passwordEncoder.encode(anyString())).thenReturn("encoded");
+            when(userRepository.save(any(User.class))).thenReturn(savedUser);
+            when(jwtService.generateAccessToken(any())).thenReturn("access");
+            when(jwtService.generateRefreshToken(any())).thenReturn("refresh");
+            doNothing().when(refreshTokenService).persistTokenPair(any(), anyString(), anyString());
+
+            AuthResponse resp = authService.register(req);
+            assertThat(resp).isNotNull();
+        }
+    }
+
+    // -------------------------------------------------------
+    // login()
+    // -------------------------------------------------------
+    @Nested
+    @DisplayName("login()")
+    class Login {
+
+        @Test
+        @DisplayName("success: valid credentials return access + refresh tokens")
+        void successfulLogin() {
+            LoginRequest req = new LoginRequest("john.doe@example.com", "password123");
+
+            when(authManager.authenticate(any())).thenReturn(
+                    new UsernamePasswordAuthenticationToken("john.doe@example.com", null));
+            when(userRepository.findByEmail("john.doe@example.com")).thenReturn(Optional.of(savedUser));
+            doNothing().when(tokenRepository).revokeAllUserTokens(anyLong());
+            when(jwtService.generateAccessToken(savedUser)).thenReturn("new.access.jwt");
+            when(jwtService.generateRefreshToken(savedUser)).thenReturn("new.refresh.jwt");
+            doNothing().when(refreshTokenService).persistTokenPair(any(), anyString(), anyString());
+
+            AuthResponse resp = authService.login(req);
+
+            assertThat(resp.accessToken()).isEqualTo("new.access.jwt");
+            assertThat(resp.refreshToken()).isEqualTo("new.refresh.jwt");
+            assertThat(resp.email()).isEqualTo("john.doe@example.com");
+
+            verify(tokenRepository).revokeAllUserTokens(1L);
+        }
+
+        @Test
+        @DisplayName("bad credentials throw InvalidCredentialsException (HTTP 401)")
+        void badCredentialsThrows() {
+            LoginRequest req = new LoginRequest("john.doe@example.com", "wrongpassword");
+            when(authManager.authenticate(any()))
+                    .thenThrow(new BadCredentialsException("Bad credentials"));
+
+            assertThatThrownBy(() -> authService.login(req))
+                    .isInstanceOf(InvalidCredentialsException.class)
+                    .satisfies(ex -> {
+                        InvalidCredentialsException e = (InvalidCredentialsException) ex;
+                        assertThat(e.getHttpStatus().value()).isEqualTo(401);
+                        assertThat(e.getMessageKey()).isEqualTo("auth.login.invalid.credentials");
+                    });
+
+            verify(tokenRepository, never()).revokeAllUserTokens(anyLong());
+        }
+
+        @Test
+        @DisplayName("user not found after auth throws InvalidCredentialsException (HTTP 401)")
+        void userNotFoundAfterAuthThrows() {
+            LoginRequest req = new LoginRequest("ghost@example.com", "password123");
+            when(authManager.authenticate(any())).thenReturn(mock(
+                    UsernamePasswordAuthenticationToken.class));
+            when(userRepository.findByEmail("ghost@example.com")).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> authService.login(req))
+                    .isInstanceOf(InvalidCredentialsException.class)
+                    .satisfies(ex ->
+                        assertThat(((InvalidCredentialsException) ex).getHttpStatus().value()).isEqualTo(401));
+        }
+
+        @Test
+        @DisplayName("login revokes all previous tokens before issuing new ones")
+        void loginRevokesOldTokens() {
+            LoginRequest req = new LoginRequest("john.doe@example.com", "password123");
+            when(authManager.authenticate(any())).thenReturn(
+                    new UsernamePasswordAuthenticationToken("john.doe@example.com", null));
+            when(userRepository.findByEmail(anyString())).thenReturn(Optional.of(savedUser));
+            doNothing().when(tokenRepository).revokeAllUserTokens(anyLong());
+            when(jwtService.generateAccessToken(any())).thenReturn("a");
+            when(jwtService.generateRefreshToken(any())).thenReturn("r");
+            doNothing().when(refreshTokenService).persistTokenPair(any(), anyString(), anyString());
+
+            authService.login(req);
+
+            verify(tokenRepository).revokeAllUserTokens(savedUser.getId());
+        }
+    }
+
+    // -------------------------------------------------------
+    // logout()
+    // -------------------------------------------------------
+    @Nested
+    @DisplayName("logout()")
+    class Logout {
+
+        @Test
+        @DisplayName("valid Bearer header with live token revokes all user tokens")
+        void validBearerRevokesTokens() {
+            HttpServletRequest req = mock(HttpServletRequest.class);
+            when(req.getHeader("Authorization")).thenReturn("Bearer valid.access.token");
+
+            // logout() now checks JTI validity before revoking
+            when(jwtService.extractJti("valid.access.token")).thenReturn("test-jti-uuid");
+            Token liveToken = Token.builder()
+                    .jti("test-jti-uuid").expired(false).revoked(false).build();
+            when(tokenRepository.findByJti("test-jti-uuid")).thenReturn(Optional.of(liveToken));
+            when(jwtService.extractUserId("valid.access.token")).thenReturn(1L);
+            doNothing().when(tokenRepository).revokeAllUserTokens(anyLong());
+
+            authService.logout(req);
+
+            verify(tokenRepository).revokeAllUserTokens(1L);
+        }
+
+        @Test
+        @DisplayName("missing Authorization header throws InvalidTokenException (HTTP 401)")
+        void missingHeaderDoesNothing() {
+            HttpServletRequest req = mock(HttpServletRequest.class);
+            when(req.getHeader("Authorization")).thenReturn(null);
+
+            assertThatThrownBy(() -> authService.logout(req))
+                    .isInstanceOf(InvalidTokenException.class)
+                    .satisfies(ex ->
+                        assertThat(((InvalidTokenException) ex).getHttpStatus().value()).isEqualTo(401));
+
+            verify(tokenRepository, never()).revokeAllUserTokens(anyLong());
+        }
+
+        @Test
+        @DisplayName("non-Bearer Authorization header throws InvalidTokenException (HTTP 401)")
+        void nonBearerHeaderDoesNothing() {
+            HttpServletRequest req = mock(HttpServletRequest.class);
+            when(req.getHeader("Authorization")).thenReturn("Basic dXNlcjpwYXNz");
+
+            assertThatThrownBy(() -> authService.logout(req))
+                    .isInstanceOf(InvalidTokenException.class)
+                    .satisfies(ex ->
+                        assertThat(((InvalidTokenException) ex).getHttpStatus().value()).isEqualTo(401));
+
+            verify(tokenRepository, never()).revokeAllUserTokens(anyLong());
+        }
+    }
+
+    // -------------------------------------------------------
+    // refreshToken()
+    // -------------------------------------------------------
+    @Nested
+    @DisplayName("refreshToken()")
+    class RefreshToken {
+
+        @Test
+        @DisplayName("valid Bearer refresh header delegates to RefreshTokenService")
+        void validRefreshHeaderDelegatesToService() {
+            HttpServletRequest req = mock(HttpServletRequest.class);
+            when(req.getHeader("Authorization")).thenReturn("Bearer my.refresh.jwt");
+            when(refreshTokenService.rotate("my.refresh.jwt")).thenReturn(
+                    AuthResponse.of("newAccess", "newRefresh", "1", "u@test.com", "USER", "default"));
+
+            AuthResponse resp = authService.refreshToken(req);
+
+            assertThat(resp.accessToken()).isEqualTo("newAccess");
+            verify(refreshTokenService).rotate("my.refresh.jwt");
+        }
+
+        @Test
+        @DisplayName("missing Authorization header throws InvalidTokenException (HTTP 401)")
+        void missingHeaderThrowsInvalidToken() {
+            HttpServletRequest req = mock(HttpServletRequest.class);
+            when(req.getHeader("Authorization")).thenReturn(null);
+
+            assertThatThrownBy(() -> authService.refreshToken(req))
+                    .isInstanceOf(InvalidTokenException.class)
+                    .satisfies(ex ->
+                        assertThat(((InvalidTokenException) ex).getHttpStatus().value()).isEqualTo(401));
+        }
+
+        @Test
+        @DisplayName("non-Bearer prefix throws InvalidTokenException (HTTP 401)")
+        void nonBearerThrowsInvalidToken() {
+            HttpServletRequest req = mock(HttpServletRequest.class);
+            when(req.getHeader("Authorization")).thenReturn("Basic abc123");
+
+            assertThatThrownBy(() -> authService.refreshToken(req))
+                    .isInstanceOf(InvalidTokenException.class);
+        }
+    }
+}

--- a/authentication-service/src/test/java/code/with/vanilson/authentication/unit/JwtServiceTest.java
+++ b/authentication-service/src/test/java/code/with/vanilson/authentication/unit/JwtServiceTest.java
@@ -1,0 +1,292 @@
+package code.with.vanilson.authentication.unit;
+
+import code.with.vanilson.authentication.domain.Role;
+import code.with.vanilson.authentication.domain.User;
+import code.with.vanilson.authentication.infrastructure.JwtService;
+import io.jsonwebtoken.JwtException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.MessageSource;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * JwtServiceTest — Pure unit tests for JWT generation, validation, and claim extraction.
+ * No Spring context — JwtService is constructed directly.
+ */
+@DisplayName("JwtService Unit Tests")
+class JwtServiceTest {
+
+    // 64-byte key (HS512): Base64("testSecretKeyForTestingOnlyNotForProductionUsage0000000000000000")
+    private static final String TEST_SECRET =
+            "dGVzdFNlY3JldEtleUZvclRlc3RpbmdPbmx5Tm90Rm9yUHJvZHVjdGlvblVzYWdlMDAwMDAwMDAwMDAwMDAwMA==";
+    private static final long ACCESS_EXPIRY  = 900_000L;   // 15 min
+    private static final long REFRESH_EXPIRY = 86_400_000L; // 24 h
+
+    private JwtService jwtService;
+    private User       testUser;
+
+    @BeforeEach
+    void setUp() {
+        MessageSource messageSource = mock(MessageSource.class);
+        when(messageSource.getMessage(any(), any(), any())).thenReturn("test message");
+
+        jwtService = new JwtService(TEST_SECRET, ACCESS_EXPIRY, REFRESH_EXPIRY, messageSource);
+
+        testUser = User.builder()
+                .id(42L)
+                .firstname("Jane")
+                .lastname("Doe")
+                .email("jane.doe@example.com")
+                .password("$2a$12$hashed")
+                .role(Role.USER)
+                .tenantId("tenant-abc")
+                .accountEnabled(true)
+                .accountLocked(false)
+                .build();
+    }
+
+    // -------------------------------------------------------
+    // Access token generation
+    // -------------------------------------------------------
+    @Nested
+    @DisplayName("Access Token Generation")
+    class AccessTokenGeneration {
+
+        @Test
+        @DisplayName("generates a non-blank access token")
+        void generatesNonBlankAccessToken() {
+            String token = jwtService.generateAccessToken(testUser);
+            assertThat(token).isNotBlank();
+        }
+
+        @Test
+        @DisplayName("access token subject equals user email")
+        void accessTokenSubjectIsEmail() {
+            String token = jwtService.generateAccessToken(testUser);
+            assertThat(jwtService.extractSubject(token)).isEqualTo("jane.doe@example.com");
+        }
+
+        @Test
+        @DisplayName("access token contains userId claim")
+        void accessTokenContainsUserId() {
+            String token = jwtService.generateAccessToken(testUser);
+            assertThat(jwtService.extractUserId(token)).isEqualTo(42L);
+        }
+
+        @Test
+        @DisplayName("access token contains tenantId claim")
+        void accessTokenContainsTenantId() {
+            String token = jwtService.generateAccessToken(testUser);
+            assertThat(jwtService.extractTenantId(token)).isEqualTo("tenant-abc");
+        }
+
+        @Test
+        @DisplayName("access token contains role claim")
+        void accessTokenContainsRole() {
+            String token = jwtService.generateAccessToken(testUser);
+            assertThat(jwtService.extractRole(token)).isEqualTo("USER");
+        }
+
+        @Test
+        @DisplayName("access token tokenType claim is ACCESS")
+        void accessTokenTypeIsAccess() {
+            String token = jwtService.generateAccessToken(testUser);
+            assertThat(jwtService.extractTokenType(token)).isEqualTo("ACCESS");
+        }
+
+        @Test
+        @DisplayName("access token has a unique JTI (UUID)")
+        void accessTokenHasUniqueJti() {
+            String token1 = jwtService.generateAccessToken(testUser);
+            String token2 = jwtService.generateAccessToken(testUser);
+            assertThat(jwtService.extractJti(token1))
+                    .isNotBlank()
+                    .isNotEqualTo(jwtService.extractJti(token2));
+        }
+
+        @Test
+        @DisplayName("two consecutive access tokens differ (different JTIs)")
+        void consecutiveAccessTokensDiffer() {
+            String t1 = jwtService.generateAccessToken(testUser);
+            String t2 = jwtService.generateAccessToken(testUser);
+            assertThat(t1).isNotEqualTo(t2);
+        }
+    }
+
+    // -------------------------------------------------------
+    // Refresh token generation
+    // -------------------------------------------------------
+    @Nested
+    @DisplayName("Refresh Token Generation")
+    class RefreshTokenGeneration {
+
+        @Test
+        @DisplayName("generates a non-blank refresh token")
+        void generatesNonBlankRefreshToken() {
+            String token = jwtService.generateRefreshToken(testUser);
+            assertThat(token).isNotBlank();
+        }
+
+        @Test
+        @DisplayName("refresh token tokenType claim is REFRESH")
+        void refreshTokenTypeIsRefresh() {
+            String token = jwtService.generateRefreshToken(testUser);
+            assertThat(jwtService.extractTokenType(token)).isEqualTo("REFRESH");
+        }
+
+        @Test
+        @DisplayName("refresh token subject equals user email")
+        void refreshTokenSubjectIsEmail() {
+            String token = jwtService.generateRefreshToken(testUser);
+            assertThat(jwtService.extractSubject(token)).isEqualTo("jane.doe@example.com");
+        }
+
+        @Test
+        @DisplayName("refresh token has a unique JTI")
+        void refreshTokenHasUniqueJti() {
+            String t1 = jwtService.generateRefreshToken(testUser);
+            String t2 = jwtService.generateRefreshToken(testUser);
+            assertThat(jwtService.extractJti(t1))
+                    .isNotBlank()
+                    .isNotEqualTo(jwtService.extractJti(t2));
+        }
+
+        @Test
+        @DisplayName("access and refresh tokens have different JTIs")
+        void accessAndRefreshHaveDifferentJtis() {
+            String access  = jwtService.generateAccessToken(testUser);
+            String refresh = jwtService.generateRefreshToken(testUser);
+            assertThat(jwtService.extractJti(access))
+                    .isNotEqualTo(jwtService.extractJti(refresh));
+        }
+    }
+
+    // -------------------------------------------------------
+    // Token validation
+    // -------------------------------------------------------
+    @Nested
+    @DisplayName("Token Validation")
+    class TokenValidation {
+
+        @Test
+        @DisplayName("valid access token is accepted for correct user")
+        void validTokenAcceptedForCorrectUser() {
+            String token = jwtService.generateAccessToken(testUser);
+            UserDetails details = buildUserDetails("jane.doe@example.com");
+            assertThat(jwtService.isTokenValid(token, details)).isTrue();
+        }
+
+        @Test
+        @DisplayName("valid token is rejected for wrong subject")
+        void validTokenRejectedForWrongUser() {
+            String token = jwtService.generateAccessToken(testUser);
+            UserDetails other = buildUserDetails("other@example.com");
+            assertThat(jwtService.isTokenValid(token, other)).isFalse();
+        }
+
+        @Test
+        @DisplayName("expired token is detected correctly")
+        void expiredTokenDetected() throws Exception {
+            // Issue a token that expires in 1 ms
+            JwtService shortLived = new JwtService(TEST_SECRET, 1L, REFRESH_EXPIRY,
+                    mock(MessageSource.class));
+            String token = shortLived.generateAccessToken(testUser);
+            Thread.sleep(10); // wait for expiry
+            assertThat(shortLived.isTokenExpired(token)).isTrue();
+        }
+
+        @Test
+        @DisplayName("non-expired token is not flagged as expired")
+        void nonExpiredTokenNotFlagged() {
+            String token = jwtService.generateAccessToken(testUser);
+            assertThat(jwtService.isTokenExpired(token)).isFalse();
+        }
+
+        @Test
+        @DisplayName("malformed token throws JwtException on extraction")
+        void malformedTokenThrowsOnExtraction() {
+            assertThatThrownBy(() -> jwtService.extractSubject("not.a.jwt"))
+                    .isInstanceOf(JwtException.class);
+        }
+
+        @Test
+        @DisplayName("token signed with different key throws JwtException")
+        void tokenWithWrongKeyRejected() throws Exception {
+            // Different secret key
+            String otherSecret =
+                    "b3RoZXJTZWNyZXRLZXlGb3JUZXN0aW5nT25seU5vdEZvclByb2R1Y3Rpb25Vc2FnZTAwMDAwMDAwMDA=";
+            JwtService other = new JwtService(otherSecret, ACCESS_EXPIRY, REFRESH_EXPIRY,
+                    mock(MessageSource.class));
+            String foreignToken = other.generateAccessToken(testUser);
+
+            assertThatThrownBy(() -> jwtService.extractSubject(foreignToken))
+                    .isInstanceOf(JwtException.class);
+        }
+
+        @Test
+        @DisplayName("tampered token payload throws JwtException")
+        void tamperedTokenRejected() {
+            String token = jwtService.generateAccessToken(testUser);
+            // Modify the payload part (index 1 in dot-separated JWT)
+            String[] parts = token.split("\\.");
+            String tampered = parts[0] + ".dGFtcGVyZWQ=" + "." + parts[2];
+
+            assertThatThrownBy(() -> jwtService.extractSubject(tampered))
+                    .isInstanceOf(JwtException.class);
+        }
+    }
+
+    // -------------------------------------------------------
+    // Claim extraction edge cases
+    // -------------------------------------------------------
+    @Nested
+    @DisplayName("Claim Extraction")
+    class ClaimExtraction {
+
+        @Test
+        @DisplayName("extractJti returns a valid UUID string")
+        void extractJtiReturnsUuid() {
+            String token = jwtService.generateAccessToken(testUser);
+            String jti = jwtService.extractJti(token);
+            assertThat(jti).matches("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}");
+        }
+
+        @Test
+        @DisplayName("ADMIN role is propagated correctly in token claims")
+        void adminRolePropagatedInToken() {
+            User admin = User.builder()
+                    .id(1L).email("admin@test.com").password("pw")
+                    .role(Role.ADMIN).tenantId("default")
+                    .accountEnabled(true).accountLocked(false).build();
+            String token = jwtService.generateAccessToken(admin);
+            assertThat(jwtService.extractRole(token)).isEqualTo("ADMIN");
+        }
+
+        @Test
+        @DisplayName("SELLER role is propagated correctly in token claims")
+        void sellerRolePropagatedInToken() {
+            User seller = User.builder()
+                    .id(2L).email("seller@test.com").password("pw")
+                    .role(Role.SELLER).tenantId("tenant-x")
+                    .accountEnabled(true).accountLocked(false).build();
+            String token = jwtService.generateAccessToken(seller);
+            assertThat(jwtService.extractRole(token)).isEqualTo("SELLER");
+        }
+    }
+
+    // -------------------------------------------------------
+    // Helper
+    // -------------------------------------------------------
+    private UserDetails buildUserDetails(String email) {
+        return new org.springframework.security.core.userdetails.User(
+                email, "pw", java.util.List.of());
+    }
+}

--- a/authentication-service/src/test/java/code/with/vanilson/authentication/unit/RefreshTokenServiceTest.java
+++ b/authentication-service/src/test/java/code/with/vanilson/authentication/unit/RefreshTokenServiceTest.java
@@ -1,0 +1,275 @@
+package code.with.vanilson.authentication.unit;
+
+import code.with.vanilson.authentication.application.AuthResponse;
+import code.with.vanilson.authentication.application.RefreshTokenService;
+import code.with.vanilson.authentication.domain.Role;
+import code.with.vanilson.authentication.domain.Token;
+import code.with.vanilson.authentication.domain.User;
+import code.with.vanilson.authentication.exception.InvalidCredentialsException;
+import code.with.vanilson.authentication.exception.InvalidTokenException;
+import code.with.vanilson.authentication.exception.TokenExpiredException;
+import code.with.vanilson.authentication.exception.TokenRevokedException;
+import code.with.vanilson.authentication.infrastructure.JwtService;
+import code.with.vanilson.authentication.infrastructure.TokenRepository;
+import code.with.vanilson.authentication.infrastructure.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.MessageSource;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * RefreshTokenServiceTest — unit tests for token rotation logic.
+ * Validates: type enforcement, DB revocation check, expiry, and user lookup.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RefreshTokenService Unit Tests")
+class RefreshTokenServiceTest {
+
+    @Mock TokenRepository tokenRepository;
+    @Mock UserRepository  userRepository;
+    @Mock JwtService      jwtService;
+    @Mock MessageSource   messageSource;
+
+    @InjectMocks RefreshTokenService refreshTokenService;
+
+    private User testUser;
+    private Token validRefreshToken;
+
+    private static final String REFRESH_JWT = "header.payload.signature";
+    private static final String JTI         = "aaaabbbb-1111-2222-3333-444455556666";
+    private static final String NEW_ACCESS   = "new.access.jwt";
+    private static final String NEW_REFRESH  = "new.refresh.jwt";
+    private static final String NEW_JTI_A    = "ccccdddd-5555-6666-7777-888899990000";
+    private static final String NEW_JTI_R    = "eeeeffff-aaaa-bbbb-cccc-ddddeeee1111";
+
+    @BeforeEach
+    void setUp() {
+        testUser = User.builder()
+                .id(10L)
+                .email("user@example.com")
+                .password("encoded")
+                .role(Role.USER)
+                .tenantId("default")
+                .accountEnabled(true)
+                .accountLocked(false)
+                .build();
+
+        validRefreshToken = Token.builder()
+                .id(1L)
+                .jti(JTI)
+                .tokenType(Token.TokenType.REFRESH)
+                .expired(false)
+                .revoked(false)
+                .user(testUser)
+                .build();
+
+        when(messageSource.getMessage(anyString(), any(), any())).thenReturn("error message");
+    }
+
+    // -------------------------------------------------------
+    // rotate() — happy path
+    // -------------------------------------------------------
+    @Nested
+    @DisplayName("rotate() — happy path")
+    class RotateHappyPath {
+
+        @Test
+        @DisplayName("valid refresh token returns new AuthResponse with new token pair")
+        void validRefreshTokenRotatesSuccessfully() {
+            when(jwtService.extractJti(REFRESH_JWT)).thenReturn(JTI);
+            when(jwtService.extractTokenType(REFRESH_JWT)).thenReturn("REFRESH");
+            when(jwtService.extractSubject(REFRESH_JWT)).thenReturn("user@example.com");
+            when(tokenRepository.findValidTokenByJtiAndType(JTI, Token.TokenType.REFRESH))
+                    .thenReturn(Optional.of(validRefreshToken));
+            when(userRepository.findByEmail("user@example.com")).thenReturn(Optional.of(testUser));
+            when(jwtService.isTokenValid(eq(REFRESH_JWT), any())).thenReturn(true);
+            doNothing().when(tokenRepository).revokeAllUserTokens(anyLong());
+            when(jwtService.generateAccessToken(testUser)).thenReturn(NEW_ACCESS);
+            when(jwtService.generateRefreshToken(testUser)).thenReturn(NEW_REFRESH);
+            when(jwtService.extractJti(NEW_ACCESS)).thenReturn(NEW_JTI_A);
+            when(jwtService.extractJti(NEW_REFRESH)).thenReturn(NEW_JTI_R);
+            when(tokenRepository.save(any())).thenReturn(null);
+
+            AuthResponse resp = refreshTokenService.rotate(REFRESH_JWT);
+
+            assertThat(resp.accessToken()).isEqualTo(NEW_ACCESS);
+            assertThat(resp.refreshToken()).isEqualTo(NEW_REFRESH);
+            assertThat(resp.email()).isEqualTo("user@example.com");
+            assertThat(resp.role()).isEqualTo("USER");
+            assertThat(resp.tokenType()).isEqualTo("Bearer");
+
+            verify(tokenRepository).revokeAllUserTokens(testUser.getId());
+        }
+
+        @Test
+        @DisplayName("rotation persists two new tokens (BEARER + REFRESH)")
+        void rotationPersistsBothTokenTypes() {
+            when(jwtService.extractJti(REFRESH_JWT)).thenReturn(JTI);
+            when(jwtService.extractTokenType(REFRESH_JWT)).thenReturn("REFRESH");
+            when(jwtService.extractSubject(REFRESH_JWT)).thenReturn("user@example.com");
+            when(tokenRepository.findValidTokenByJtiAndType(JTI, Token.TokenType.REFRESH))
+                    .thenReturn(Optional.of(validRefreshToken));
+            when(userRepository.findByEmail("user@example.com")).thenReturn(Optional.of(testUser));
+            when(jwtService.isTokenValid(eq(REFRESH_JWT), any())).thenReturn(true);
+            doNothing().when(tokenRepository).revokeAllUserTokens(anyLong());
+            when(jwtService.generateAccessToken(testUser)).thenReturn(NEW_ACCESS);
+            when(jwtService.generateRefreshToken(testUser)).thenReturn(NEW_REFRESH);
+            when(jwtService.extractJti(NEW_ACCESS)).thenReturn(NEW_JTI_A);
+            when(jwtService.extractJti(NEW_REFRESH)).thenReturn(NEW_JTI_R);
+            when(tokenRepository.save(any())).thenReturn(null);
+
+            refreshTokenService.rotate(REFRESH_JWT);
+
+            // persistTokenPair calls saveToken twice → tokenRepository.save twice
+            verify(tokenRepository, org.mockito.Mockito.times(2)).save(any(Token.class));
+        }
+    }
+
+    // -------------------------------------------------------
+    // rotate() — type enforcement
+    // -------------------------------------------------------
+    @Nested
+    @DisplayName("rotate() — token type enforcement")
+    class TypeEnforcement {
+
+        @Test
+        @DisplayName("access token used as refresh token throws InvalidTokenException (HTTP 401)")
+        void accessTokenAsRefreshThrows() {
+            when(jwtService.extractJti(REFRESH_JWT)).thenReturn(JTI);
+            when(jwtService.extractTokenType(REFRESH_JWT)).thenReturn("ACCESS"); // wrong type
+            when(jwtService.extractSubject(REFRESH_JWT)).thenReturn("user@example.com");
+
+            assertThatThrownBy(() -> refreshTokenService.rotate(REFRESH_JWT))
+                    .isInstanceOf(InvalidTokenException.class)
+                    .satisfies(ex ->
+                        assertThat(((InvalidTokenException) ex).getHttpStatus().value()).isEqualTo(401));
+
+            verify(tokenRepository, never()).findValidTokenByJtiAndType(anyString(), any());
+        }
+    }
+
+    // -------------------------------------------------------
+    // rotate() — DB revocation check
+    // -------------------------------------------------------
+    @Nested
+    @DisplayName("rotate() — DB revocation check")
+    class DbRevocationCheck {
+
+        @Test
+        @DisplayName("revoked refresh token throws TokenRevokedException (HTTP 401)")
+        void revokedRefreshTokenThrows() {
+            when(jwtService.extractJti(REFRESH_JWT)).thenReturn(JTI);
+            when(jwtService.extractTokenType(REFRESH_JWT)).thenReturn("REFRESH");
+            when(jwtService.extractSubject(REFRESH_JWT)).thenReturn("user@example.com");
+            when(tokenRepository.findValidTokenByJtiAndType(JTI, Token.TokenType.REFRESH))
+                    .thenReturn(Optional.empty()); // not found → revoked/expired
+
+            assertThatThrownBy(() -> refreshTokenService.rotate(REFRESH_JWT))
+                    .isInstanceOf(TokenRevokedException.class)
+                    .satisfies(ex ->
+                        assertThat(((TokenRevokedException) ex).getHttpStatus().value()).isEqualTo(401));
+        }
+
+        @Test
+        @DisplayName("token not in DB at all throws TokenRevokedException")
+        void tokenNotInDbThrows() {
+            when(jwtService.extractJti(REFRESH_JWT)).thenReturn("unknown-jti");
+            when(jwtService.extractTokenType(REFRESH_JWT)).thenReturn("REFRESH");
+            when(jwtService.extractSubject(REFRESH_JWT)).thenReturn("user@example.com");
+            when(tokenRepository.findValidTokenByJtiAndType("unknown-jti", Token.TokenType.REFRESH))
+                    .thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> refreshTokenService.rotate(REFRESH_JWT))
+                    .isInstanceOf(TokenRevokedException.class);
+        }
+    }
+
+    // -------------------------------------------------------
+    // rotate() — expiry check
+    // -------------------------------------------------------
+    @Nested
+    @DisplayName("rotate() — expiry check")
+    class ExpiryCheck {
+
+        @Test
+        @DisplayName("cryptographically expired token throws TokenExpiredException (HTTP 401)")
+        void expiredTokenThrows() {
+            when(jwtService.extractJti(REFRESH_JWT)).thenReturn(JTI);
+            when(jwtService.extractTokenType(REFRESH_JWT)).thenReturn("REFRESH");
+            when(jwtService.extractSubject(REFRESH_JWT)).thenReturn("user@example.com");
+            when(tokenRepository.findValidTokenByJtiAndType(JTI, Token.TokenType.REFRESH))
+                    .thenReturn(Optional.of(validRefreshToken));
+            when(userRepository.findByEmail("user@example.com")).thenReturn(Optional.of(testUser));
+            when(jwtService.isTokenValid(eq(REFRESH_JWT), any())).thenReturn(false); // expired
+
+            assertThatThrownBy(() -> refreshTokenService.rotate(REFRESH_JWT))
+                    .isInstanceOf(TokenExpiredException.class)
+                    .satisfies(ex ->
+                        assertThat(((TokenExpiredException) ex).getHttpStatus().value()).isEqualTo(401));
+
+            verify(tokenRepository, never()).revokeAllUserTokens(anyLong());
+        }
+    }
+
+    // -------------------------------------------------------
+    // rotate() — user lookup failure
+    // -------------------------------------------------------
+    @Nested
+    @DisplayName("rotate() — user lookup failure")
+    class UserLookupFailure {
+
+        @Test
+        @DisplayName("unknown user after DB token check throws InvalidCredentialsException (HTTP 401)")
+        void unknownUserThrows() {
+            when(jwtService.extractJti(REFRESH_JWT)).thenReturn(JTI);
+            when(jwtService.extractTokenType(REFRESH_JWT)).thenReturn("REFRESH");
+            when(jwtService.extractSubject(REFRESH_JWT)).thenReturn("ghost@example.com");
+            when(tokenRepository.findValidTokenByJtiAndType(JTI, Token.TokenType.REFRESH))
+                    .thenReturn(Optional.of(validRefreshToken));
+            when(userRepository.findByEmail("ghost@example.com")).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> refreshTokenService.rotate(REFRESH_JWT))
+                    .isInstanceOf(InvalidCredentialsException.class)
+                    .satisfies(ex ->
+                        assertThat(((InvalidCredentialsException) ex).getHttpStatus().value()).isEqualTo(401));
+        }
+    }
+
+    // -------------------------------------------------------
+    // persistTokenPair()
+    // -------------------------------------------------------
+    @Nested
+    @DisplayName("persistTokenPair()")
+    class PersistTokenPair {
+
+        @Test
+        @DisplayName("saves BEARER and REFRESH tokens with extracted JTIs")
+        void savesBothTokenTypes() {
+            when(jwtService.extractJti("access.jwt")).thenReturn("jti-access");
+            when(jwtService.extractJti("refresh.jwt")).thenReturn("jti-refresh");
+            when(tokenRepository.save(any())).thenReturn(null);
+
+            refreshTokenService.persistTokenPair(testUser, "access.jwt", "refresh.jwt");
+
+            verify(tokenRepository, org.mockito.Mockito.times(2)).save(any(Token.class));
+        }
+    }
+}

--- a/authentication-service/src/test/resources/application-test.properties
+++ b/authentication-service/src/test/resources/application-test.properties
@@ -1,0 +1,35 @@
+# ============================================================
+# TEST PROFILE â authentication-service
+# Disables Spring Cloud Config + Eureka; provides JWT test config.
+# Testcontainers overrides spring.datasource.* via @DynamicPropertySource.
+# ============================================================
+
+# --- Disable Spring Cloud wiring (no config-server, no Eureka in tests) ---
+spring.config.import=
+spring.cloud.config.enabled=false
+spring.cloud.config.import-check.enabled=false
+eureka.client.enabled=false
+spring.cloud.discovery.enabled=false
+
+# --- JPA / Flyway ---
+spring.jpa.hibernate.ddl-auto=validate
+spring.flyway.enabled=true
+spring.jpa.show-sql=false
+
+# --- JWT test constants (64-byte key as HS512) ---
+# Decodes to: "testSecretKeyForTestingOnlyNotForProductionUsage0000000000000000"
+application.security.jwt.secret-key=dGVzdFNlY3JldEtleUZvclRlc3RpbmdPbmx5Tm90Rm9yUHJvZHVjdGlvblVzYWdlMDAwMDAwMDAwMDAwMDAwMA==
+application.security.jwt.expiration=900000
+application.security.jwt.refresh-expiration=86400000
+
+# --- Actuator ---
+management.endpoints.web.exposure.include=health
+management.endpoint.health.show-details=never
+
+# --- Reduce log noise in tests ---
+logging.level.org.springframework.security=WARN
+logging.level.org.hibernate=WARN
+logging.level.org.testcontainers=WARN
+logging.level.com.zaxxer.hikari=WARN
+logging.level.org.flywaydb=WARN
+logging.level.code.with.vanilson=DEBUG

--- a/authentication-service/src/test/resources/cucumber.properties
+++ b/authentication-service/src/test/resources/cucumber.properties
@@ -1,0 +1,4 @@
+cucumber.glue=code.with.vanilson.authentication.bdd
+cucumber.plugin=pretty
+cucumber.features=classpath:features
+cucumber.publish.quiet=true

--- a/authentication-service/src/test/resources/features/auth.feature
+++ b/authentication-service/src/test/resources/features/auth.feature
@@ -1,0 +1,184 @@
+@auth
+Feature: Authentication Service
+  As a client application
+  I want to register, log in, refresh tokens, and log out
+  So that I can access protected resources with JWT-based security
+
+  Background:
+    Given the authentication service is running
+
+  # =========================================================
+  # User Registration
+  # =========================================================
+
+  @registration @happy-path
+  Scenario: Successful user registration returns a JWT token pair
+    Given no user exists with email "bdd.register@example.com"
+    When I register with the following details:
+      | firstname | lastname | email                       | password   |
+      | Alice     | Smith    | bdd.register@example.com    | Secure123! |
+    Then the response status is 201
+    And the response contains a valid access token
+    And the response contains a valid refresh token
+    And the response token type is "Bearer"
+    And the response role is "USER"
+    And the response email is "bdd.register@example.com"
+
+  @registration @negative
+  Scenario: Registration with duplicate email returns 409 Conflict
+    Given a user already exists with email "existing.bdd@example.com"
+    When I register with the following details:
+      | firstname | lastname | email                    | password   |
+      | Bob       | Jones    | existing.bdd@example.com | Secure123! |
+    Then the response status is 409
+    And the error code is "auth.user.already.exists"
+    And the error message contains "already exists"
+
+  @registration @negative
+  Scenario: Registration without email returns 400 Bad Request
+    When I register with the following details:
+      | firstname | lastname | password   |
+      | Alice     | Smith    | Secure123! |
+    Then the response status is 400
+    And the error code is "auth.validation.failed"
+    And the field error "email" is present
+
+  @registration @negative
+  Scenario: Registration with invalid email format returns 400 Bad Request
+    When I register with the following details:
+      | firstname | lastname | email       | password   |
+      | Alice     | Smith    | not-a-email | Secure123! |
+    Then the response status is 400
+    And the field error "email" is present
+
+  @registration @negative
+  Scenario: Registration with password shorter than 8 characters returns 400 Bad Request
+    When I register with the following details:
+      | firstname | lastname | email                    | password |
+      | Alice     | Smith    | short.pass@example.com   | short    |
+    Then the response status is 400
+    And the field error "password" is present
+
+  # =========================================================
+  # User Login
+  # =========================================================
+
+  @login @happy-path
+  Scenario: Successful login with valid credentials returns JWT token pair
+    Given a user exists with email "bdd.login@example.com" and password "LoginPass99"
+    When I log in with email "bdd.login@example.com" and password "LoginPass99"
+    Then the response status is 200
+    And the response contains a valid access token
+    And the response contains a valid refresh token
+    And the response token type is "Bearer"
+
+  @login @negative
+  Scenario: Login with wrong password returns 401 Unauthorized
+    Given a user exists with email "bdd.wrongpwd@example.com" and password "CorrectPass1"
+    When I log in with email "bdd.wrongpwd@example.com" and password "WrongPassword"
+    Then the response status is 401
+    And the error code is "auth.login.invalid.credentials"
+    And the error message is "Invalid email or password. Please check and try again."
+
+  @login @negative
+  Scenario: Login with non-existent email returns 401 Unauthorized
+    When I log in with email "ghost.user@nowhere.com" and password "anyPassword"
+    Then the response status is 401
+    And the error code is "auth.login.invalid.credentials"
+
+  @login @negative
+  Scenario: Login with empty body returns 400 Bad Request
+    When I send an empty login request
+    Then the response status is 400
+    And the error code is "auth.validation.failed"
+    And the field error "email" is present
+    And the field error "password" is present
+
+  # =========================================================
+  # Token Refresh
+  # =========================================================
+
+  @refresh @happy-path
+  Scenario: Valid refresh token returns a new JWT token pair
+    Given a user is registered and logged in with email "bdd.refresh@example.com"
+    When I refresh the token using the refresh token
+    Then the response status is 200
+    And the response contains a valid access token
+    And the new access token is different from the original access token
+
+  @refresh @negative
+  Scenario: Access token used as refresh token returns 401 Unauthorized
+    Given a user is registered and logged in with email "bdd.accessasrefresh@example.com"
+    When I refresh the token using the access token instead of the refresh token
+    Then the response status is 401
+
+  @refresh @negative
+  Scenario: Missing Authorization header on refresh returns 401 Unauthorized
+    When I call the refresh endpoint without any authorization header
+    Then the response status is 401
+
+  @refresh @negative
+  Scenario: Completely malformed token string on refresh returns 401 Unauthorized
+    When I call the refresh endpoint with token "garbage.token.string"
+    Then the response status is 401
+    And the error code is "auth.jwt.invalid"
+
+  @refresh @negative
+  Scenario: Revoked refresh token after logout returns 401 Unauthorized
+    Given a user is registered and logged in with email "bdd.revokerefresh@example.com"
+    When I log out using the current access token
+    And I refresh the token using the refresh token
+    Then the response status is 401
+    And the error code is "auth.token.refresh.invalid"
+
+  # =========================================================
+  # Logout
+  # =========================================================
+
+  @logout @happy-path
+  Scenario: Authenticated user can log out successfully
+    Given a user is registered and logged in with email "bdd.logout@example.com"
+    When I log out using the current access token
+    Then the response status is 204
+
+  @logout @negative
+  Scenario: Logout without any token returns 401 Unauthorized
+    When I call the logout endpoint without any authorization header
+    Then the response status is 401
+
+  @logout @security
+  Scenario: Access token is revoked after logout — reuse is rejected
+    Given a user is registered and logged in with email "bdd.reusetoken@example.com"
+    When I log out using the current access token
+    And I attempt to log out again with the same access token
+    Then the response status is 401
+
+  # =========================================================
+  # Security Edge Cases
+  # =========================================================
+
+  @security @edge-case
+  Scenario: Unauthenticated request to protected endpoint returns 401
+    When I call the logout endpoint without any authorization header
+    Then the response status is 401
+
+  @security @edge-case
+  Scenario: Error response structure matches API contract
+    When I log in with email "bad@example.com" and password "wrongPass"
+    Then the response status is 401
+    And the error response contains field "timestamp"
+    And the error response contains field "status"
+    And the error response contains field "errorCode"
+    And the error response contains field "message"
+    And the error response contains field "path"
+
+  # =========================================================
+  # Full Authentication Lifecycle
+  # =========================================================
+
+  @lifecycle @happy-path
+  Scenario: Full authentication lifecycle completes successfully
+    Given no user exists with email "bdd.lifecycle@example.com"
+    When I complete the full auth lifecycle for "bdd.lifecycle@example.com"
+    Then the lifecycle completes without errors
+    And all tokens are properly rotated and invalidated

--- a/authentication-service/src/test/resources/junit-platform.properties
+++ b/authentication-service/src/test/resources/junit-platform.properties
@@ -1,0 +1,7 @@
+# Cucumber JUnit Platform Engine configuration
+# Tells the engine where to find step definitions and feature files
+# when running via Maven Surefire, IDE, or the @Suite runner.
+cucumber.glue=code.with.vanilson.authentication.bdd
+cucumber.features=classpath:features
+cucumber.plugin=pretty, html:target/cucumber-reports/auth-bdd-report.html
+cucumber.publish.quiet=true

--- a/cart-service/pom.xml
+++ b/cart-service/pom.xml
@@ -120,6 +120,7 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <version>3.27.7</version>
             <scope>test</scope>
         </dependency>
         <!-- Testcontainers Redis for integration tests -->
@@ -183,6 +184,44 @@
                         </exclude>
                     </excludes>
                 </configuration>
+            </plugin>
+            <!-- Maven Compiler Plugin -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <source>17</source>
+                    <target>17</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.3.0</version>
+                <configuration>
+                    <excludes>
+                        <exclude>**/*IntegrationTest.java</exclude>
+                    </excludes>
+                    <properties>
+                        <configurationParameters>
+                            cucumber.junit-platform.naming-strategy=long
+                        </configurationParameters>
+                    </properties>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>3.2.5</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
**All 78 tests pass. `BUILD SUCCESS`.**

## Root causes fixed

### 1. `@Import(SecurityConfig.class)` on `AuthControllerTest` *(this session — the actual fix)*
`@WebMvcTest` uses `WebMvcTypeExcludeFilter` for its component scan, which only includes `@Controller`, `@ControllerAdvice`, `Filter`, and a few other web-layer types. `SecurityConfig` (a plain `@Configuration @EnableWebSecurity`) is **not** in that list, so it was silently excluded. Without a `SecurityFilterChain` bean, Spring Boot's `@ConditionalOnDefaultWebSecurity` fired and registered the default HTTP Basic chain — meaning every request without HTTP Basic credentials got `401 WWW-Authenticate: Basic realm="Realm"`. Explicitly importing `SecurityConfig` forces the custom JWT chain to be registered, which suppresses the default chain entirely.

### 2. `@Order(1)` on `SecurityConfig.securityFilterChain()` *(prior session)*
Ensures our custom chain wins in `FilterChainProxy` even if the default chain somehow coexists during context startup.

### 3. `doAnswer` pass-through on `jwtAuthFilter.doFilter()` *(prior session)*
Mockito 5.x (inline mock maker) mocks `final` methods. `OncePerRequestFilter.doFilter()` is `final`, making the mock a no-op and stalling the `VirtualFilterChain` before `AuthorizationFilter` could run.

### 4. `@EnableJpaAuditing` moved to `JpaConfig` *(prior session)*
Prevented `@WebMvcTest` from failing to load `SecurityConfig` due to missing JPA infrastructure in the web slice.

### 5. `Refresh.noTokenReturns401` uses `doThrow(InvalidTokenException)` *(prior session)*
`/refresh` is `permitAll()` — Spring Security lets it through, so the service must be the one to reject a missing Bearer header.

The background diagnostic task completed, but it's no longer needed — all 78 tests are already passing after the `@Import(SecurityConfig.class)` fix. Nothing further to action from that notification.