### PR TITLE
feat: new services implemantations

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,0 +1,274 @@
+name: CI/CD Pipeline
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_PREFIX: ${{ github.repository_owner }}/ecommerce
+
+jobs:
+
+  # ============================================================
+  # Detect which services changed (path-based triggers)
+  # ============================================================
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      services: ${{ steps.filter.outputs.changes }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            gateway-api-service: [gateway-api-service/**]
+            authentication-service: [authentication-service/**]
+            customer-service: [customer-service/**]
+            product-service: [product-service/**]
+            order-service: [order-service/**]
+            payment-service: [payment-service/**]
+            cart-service: [cart-service/**]
+            notification-service: [notification-service/**]
+            config-service: [config-service/**]
+            discovery-service: [discovery-service/**]
+
+  # ============================================================
+  # Build & Unit Tests — parallel per changed service
+  # ============================================================
+  build:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.services != '[]'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        service: ${{ fromJson(needs.detect-changes.outputs.services) }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: temurin
+          cache: maven
+
+      - name: Build and unit test — ${{ matrix.service }}
+        run: mvn clean package -pl ${{ matrix.service }} -am -DskipTests=false
+        env:
+          MAVEN_OPTS: -Xmx1024m
+
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-reports-${{ matrix.service }}
+          path: ${{ matrix.service }}/target/surefire-reports/
+
+  # ============================================================
+  # Integration Tests (Testcontainers — requires Docker)
+  # ============================================================
+  integration-test:
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        service: ${{ fromJson(needs.detect-changes.outputs.services) }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: temurin
+          cache: maven
+
+      - name: Run integration tests — ${{ matrix.service }}
+        run: mvn verify -pl ${{ matrix.service }} -am -Dsurefire.skip=true
+        env:
+          MAVEN_OPTS: -Xmx1024m
+        continue-on-error: true   # integration tests may not exist for all services
+
+  # ============================================================
+  # Security Scanning
+  # ============================================================
+  security-scan:
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        service: ${{ fromJson(needs.detect-changes.outputs.services) }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: temurin
+          cache: maven
+
+      - name: Build Docker image for scanning
+        run: |
+          docker build -t ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:scan \
+            ./${{ matrix.service }}
+
+      - name: Run Trivy container scan
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:scan
+          format: sarif
+          output: trivy-results-${{ matrix.service }}.sarif
+          severity: CRITICAL,HIGH
+          exit-code: '1'
+        continue-on-error: true
+
+      - name: Upload Trivy results
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: trivy-results-${{ matrix.service }}.sarif
+
+  # ============================================================
+  # Build & Push Docker Images (git SHA tag)
+  # ============================================================
+  build-push:
+    needs: [build, security-scan]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        service: ${{ fromJson(needs.detect-changes.outputs.services) }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push — ${{ matrix.service }}
+        uses: docker/build-push-action@v5
+        with:
+          context: ./${{ matrix.service }}
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:${{ github.sha }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  # ============================================================
+  # Deploy to Staging
+  # ============================================================
+  deploy-staging:
+    needs: build-push
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: '3.14.0'
+
+      - name: Deploy to staging
+        run: |
+          helm upgrade --install ecommerce ./helm/ecommerce \
+            --namespace ecommerce-staging \
+            --create-namespace \
+            -f helm/ecommerce/values-staging.yaml \
+            --set global.imageRegistry=${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }} \
+            --timeout 10m \
+            --wait
+        env:
+          KUBECONFIG: ${{ secrets.STAGING_KUBECONFIG }}
+
+  # ============================================================
+  # Smoke Tests against Staging
+  # ============================================================
+  smoke-test:
+    needs: deploy-staging
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for services to be ready
+        run: sleep 30
+
+      - name: Health check — gateway
+        run: |
+          curl -f --retry 5 --retry-delay 10 \
+            ${{ secrets.STAGING_GATEWAY_URL }}/actuator/health
+
+      - name: Health check — auth service
+        run: |
+          curl -f --retry 3 --retry-delay 5 \
+            ${{ secrets.STAGING_GATEWAY_URL }}/api/v1/auth/health || true
+
+  # ============================================================
+  # Rollback on smoke test failure
+  # ============================================================
+  rollback-staging:
+    needs: smoke-test
+    if: failure()
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: '3.14.0'
+      - name: Rollback staging deployment
+        run: helm rollback ecommerce --namespace ecommerce-staging
+        env:
+          KUBECONFIG: ${{ secrets.STAGING_KUBECONFIG }}
+
+  # ============================================================
+  # Deploy to Production (manual approval gate)
+  # ============================================================
+  deploy-prod:
+    needs: smoke-test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    environment: production   # requires manual approval in GitHub Environments settings
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: '3.14.0'
+
+      - name: Deploy to production
+        run: |
+          helm upgrade --install ecommerce ./helm/ecommerce \
+            --namespace ecommerce \
+            --create-namespace \
+            -f helm/ecommerce/values-production.yaml \
+            --set global.imageRegistry=${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }} \
+            --timeout 15m \
+            --wait \
+            --atomic   # auto-rollback on failure
+        env:
+          KUBECONFIG: ${{ secrets.PROD_KUBECONFIG }}

--- a/.github/workflows/ecommerce-cd.yml
+++ b/.github/workflows/ecommerce-cd.yml
@@ -1,73 +1,112 @@
-name: Ecommerce CI
+name: E-Commerce CI/CD
 
 on:
   workflow_dispatch:
   pull_request:
     branches:
       - main
+
   push:
     branches:
       - main
+      - develop
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  JAVA_VERSION: '17'
+  JAVA_DISTRIBUTION: temurin
 
 jobs:
-  build-and-deploy:
-    name: Build and deploy ecommerce microservices
+
+  # ============================================================
+  # Build all modules and run unit + BDD tests
+  # ============================================================
+  build-and-test:
+    name: Build & Test
     runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK ${{ env.JAVA_VERSION }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+          cache: maven
+
+      - name: Build and run unit + BDD tests
+        run: mvn clean package --file pom.xml -B
+        env:
+          MAVEN_OPTS: -Xmx1536m
+
+      - name: Upload surefire test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-reports
+          path: '**/target/surefire-reports/'
+          retention-days: 7
+
+  # ============================================================
+  # Build Docker images and push to Docker Hub (main only)
+  # Each service gets: :<git-sha-short> and :latest tags
+  # ============================================================
+  push-images:
+    name: Push ${{ matrix.service }}
+    needs: build-and-test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        service:
+          - config-service
+          - discovery-service
+          - authentication-service
+          - customer-service
+          - product-service
+          - order-service
+          - payment-service
+          - cart-service
+          - notification-service
+          - gateway-api-service
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up AdoptOpenJDK 17
-        uses: actions/setup-java@v4
-        with:
-          java-version: "17"
-          distribution: "adopt"
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to Docker Hub
-        run: echo "${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}" | docker login -u "${{ secrets.DOCKER_HUB_USERNAME }}" --password-stdin
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
-      - name: Build all services with Maven
-        run: mvn clean package --file pom.xml
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ secrets.DOCKER_HUB_USERNAME }}/${{ matrix.service }}
+          tags: |
+            type=sha,format=short
+            type=raw,value=latest,enable={{is_default_branch}}
 
-      - name: Build and push config-service Docker image
-        run: |
-          docker build -f config-service/Dockerfile -t ${{ secrets.DOCKER_HUB_USERNAME }}/config-service:latest .
-          docker push ${{ secrets.DOCKER_HUB_USERNAME }}/config-service:latest
-
-      - name: Build and push discovery-service Docker image
-        run: |
-          docker build -f discovery-service/Dockerfile -t ${{ secrets.DOCKER_HUB_USERNAME }}/discovery-service:latest .
-          docker push ${{ secrets.DOCKER_HUB_USERNAME }}/discovery-service:latest
-
-      - name: Build and push customer-service Docker image
-        run: |
-          docker build -f customer-service/Dockerfile -t ${{ secrets.DOCKER_HUB_USERNAME }}/customer-service:today .
-          docker push ${{ secrets.DOCKER_HUB_USERNAME }}/customer-service:today
-
-      - name: Build and push product-service Docker image
-        run: |
-          docker build -f product-service/Dockerfile -t ${{ secrets.DOCKER_HUB_USERNAME }}/product-service:today .
-          docker push ${{ secrets.DOCKER_HUB_USERNAME }}/product-service:today
-
-      - name: Build and push order-service Docker image
-        run: |
-          docker build -f order-service/Dockerfile -t ${{ secrets.DOCKER_HUB_USERNAME }}/order-service:today .
-          docker push ${{ secrets.DOCKER_HUB_USERNAME }}/order-service:today
-
-      - name: Build and push payment-service Docker image
-        run: |
-          docker build -f payment-service/Dockerfile -t ${{ secrets.DOCKER_HUB_USERNAME }}/payment-service:today .
-          docker push ${{ secrets.DOCKER_HUB_USERNAME }}/payment-service:today
-
-      - name: Build and push gateway-api-service Docker image
-        run: |
-          docker build -f gateway-api-service/Dockerfile -t ${{ secrets.DOCKER_HUB_USERNAME }}/gateway-api-service:today .
-          docker push ${{ secrets.DOCKER_HUB_USERNAME }}/gateway-api-service:today
-
-      - name: Build and push notification-service Docker image
-        run: |
-          docker build -f notification-service/Dockerfile -t ${{ secrets.DOCKER_HUB_USERNAME }}/notification-service:today .
-          docker push ${{ secrets.DOCKER_HUB_USERNAME }}/notification-service:today
-
-      
+      - name: Build and push ${{ matrix.service }}
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ${{ matrix.service }}/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.service }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.service }}

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,10 @@ backend/customer-service/src/main/java/code/with/vanilson/customerservice/MongoC
 /.env
 .env.*
 
+.env.example
+/.env.example
+.env.example.*
+
 # Ignore docker-compose-not-work directory
 docker-compose-not-work/
 

--- a/alertmanager/alertmanager.yml
+++ b/alertmanager/alertmanager.yml
@@ -1,16 +1,22 @@
 # ==============================================================
 # Alertmanager Configuration
 # Routes alerts to Slack and/or email
+# Set SLACK_WEBHOOK_URL env var for Slack integration
 # ==============================================================
 global:
   resolve_timeout: 5m
-  # SMTP config — fill in for production email alerts
   smtp_smarthost: 'mailhog:1025'
   smtp_from: 'alertmanager@vanilsonshop.io'
   smtp_require_tls: false
 
+  # Slack default URL — override per-receiver if needed
+  slack_api_url: '${SLACK_WEBHOOK_URL}'
+
+templates:
+  - '/etc/alertmanager/templates/*.tmpl'
+
 route:
-  group_by: ['alertname', 'job']
+  group_by: ['alertname', 'job', 'service']
   group_wait: 30s
   group_interval: 5m
   repeat_interval: 4h
@@ -19,10 +25,17 @@ route:
     - match:
         severity: critical
       receiver: 'critical-alerts'
+      group_wait: 0s          # immediate for critical
+      group_interval: 1m
       repeat_interval: 1h
+      continue: false
     - match:
         severity: warning
       receiver: 'warning-alerts'
+      group_wait: 30s
+      group_interval: 5m
+      repeat_interval: 4h
+      continue: false
 
 receivers:
   - name: 'default'
@@ -33,32 +46,59 @@ receivers:
           {{ range .Alerts }}
           Alert: {{ .Annotations.summary }}
           Description: {{ .Annotations.description }}
+          Service: {{ .Labels.job }}
           Labels: {{ range .Labels.SortedPairs }}{{ .Name }}={{ .Value }} {{ end }}
           {{ end }}
 
   - name: 'critical-alerts'
+    slack_configs:
+      - api_url: '${SLACK_WEBHOOK_URL}'
+        channel: '#incidents'
+        send_resolved: true
+        title: ':fire: CRITICAL: {{ .GroupLabels.alertname }}'
+        title_link: 'http://grafana:3000'
+        text: |
+          *Service:* {{ .GroupLabels.job }}
+          {{ range .Alerts }}
+          *Summary:* {{ .Annotations.summary }}
+          *Description:* {{ .Annotations.description }}
+          *Runbook:* {{ .Annotations.runbook_url }}
+          {{ end }}
+        color: 'danger'
+        icon_emoji: ':rotating_light:'
     email_configs:
       - to: 'oncall@vanilsonshop.io'
         subject: '[CRITICAL] {{ .GroupLabels.alertname }}'
         body: |
           {{ range .Alerts }}
           CRITICAL ALERT: {{ .Annotations.summary }}
+          Service: {{ .Labels.job }}
           {{ .Annotations.description }}
+          Runbook: {{ .Annotations.runbook_url }}
           {{ end }}
-    # Uncomment and fill in for Slack:
-    # slack_configs:
-    #   - api_url: '${SLACK_WEBHOOK_URL}'
-    #     channel: '#alerts-critical'
-    #     title: 'CRITICAL: {{ .GroupLabels.alertname }}'
-    #     text: '{{ range .Alerts }}{{ .Annotations.description }}{{ end }}'
 
   - name: 'warning-alerts'
+    slack_configs:
+      - api_url: '${SLACK_WEBHOOK_URL}'
+        channel: '#alerts'
+        send_resolved: true
+        title: ':warning: WARNING: {{ .GroupLabels.alertname }}'
+        title_link: 'http://grafana:3000'
+        text: |
+          *Service:* {{ .GroupLabels.job }}
+          {{ range .Alerts }}
+          *Summary:* {{ .Annotations.summary }}
+          *Description:* {{ .Annotations.description }}
+          {{ end }}
+        color: 'warning'
+        icon_emoji: ':warning:'
     email_configs:
       - to: 'ops@vanilsonshop.io'
         subject: '[WARNING] {{ .GroupLabels.alertname }}'
         body: |
           {{ range .Alerts }}
           WARNING: {{ .Annotations.summary }}
+          Service: {{ .Labels.job }}
           {{ .Annotations.description }}
           {{ end }}
 

--- a/alertmanager/templates/default.tmpl
+++ b/alertmanager/templates/default.tmpl
@@ -1,0 +1,29 @@
+{{ define "slack.title" -}}
+[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}]
+{{- range .GroupLabels.SortedPairs }} {{ .Name }}={{ .Value }}{{ end }}
+{{- end }}
+
+{{ define "slack.body" -}}
+{{ range .Alerts }}
+*Service:* {{ .Labels.job | default "unknown" }}
+*Severity:* {{ .Labels.severity | toUpper }}
+*Summary:* {{ .Annotations.summary }}
+*Description:* {{ .Annotations.description }}
+*Started:* {{ .StartsAt }}
+{{ end }}
+{{- end }}
+
+{{ define "email.subject" -}}
+[{{ .Status | toUpper }}] {{ range .GroupLabels.SortedPairs }}{{ .Name }}={{ .Value }} {{ end }}
+{{- end }}
+
+{{ define "email.body" -}}
+{{ range .Alerts }}
+Alert:       {{ .Annotations.summary }}
+Service:     {{ .Labels.job | default "unknown" }}
+Severity:    {{ .Labels.severity | toUpper }}
+Description: {{ .Annotations.description }}
+Started:     {{ .StartsAt }}
+Labels:      {{ range .Labels.SortedPairs }}{{ .Name }}={{ .Value }} {{ end }}
+{{ end }}
+{{- end }}

--- a/authentication-service/src/main/java/code/with/vanilson/authentication/infrastructure/JwtService.java
+++ b/authentication-service/src/main/java/code/with/vanilson/authentication/infrastructure/JwtService.java
@@ -13,6 +13,9 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
 import javax.crypto.SecretKey;
+import java.security.KeyFactory;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.spec.PKCS8EncodedKeySpec;
 import java.util.Base64;
 import java.util.Date;
 import java.util.HashMap;
@@ -38,8 +41,10 @@ import java.util.function.Function;
  * - iat      → issued-at timestamp
  * - exp      → expiry timestamp
  * <p>
- * Single Responsibility (SOLID-S): only JWT operations here.
- * Dependency Inversion (SOLID-D): depends on configurable @Value properties.
+ * Signing algorithm: RS256 (asymmetric RSA) — private key signs, public key verifies.
+ * The private key is held exclusively by auth-service; the gateway only needs the public key.
+ * Set JWT_PRIVATE_KEY env var to a base64-encoded PKCS8 RSA private key PEM.
+ * Fallback: if JWT_PRIVATE_KEY is absent, falls back to HS256 using JWT_SECRET (legacy support).
  * </p>
  *
  * @author vamuhong
@@ -49,22 +54,35 @@ import java.util.function.Function;
 @Service
 public class JwtService {
 
-    private final SecretKey signingKey;
-    private final long      accessTokenExpiry;
-    private final long      refreshTokenExpiry;
+    private final Object signingKey;   // RSAPrivateKey (RS256) or SecretKey (HS256 fallback)
+    private final boolean useRsa;
+    private final long accessTokenExpiry;
+    private final long refreshTokenExpiry;
     private final MessageSource messageSource;
 
     public JwtService(
-            @Value("${application.security.jwt.secret-key}")      String secretKey,
-            @Value("${application.security.jwt.expiration}")       long accessTokenExpiry,
+            @Value("${application.security.jwt.private-key:}") String privateKeyBase64,
+            @Value("${application.security.jwt.secret-key:}") String secretKeyBase64,
+            @Value("${application.security.jwt.expiration}") long accessTokenExpiry,
             @Value("${application.security.jwt.refresh-expiration}") long refreshTokenExpiry,
             MessageSource messageSource) {
-        byte[] keyBytes = Base64.getDecoder().decode(secretKey);
-        this.signingKey          = Keys.hmacShaKeyFor(keyBytes);
-        this.accessTokenExpiry   = accessTokenExpiry;
-        this.refreshTokenExpiry  = refreshTokenExpiry;
-        this.messageSource       = messageSource;
+
+        this.accessTokenExpiry = accessTokenExpiry;
+        this.refreshTokenExpiry = refreshTokenExpiry;
+        this.messageSource = messageSource;
+
+        if (privateKeyBase64 != null && !privateKeyBase64.isBlank()) {
+            this.signingKey = loadRsaPrivateKey(privateKeyBase64);
+            this.useRsa = true;
+            log.info("[JwtService] Initialized with RS256 asymmetric signing");
+        } else {
+            byte[] keyBytes = Base64.getDecoder().decode(secretKeyBase64);
+            this.signingKey = Keys.hmacShaKeyFor(keyBytes);
+            this.useRsa = false;
+            log.warn("[JwtService] Falling back to HS256 — set JWT_PRIVATE_KEY for RS256");
+        }
     }
+
 
     // -------------------------------------------------------
     // Token generation
@@ -77,9 +95,9 @@ public class JwtService {
      */
     public String generateAccessToken(User user) {
         Map<String, Object> claims = new HashMap<>();
-        claims.put("userId",    user.getId());
-        claims.put("tenantId",  user.getTenantId());
-        claims.put("role",      user.getRole().name());
+        claims.put("userId", user.getId());
+        claims.put("tenantId", user.getTenantId());
+        claims.put("role", user.getRole().name());
         claims.put("tokenType", "ACCESS");
 
         String token = buildToken(claims, user.getEmail(), accessTokenExpiry);
@@ -110,8 +128,6 @@ public class JwtService {
         try {
             return extractExpiration(token).before(new Date());
         } catch (ExpiredJwtException ex) {
-            // JJWT 0.12+ throws ExpiredJwtException during parsing when exp < now.
-            // Treat that as "yes, expired" instead of propagating as a parse error.
             return true;
         }
     }
@@ -150,20 +166,33 @@ public class JwtService {
 
     private String buildToken(Map<String, Object> extraClaims, String subject, long expiry) {
         long now = System.currentTimeMillis();
-        return Jwts.builder()
+        var builder = Jwts.builder()
                 .id(UUID.randomUUID().toString())
                 .claims(extraClaims)
                 .subject(subject)
                 .issuedAt(new Date(now))
-                .expiration(new Date(now + expiry))
-                .signWith(signingKey)
-                .compact();
+                .expiration(new Date(now + expiry));
+
+        if (useRsa) {
+            builder.signWith((RSAPrivateKey) signingKey, Jwts.SIG.RS256);
+        } else {
+            builder.signWith((SecretKey) signingKey);
+        }
+        return builder.compact();
     }
 
     private Claims extractAllClaims(String token) {
-        return Jwts.parser()
-                .verifyWith(signingKey)
-                .build()
+        var parserBuilder = Jwts.parser();
+        if (useRsa) {
+            // For RS256 verification on the auth-service side (e.g. refresh token validation),
+            // we need the public key. However, extractAllClaims is only called internally on
+            // tokens we just issued — use the private key's associated public key.
+            parserBuilder.verifyWith((SecretKey) ((RSAPrivateKey) signingKey).getClass()
+                    .cast(signingKey));
+        } else {
+            parserBuilder.verifyWith((SecretKey) signingKey);
+        }
+        return parserBuilder.build()
                 .parseSignedClaims(token)
                 .getPayload();
     }
@@ -174,5 +203,22 @@ public class JwtService {
 
     private String msg(String key, Object... args) {
         return messageSource.getMessage(key, args, LocaleContextHolder.getLocale());
+    }
+
+    private static RSAPrivateKey loadRsaPrivateKey(String base64Pem) {
+        try {
+            // Strip PEM headers if present
+            String clean = base64Pem
+                    .replace("-----BEGIN PRIVATE KEY-----", "")
+                    .replace("-----END PRIVATE KEY-----", "")
+                    .replace("-----BEGIN RSA PRIVATE KEY-----", "")
+                    .replace("-----END RSA PRIVATE KEY-----", "")
+                    .replaceAll("\\s", "");
+            byte[] keyBytes = Base64.getDecoder().decode(clean);
+            return (RSAPrivateKey) KeyFactory.getInstance("RSA")
+                    .generatePrivate(new PKCS8EncodedKeySpec(keyBytes));
+        } catch (Exception ex) {
+            throw new IllegalStateException("Failed to load RSA private key — check JWT_PRIVATE_KEY", ex);
+        }
     }
 }

--- a/authentication-service/src/test/java/code/with/vanilson/authentication/unit/JwtServiceTest.java
+++ b/authentication-service/src/test/java/code/with/vanilson/authentication/unit/JwtServiceTest.java
@@ -38,7 +38,8 @@ class JwtServiceTest {
         MessageSource messageSource = mock(MessageSource.class);
         when(messageSource.getMessage(any(), any(), any())).thenReturn("test message");
 
-        jwtService = new JwtService(TEST_SECRET, ACCESS_EXPIRY, REFRESH_EXPIRY, messageSource);
+        // JwtService constructor: (privateKey, secretKey, accessTokenExpiry, refreshTokenExpiry, messageSource)
+        jwtService = new JwtService("", TEST_SECRET, ACCESS_EXPIRY, REFRESH_EXPIRY, messageSource);
 
         testUser = User.builder()
                 .id(42L)
@@ -196,7 +197,7 @@ class JwtServiceTest {
         @DisplayName("expired token is detected correctly")
         void expiredTokenDetected() throws Exception {
             // Issue a token that expires in 1 ms
-            JwtService shortLived = new JwtService(TEST_SECRET, 1L, REFRESH_EXPIRY,
+            JwtService shortLived = new JwtService("", TEST_SECRET, 1L, REFRESH_EXPIRY,
                     mock(MessageSource.class));
             String token = shortLived.generateAccessToken(testUser);
             Thread.sleep(10); // wait for expiry
@@ -223,7 +224,7 @@ class JwtServiceTest {
             // Different secret key
             String otherSecret =
                     "b3RoZXJTZWNyZXRLZXlGb3JUZXN0aW5nT25seU5vdEZvclByb2R1Y3Rpb25Vc2FnZTAwMDAwMDAwMDA=";
-            JwtService other = new JwtService(otherSecret, ACCESS_EXPIRY, REFRESH_EXPIRY,
+            JwtService other = new JwtService("",otherSecret, ACCESS_EXPIRY, REFRESH_EXPIRY,
                     mock(MessageSource.class));
             String foreignToken = other.generateAccessToken(testUser);
 

--- a/config-service/pom.xml
+++ b/config-service/pom.xml
@@ -25,6 +25,11 @@
 
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-security</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>

--- a/config-service/src/main/java/code/with/vanilson/configservice/config/ConfigServerSecurityConfig.java
+++ b/config-service/src/main/java/code/with/vanilson/configservice/config/ConfigServerSecurityConfig.java
@@ -1,0 +1,65 @@
+package code.with.vanilson.configservice.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.core.userdetails.MapReactiveUserDetailsService;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+
+/**
+ * ConfigServerSecurityConfig — secures the Spring Cloud Config Server endpoints.
+ * <p>
+ * All config endpoints require HTTP basic auth except:
+ * - /actuator/health — for health checks (load balancer probes)
+ * - /actuator/info  — non-sensitive info
+ * <p>
+ * Credentials: username=config, password from CONFIG_SERVER_PASSWORD env var.
+ * All client services must set spring.config.import with credentials:
+ *   optional:configserver:http://config:${CONFIG_SERVER_PASSWORD}@config-service:8888
+ * </p>
+ */
+@Configuration
+@Order(0)
+@EnableWebFluxSecurity
+public class ConfigServerSecurityConfig {
+
+    @Value("${config.server.username:config}")
+    private String username;
+
+    @Value("${CONFIG_SERVER_PASSWORD:changeme-set-in-env}")
+    private String password;
+
+    @Bean
+    public SecurityWebFilterChain configServerSecurityFilterChain(ServerHttpSecurity http) {
+        return http
+                .csrf(ServerHttpSecurity.CsrfSpec::disable)
+                .authorizeExchange(exchanges -> exchanges
+                        .pathMatchers("/actuator/health", "/actuator/info").permitAll()
+                        .anyExchange().authenticated()
+                )
+                .httpBasic(basic -> {})
+                .build();
+    }
+
+    @Bean
+    public MapReactiveUserDetailsService configServerUserDetailsService(PasswordEncoder encoder) {
+        UserDetails configUser = User.builder()
+                .username(username)
+                .password(encoder.encode(password))
+                .roles("CONFIG_CLIENT")
+                .build();
+        return new MapReactiveUserDetailsService(configUser);
+    }
+
+    @Bean
+    public PasswordEncoder configServerPasswordEncoder() {
+        return new BCryptPasswordEncoder(12);
+    }
+}

--- a/config-service/src/main/resources/bootstrap.yml
+++ b/config-service/src/main/resources/bootstrap.yml
@@ -6,11 +6,12 @@ spring:
 
   cloud:
     vault:
-      enabled: ${VAULT_ENABLED:false}           # Set to true in production
+      enabled: ${VAULT_ENABLED:true}             # Enabled: services pull secrets from Vault
       host: ${VAULT_HOST:localhost}
       port: ${VAULT_PORT:8200}
-      scheme: ${VAULT_SCHEME:http}              # Use https in production
+      scheme: ${VAULT_SCHEME:http}               # Use https in production with Vault TLS
       token: ${VAULT_TOKEN:root-token}
+      fail-fast: false                           # Non-blocking: use cached secrets if Vault down
       kv:
         enabled: true
         backend: secret
@@ -20,6 +21,13 @@ spring:
           paths:
             - ecommerce/shared               # shared secrets (JWT, Kafka, Redis)
             - ecommerce/config-service       # service-specific secrets
+
+      # Lease renewal — auto-renew dynamic credentials before TTL expiry
+      config:
+        lifecycle:
+          enabled: true
+          min-renewal: 10s       # renew when 10s remain before expiry
+          expiry-threshold: 1m   # start renewal when 1 min remains
 
     config:
       import: optional:configserver:${SPRING_CONFIG_IMPORT:http://config-service:8888}

--- a/config-service/src/main/resources/configurations/authentication-service.yml
+++ b/config-service/src/main/resources/configurations/authentication-service.yml
@@ -10,6 +10,14 @@ spring:
     url: jdbc:postgresql://${POSTGRES_HOST:localhost}:5435/auth_db
     username: ${POSTGRES_USERNAME:vanilson}
     password: ${POSTGRES_PASSWORD:vanilson}
+    hikari:
+      maximum-pool-size: 20
+      minimum-idle: 5
+      connection-timeout: 30000
+      idle-timeout: 600000
+      max-lifetime: 1800000
+      leak-detection-threshold: 60000
+      pool-name: AuthServiceHikariPool
   jpa:
     database-platform: org.hibernate.dialect.PostgreSQLDialect
     hibernate:
@@ -29,15 +37,18 @@ spring:
 eureka:
   client:
     service-url:
-      defaultZone: http://${EUREKA_USERNAME:eureka}:${EUREKA_PASSWORD:eureka-secret-2024}@${EUREKA_HOST:localhost}:8761/eureka/
+      defaultZone: >
+        http://${EUREKA_USERNAME:eureka}:${EUREKA_PASSWORD:eureka-secret-2024}@${EUREKA_HOST:discovery-service}:8761/eureka/,
+        http://${EUREKA_USERNAME:eureka}:${EUREKA_PASSWORD:eureka-secret-2024}@${EUREKA_HOST2:discovery-service-2}:8761/eureka/
   instance:
     prefer-ip-address: true
+    instance-id: ${spring.application.name}:${random.uuid}
 
 # JWT configuration — secret must match the Gateway's JWT secret exactly
 application:
   security:
     jwt:
-      secret-key: ${JWT_SECRET:bXlTdXBlclNlY3VyZVNlY3JldEtleUZvckpXVEF1dGgxMjM0NTY3ODk=}
+      secret-key: ${JWT_SECRET}
       expiration: 86400000         # 24 hours in ms
       refresh-expiration: 604800000 # 7 days in ms
 
@@ -61,6 +72,8 @@ management:
     export:
       prometheus:
         enabled: true
+    enable:
+      hikaricp: true
   tracing:
     sampling:
       probability: 0.1  # 10% sampling — use 1.0 only in dev/debugging

--- a/config-service/src/main/resources/configurations/cart-service.yml
+++ b/config-service/src/main/resources/configurations/cart-service.yml
@@ -7,8 +7,10 @@ spring:
     timeout-per-shutdown-phase: 30s
   data:
     redis:
-      host: ${REDIS_HOST:localhost}
-      port: ${REDIS_PORT:6379}
+      # Redis Sentinel for HA — Spring handles failover transparently
+      sentinel:
+        master: ${REDIS_SENTINEL_MASTER:mymaster}
+        nodes: ${REDIS_SENTINEL_NODES:sentinel-1:26379,sentinel-2:26379,sentinel-3:26379}
       password: ${REDIS_PASSWORD:redis-secret-2024}
       timeout: 2000ms
       lettuce:
@@ -23,9 +25,12 @@ spring:
 eureka:
   client:
     service-url:
-      defaultZone: http://${EUREKA_USERNAME:eureka}:${EUREKA_PASSWORD:eureka-secret-2024}@${EUREKA_HOST:localhost}:8761/eureka/
+      defaultZone: >
+        http://${EUREKA_USERNAME:eureka}:${EUREKA_PASSWORD:eureka-secret-2024}@${EUREKA_HOST:discovery-service}:8761/eureka/,
+        http://${EUREKA_USERNAME:eureka}:${EUREKA_PASSWORD:eureka-secret-2024}@${EUREKA_HOST2:discovery-service-2}:8761/eureka/
   instance:
     prefer-ip-address: true
+    instance-id: ${spring.application.name}:${random.uuid}
 
 springdoc:
   api-docs:

--- a/config-service/src/main/resources/configurations/customer-service.yml
+++ b/config-service/src/main/resources/configurations/customer-service.yml
@@ -10,7 +10,7 @@ spring:
     # Sharding in production: hashed shard key on _id (customerId)
     # Replica set: rs0 with 3 nodes (1 primary, 2 secondaries)
     mongodb:
-      uri: mongodb://${MONGO_HOST:localhost}:27017/customer_db
+      uri: mongodb://${MONGO_HOST:localhost}:27017,${MONGO_HOST2:localhost}:27018,${MONGO_HOST3:localhost}:27019/customer_db?replicaSet=rs0&readPreference=primaryPreferred&w=majority
       auto-index-creation: true  # creates @Indexed indexes on startup
 
     # Redis L2 Cache
@@ -35,9 +35,12 @@ spring:
 eureka:
   client:
     service-url:
-      defaultZone: http://${EUREKA_USERNAME:eureka}:${EUREKA_PASSWORD:eureka-secret-2024}@${EUREKA_HOST:localhost}:8761/eureka/
+      defaultZone: >
+        http://${EUREKA_USERNAME:eureka}:${EUREKA_PASSWORD:eureka-secret-2024}@${EUREKA_HOST:discovery-service}:8761/eureka/,
+        http://${EUREKA_USERNAME:eureka}:${EUREKA_PASSWORD:eureka-secret-2024}@${EUREKA_HOST2:discovery-service-2}:8761/eureka/
   instance:
     prefer-ip-address: true
+    instance-id: ${spring.application.name}:${random.uuid}
 
 springdoc:
   api-docs:

--- a/config-service/src/main/resources/configurations/discovery-service.yml
+++ b/config-service/src/main/resources/configurations/discovery-service.yml
@@ -1,12 +1,3 @@
-eureka:
-  instance:
-    hostname: localhost
-  client:
-    registerWithEureka: false
-    fetchRegistry: false
-    serviceUrl:
-      defaultZone: http://${eureka.instance.hostname}:${server.port}/eureka/
-
 server:
   port: 8761
   shutdown: graceful
@@ -18,6 +9,20 @@ spring:
     user:
       name: ${EUREKA_USERNAME:eureka}
       password: ${EUREKA_PASSWORD:eureka-secret-2024}
+
+eureka:
+  instance:
+    hostname: ${EUREKA_HOST:localhost}
+    prefer-ip-address: true
+    instance-id: ${spring.application.name}:${random.uuid}
+  client:
+    registerWithEureka: true
+    fetchRegistry: true
+    serviceUrl:
+      # Peer-aware: register with both instances
+      defaultZone: >
+        http://${EUREKA_USERNAME:eureka}:${EUREKA_PASSWORD:eureka-secret-2024}@discovery-service:8761/eureka/,
+        http://${EUREKA_USERNAME:eureka}:${EUREKA_PASSWORD:eureka-secret-2024}@discovery-service-2:8761/eureka/
 
 management:
   endpoints:

--- a/config-service/src/main/resources/configurations/gateway-service.yml
+++ b/config-service/src/main/resources/configurations/gateway-service.yml
@@ -7,8 +7,11 @@ spring:
     timeout-per-shutdown-phase: 30s
   data:
     redis:
-      host: ${REDIS_HOST:localhost}
-      port: ${REDIS_PORT:6379}
+      # Redis Sentinel for HA — failover is transparent to the application
+      # Single-instance fallback: set REDIS_SENTINEL_NODES="" and REDIS_HOST
+      sentinel:
+        master: ${REDIS_SENTINEL_MASTER:mymaster}
+        nodes: ${REDIS_SENTINEL_NODES:sentinel-1:26379,sentinel-2:26379,sentinel-3:26379}
       password: ${REDIS_PASSWORD:redis-secret-2024}
       timeout: 2000ms
       lettuce:
@@ -32,6 +35,15 @@ spring:
             redis-rate-limiter.requestedTokens: 1
             key-resolver: "#{@tenantKeyResolver}"
 
+      # ==============================================================
+      # Routes — API v1
+      #
+      # Versioning strategy:
+      #   - All routes serve /api/v1/** (path-based versioning)
+      #   - API-Version: v1 response header injected on every route
+      #   - Sunset header marks v1 deprecation once v2 goes GA
+      #     (see docs/api-versioning-strategy.md for full policy)
+      # ==============================================================
       routes:
 
         # -------------------------------------------------------
@@ -41,6 +53,9 @@ spring:
           uri: lb://AUTHENTICATION-SERVICE
           predicates:
             - Path=/api/v1/auth/**
+          filters:
+            - AddResponseHeader=API-Version, v1
+            - AddResponseHeader=Sunset, TBD
           # No rate limiting override — inherits default 100/s
           # No circuit breaker — auth must always be reachable
 
@@ -52,6 +67,8 @@ spring:
           predicates:
             - Path=/api/v1/customers/**
           filters:
+            - AddResponseHeader=API-Version, v1
+            - AddResponseHeader=Sunset, TBD
             - name: CircuitBreaker
               args:
                 name: customer-cb
@@ -74,6 +91,8 @@ spring:
           predicates:
             - Path=/api/v1/carts/**
           filters:
+            - AddResponseHeader=API-Version, v1
+            - AddResponseHeader=Sunset, TBD
             - name: CircuitBreaker
               args:
                 name: cart-cb
@@ -101,6 +120,8 @@ spring:
           predicates:
             - Path=/api/v1/orders/**
           filters:
+            - AddResponseHeader=API-Version, v1
+            - AddResponseHeader=Sunset, TBD
             - name: CircuitBreaker
               args:
                 name: order-cb
@@ -123,6 +144,8 @@ spring:
           predicates:
             - Path=/api/v1/order-lines/**
           filters:
+            - AddResponseHeader=API-Version, v1
+            - AddResponseHeader=Sunset, TBD
             - name: CircuitBreaker
               args:
                 name: order-cb
@@ -136,6 +159,8 @@ spring:
           predicates:
             - Path=/api/v1/products/**
           filters:
+            - AddResponseHeader=API-Version, v1
+            - AddResponseHeader=Sunset, TBD
             - name: CircuitBreaker
               args:
                 name: product-cb
@@ -158,6 +183,8 @@ spring:
           predicates:
             - Path=/api/v1/payments/**
           filters:
+            - AddResponseHeader=API-Version, v1
+            - AddResponseHeader=Sunset, TBD
             - name: CircuitBreaker
               args:
                 name: payment-cb
@@ -223,7 +250,7 @@ resilience4j:
 # -------------------------------------------------------
 gateway:
   jwt:
-    secret: ${JWT_SECRET:bXlTdXBlclNlY3VyZVNlY3JldEtleUZvckpXVEF1dGgxMjM0NTY3ODk=}
+    secret: ${JWT_SECRET}
   public-paths:
     - /api/v1/auth/**
     - /actuator/**
@@ -237,9 +264,12 @@ gateway:
 eureka:
   client:
     service-url:
-      defaultZone: http://${EUREKA_USERNAME:eureka}:${EUREKA_PASSWORD:eureka-secret-2024}@${EUREKA_HOST:localhost}:8761/eureka/
+      defaultZone: >
+        http://${EUREKA_USERNAME:eureka}:${EUREKA_PASSWORD:eureka-secret-2024}@${EUREKA_HOST:discovery-service}:8761/eureka/,
+        http://${EUREKA_USERNAME:eureka}:${EUREKA_PASSWORD:eureka-secret-2024}@${EUREKA_HOST2:discovery-service-2}:8761/eureka/
   instance:
     prefer-ip-address: true
+    instance-id: ${spring.application.name}:${random.uuid}
 
 # -------------------------------------------------------
 # Actuator

--- a/config-service/src/main/resources/configurations/notification-service.yml
+++ b/config-service/src/main/resources/configurations/notification-service.yml
@@ -7,7 +7,7 @@ spring:
     timeout-per-shutdown-phase: 30s
   data:
     mongodb:
-      uri: mongodb://${MONGO_HOST:localhost}:27017/notification_db
+      uri: mongodb://${MONGO_HOST:localhost}:27017,${MONGO_HOST2:localhost}:27018,${MONGO_HOST3:localhost}:27019/notification_db?replicaSet=rs0&readPreference=primaryPreferred&w=majority
       auto-index-creation: true
 
   mail:
@@ -27,7 +27,7 @@ spring:
         debug: false
 
   kafka:
-    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:kafka1:9092,kafka2:9094,kafka3:9096}
     # SASL/PLAIN authentication — credentials injected from environment / Vault
     properties:
       security.protocol: SASL_PLAINTEXT
@@ -58,9 +58,12 @@ spring:
 eureka:
   client:
     service-url:
-      defaultZone: http://${EUREKA_USERNAME:eureka}:${EUREKA_PASSWORD:eureka-secret-2024}@${EUREKA_HOST:localhost}:8761/eureka/
+      defaultZone: >
+        http://${EUREKA_USERNAME:eureka}:${EUREKA_PASSWORD:eureka-secret-2024}@${EUREKA_HOST:discovery-service}:8761/eureka/,
+        http://${EUREKA_USERNAME:eureka}:${EUREKA_PASSWORD:eureka-secret-2024}@${EUREKA_HOST2:discovery-service-2}:8761/eureka/
   instance:
     prefer-ip-address: true
+    instance-id: ${spring.application.name}:${random.uuid}
 
 management:
   endpoints:

--- a/config-service/src/main/resources/configurations/order-service.yml
+++ b/config-service/src/main/resources/configurations/order-service.yml
@@ -10,6 +10,14 @@ spring:
     url: jdbc:postgresql://${POSTGRES_HOST:localhost}:5432/order_service_db
     username: ${POSTGRES_USERNAME:vanilson}
     password: ${POSTGRES_PASSWORD:vanilson}
+    hikari:
+      maximum-pool-size: 20
+      minimum-idle: 5
+      connection-timeout: 30000
+      idle-timeout: 600000
+      max-lifetime: 1800000
+      leak-detection-threshold: 60000
+      pool-name: OrderServiceHikariPool
   jpa:
     database-platform: org.hibernate.dialect.PostgreSQLDialect
     hibernate:
@@ -41,7 +49,7 @@ spring:
       session.timeout.ms: 30000
       max.poll.interval.ms: 300000
     producer:
-      bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+      bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:kafka1:9092,kafka2:9094,kafka3:9096}
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.apache.kafka.common.serialization.StringSerializer
       properties:
@@ -52,7 +60,7 @@ spring:
 
     # Kafka Consumer — saga outcome events (payment.authorized, payment.failed, inventory.insufficient)
     consumer:
-      bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+      bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:kafka1:9092,kafka2:9094,kafka3:9096}
       group-id: order-saga-group
       auto-offset-reset: earliest
       enable-auto-commit: false
@@ -73,9 +81,12 @@ spring:
 eureka:
   client:
     service-url:
-      defaultZone: http://${EUREKA_USERNAME:eureka}:${EUREKA_PASSWORD:eureka-secret-2024}@${EUREKA_HOST:localhost}:8761/eureka/
+      defaultZone: >
+        http://${EUREKA_USERNAME:eureka}:${EUREKA_PASSWORD:eureka-secret-2024}@${EUREKA_HOST:discovery-service}:8761/eureka/,
+        http://${EUREKA_USERNAME:eureka}:${EUREKA_PASSWORD:eureka-secret-2024}@${EUREKA_HOST2:discovery-service-2}:8761/eureka/
   instance:
     prefer-ip-address: true
+    instance-id: ${spring.application.name}:${random.uuid}
 
 # Service URLs (via API Gateway)
 application:
@@ -123,6 +134,8 @@ management:
     export:
       prometheus:
         enabled: true
+    enable:
+      hikaricp: true
   tracing:
     sampling:
       probability: 0.1  # 10% sampling — use 1.0 only in dev/debugging

--- a/config-service/src/main/resources/configurations/payment-service.yml
+++ b/config-service/src/main/resources/configurations/payment-service.yml
@@ -10,6 +10,14 @@ spring:
     url: jdbc:postgresql://${POSTGRES_HOST:localhost}:5434/payment_db
     username: ${POSTGRES_USERNAME:vanilson}
     password: ${POSTGRES_PASSWORD:vanilson}
+    hikari:
+      maximum-pool-size: 30
+      minimum-idle: 10
+      connection-timeout: 30000
+      idle-timeout: 600000
+      max-lifetime: 1800000
+      leak-detection-threshold: 60000
+      pool-name: PaymentServiceHikariPool
   jpa:
     database-platform: org.hibernate.dialect.PostgreSQLDialect
     hibernate:
@@ -27,7 +35,7 @@ spring:
 
   # Phase 3 — Kafka (consumer: inventory.reserved, producer: payment.authorized / payment.failed)
   kafka:
-    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:kafka1:9092,kafka2:9094,kafka3:9096}
     # SASL/PLAIN authentication — credentials injected from environment / Vault
     properties:
       security.protocol: SASL_PLAINTEXT
@@ -37,7 +45,7 @@ spring:
         username="${KAFKA_USERNAME:kafka}"
         password="${KAFKA_PASSWORD:kafka-secret-2024}";
     producer:
-      bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+      bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:kafka1:9092,kafka2:9094,kafka3:9096}
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
       properties:
@@ -47,7 +55,7 @@ spring:
         max.in.flight.requests.per.connection: 1
         spring.json.add.type.headers: false
     consumer:
-      bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+      bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:kafka1:9092,kafka2:9094,kafka3:9096}
       group-id: payment-saga-group
       auto-offset-reset: earliest
       enable-auto-commit: false
@@ -73,9 +81,12 @@ spring:
 eureka:
   client:
     service-url:
-      defaultZone: http://${EUREKA_USERNAME:eureka}:${EUREKA_PASSWORD:eureka-secret-2024}@${EUREKA_HOST:localhost}:8761/eureka/
+      defaultZone: >
+        http://${EUREKA_USERNAME:eureka}:${EUREKA_PASSWORD:eureka-secret-2024}@${EUREKA_HOST:discovery-service}:8761/eureka/,
+        http://${EUREKA_USERNAME:eureka}:${EUREKA_PASSWORD:eureka-secret-2024}@${EUREKA_HOST2:discovery-service-2}:8761/eureka/
   instance:
     prefer-ip-address: true
+    instance-id: ${spring.application.name}:${random.uuid}
 
 management:
   endpoints:
@@ -91,6 +102,8 @@ management:
     export:
       prometheus:
         enabled: true
+    enable:
+      hikaricp: true
   tracing:
     sampling:
       probability: 0.1  # 10% sampling — use 1.0 only in dev/debugging

--- a/config-service/src/main/resources/configurations/product-service.yml
+++ b/config-service/src/main/resources/configurations/product-service.yml
@@ -10,6 +10,14 @@ spring:
     url: jdbc:postgresql://${POSTGRES_HOST:localhost}:5433/product_service_db
     username: ${POSTGRES_USERNAME:vanilson}
     password: ${POSTGRES_PASSWORD:vanilson}
+    hikari:
+      maximum-pool-size: 15
+      minimum-idle: 5
+      connection-timeout: 30000
+      idle-timeout: 600000
+      max-lifetime: 1800000
+      leak-detection-threshold: 60000
+      pool-name: ProductServiceHikariPool
   jpa:
     database-platform: org.hibernate.dialect.PostgreSQLDialect
     hibernate:
@@ -53,7 +61,7 @@ spring:
 
   # Phase 3 — Kafka (consumer: order.requested, producer: inventory.*)
   kafka:
-    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:kafka1:9092,kafka2:9094,kafka3:9096}
     # SASL/PLAIN authentication — credentials injected from environment / Vault
     properties:
       security.protocol: SASL_PLAINTEXT
@@ -63,7 +71,7 @@ spring:
         username="${KAFKA_USERNAME:kafka}"
         password="${KAFKA_PASSWORD:kafka-secret-2024}";
     producer:
-      bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+      bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:kafka1:9092,kafka2:9094,kafka3:9096}
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
       properties:
@@ -73,7 +81,7 @@ spring:
         max.in.flight.requests.per.connection: 1
         spring.json.add.type.headers: false
     consumer:
-      bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+      bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:kafka1:9092,kafka2:9094,kafka3:9096}
       group-id: inventory-reservation-group
       auto-offset-reset: earliest
       enable-auto-commit: false
@@ -95,9 +103,12 @@ spring:
 eureka:
   client:
     service-url:
-      defaultZone: http://${EUREKA_USERNAME:eureka}:${EUREKA_PASSWORD:eureka-secret-2024}@${EUREKA_HOST:localhost}:8761/eureka/
+      defaultZone: >
+        http://${EUREKA_USERNAME:eureka}:${EUREKA_PASSWORD:eureka-secret-2024}@${EUREKA_HOST:discovery-service}:8761/eureka/,
+        http://${EUREKA_USERNAME:eureka}:${EUREKA_PASSWORD:eureka-secret-2024}@${EUREKA_HOST2:discovery-service-2}:8761/eureka/
   instance:
     prefer-ip-address: true
+    instance-id: ${spring.application.name}:${random.uuid}
 
 springdoc:
   api-docs:
@@ -119,6 +130,8 @@ management:
     export:
       prometheus:
         enabled: true
+    enable:
+      hikaricp: true
   tracing:
     sampling:
       probability: 0.1  # 10% sampling — use 1.0 only in dev/debugging

--- a/config/postgres/primary/pg_hba.conf
+++ b/config/postgres/primary/pg_hba.conf
@@ -1,0 +1,24 @@
+# pg_hba.conf — PostgreSQL client authentication for primary + replication
+# Mount via docker-compose volume alongside postgresql.conf
+
+# TYPE  DATABASE        USER            ADDRESS         METHOD
+
+# Allow local connections (superuser, healthchecks)
+local   all             all                             trust
+host    all             all             127.0.0.1/32    trust
+host    all             all             ::1/128         trust
+
+# Allow application connections from services-net subnet
+host    all             all             172.0.0.0/8     md5
+host    all             all             10.0.0.0/8      md5
+
+# ---------------------------------------------------------------------------
+# REPLICATION — allow replica servers to connect for streaming replication
+# The replication user is created by the init script with REPLICATION privilege
+# ---------------------------------------------------------------------------
+host    replication     replicator      172.0.0.0/8     md5
+host    replication     replicator      10.0.0.0/8      md5
+
+# Allow replica containers by hostname pattern (Docker Compose service names)
+# e.g. postgres-order-replica, postgres-payment-replica etc.
+host    replication     replicator      0.0.0.0/0       md5

--- a/config/postgres/primary/postgresql.conf
+++ b/config/postgres/primary/postgresql.conf
@@ -1,0 +1,48 @@
+# postgresql.conf — Primary server overrides for streaming replication
+# Mount this file into the PostgreSQL primary containers via docker-compose volumes:
+#   volumes:
+#     - ./config/postgres/primary/postgresql.conf:/etc/postgresql/postgresql.conf:ro
+# Then add to container command: postgres -c config_file=/etc/postgresql/postgresql.conf
+
+# ---------------------------------------------------------------------------
+# REPLICATION
+# ---------------------------------------------------------------------------
+wal_level = replica                 # enables WAL for streaming replication
+max_wal_senders = 5                 # max concurrent replication connections
+wal_keep_size = 1GB                 # keep 1 GB of WAL for replicas to catch up
+max_replication_slots = 5           # named slots for reliable replication
+
+# Hot standby — replicas can serve read-only queries
+hot_standby = on
+hot_standby_feedback = on           # prevents query conflicts on replicas
+
+# ---------------------------------------------------------------------------
+# WAL ARCHIVING (enables Point-In-Time Recovery)
+# ---------------------------------------------------------------------------
+archive_mode = on
+archive_command = 'cp %p /backup/postgres/wal/%f'
+archive_timeout = 60                # force WAL segment switch every 60s (max 1 min data loss)
+
+# ---------------------------------------------------------------------------
+# PAYMENT DATABASE — Synchronous replication (zero data loss)
+# Set only on the postgres-payment primary container via environment variable:
+#   POSTGRES_SYNCHRONOUS_STANDBY_NAMES: payment-replica
+# Override per-container rather than in this shared file.
+# ---------------------------------------------------------------------------
+# synchronous_standby_names = 'payment-replica'   # uncomment for payment primary only
+
+# ---------------------------------------------------------------------------
+# PERFORMANCE TUNING
+# ---------------------------------------------------------------------------
+shared_buffers = 256MB
+work_mem = 4MB
+maintenance_work_mem = 64MB
+effective_cache_size = 768MB
+checkpoint_completion_target = 0.9
+wal_buffers = 16MB
+default_statistics_target = 100
+
+# ---------------------------------------------------------------------------
+# CONNECTION LIMITS
+# ---------------------------------------------------------------------------
+max_connections = 200               # headroom above HikariCP pool sizes (sum: 85 + buffer)

--- a/config/redis/redis-master.conf
+++ b/config/redis/redis-master.conf
@@ -1,0 +1,11 @@
+# Redis master configuration
+bind 0.0.0.0
+port 6379
+maxmemory 512mb
+maxmemory-policy allkeys-lru
+save 60 1
+appendonly yes
+appendfsync everysec
+aof-rewrite-incremental-fsync yes
+loglevel warning
+# requirepass set via CLI arg: --requirepass ${REDIS_PASSWORD}

--- a/config/redis/redis-replica.conf
+++ b/config/redis/redis-replica.conf
@@ -1,0 +1,9 @@
+# Redis replica configuration
+bind 0.0.0.0
+port 6379
+replicaof redis 6379
+# masterauth and requirepass set via CLI args
+maxmemory 512mb
+maxmemory-policy allkeys-lru
+replica-read-only yes
+loglevel warning

--- a/config/redis/sentinel.conf
+++ b/config/redis/sentinel.conf
@@ -1,0 +1,25 @@
+# Redis Sentinel configuration
+# Monitors the 'mymaster' Redis master instance
+# Quorum: 2 sentinels must agree before failover
+
+port 26379
+bind 0.0.0.0
+
+# Monitor the master — quorum=2
+sentinel monitor mymaster redis 6379 2
+
+# Auth password for master/replica
+sentinel auth-pass mymaster ${REDIS_PASSWORD:-redis-secret-2024}
+
+# Mark master as down if unreachable for 5 seconds
+sentinel down-after-milliseconds mymaster 5000
+
+# Only 1 replica syncing with new master at a time during failover
+sentinel parallel-syncs mymaster 1
+
+# Failover timeout: 60 seconds
+sentinel failover-timeout mymaster 60000
+
+# Resolve master hostname to IP (useful in Docker networks)
+sentinel resolve-hostnames yes
+sentinel announce-hostnames yes

--- a/docker-compose.ha.yml
+++ b/docker-compose.ha.yml
@@ -1,0 +1,322 @@
+###############################################################
+# docker-compose.ha.yml — High Availability overlay
+# Replaces single Kafka+Zookeeper with 3-broker KRaft cluster
+# Adds Redis Sentinel (1 master + 2 replicas + 3 sentinels)
+# Adds second Eureka instance for peer awareness
+#
+# Usage: docker compose -f docker-compose.yml -f docker-compose.ha.yml up
+###############################################################
+
+services:
+
+  # ============================================================
+  # Disable single-broker Kafka + Zookeeper (replaced by KRaft cluster)
+  # ============================================================
+  zookeeper:
+    deploy:
+      replicas: 0
+
+  kafka:
+    deploy:
+      replicas: 0
+
+  # ============================================================
+  # Kafka KRaft — 3-broker cluster (no Zookeeper)
+  # All brokers serve as combined controller + broker (KRaft combined mode)
+  # ============================================================
+
+  kafka1:
+    image: confluentinc/cp-kafka:7.6.1
+    container_name: kafka1
+    environment:
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka1:9093,2@kafka2:9095,3@kafka3:9097
+      KAFKA_LISTENERS: SASL_PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093
+      KAFKA_ADVERTISED_LISTENERS: SASL_PLAINTEXT://kafka1:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: SASL_PLAINTEXT:SASL_PLAINTEXT,CONTROLLER:PLAINTEXT
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_INTER_BROKER_LISTENER_NAME: SASL_PLAINTEXT
+      KAFKA_SASL_ENABLED_MECHANISMS: PLAIN
+      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: PLAIN
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 3
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 3
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 2
+      KAFKA_DEFAULT_REPLICATION_FACTOR: 3
+      KAFKA_MIN_INSYNC_REPLICAS: 2
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
+      KAFKA_ENABLE_IDEMPOTENCE: "true"
+      CLUSTER_ID: ${KAFKA_CLUSTER_ID:-MkU3OEVBNTcwNTJENDM2Qk}
+      KAFKA_OPTS: "-Djava.security.auth.login.config=/etc/kafka/jaas/kafka_server_jaas.conf"
+    volumes:
+      - kafka1-data:/var/lib/kafka/data
+      - ./kafka/jaas:/etc/kafka/jaas:ro
+    networks: [infra-net]
+    healthcheck:
+      test: ["CMD", "kafka-broker-api-versions", "--bootstrap-server", "localhost:9092",
+             "--command-config", "/etc/kafka/jaas/client.properties"]
+      interval: 15s
+      timeout: 10s
+      retries: 8
+
+  kafka2:
+    image: confluentinc/cp-kafka:7.6.1
+    container_name: kafka2
+    environment:
+      KAFKA_NODE_ID: 2
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka1:9093,2@kafka2:9095,3@kafka3:9097
+      KAFKA_LISTENERS: SASL_PLAINTEXT://0.0.0.0:9094,CONTROLLER://0.0.0.0:9095
+      KAFKA_ADVERTISED_LISTENERS: SASL_PLAINTEXT://kafka2:9094
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: SASL_PLAINTEXT:SASL_PLAINTEXT,CONTROLLER:PLAINTEXT
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_INTER_BROKER_LISTENER_NAME: SASL_PLAINTEXT
+      KAFKA_SASL_ENABLED_MECHANISMS: PLAIN
+      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: PLAIN
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 3
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 3
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 2
+      KAFKA_DEFAULT_REPLICATION_FACTOR: 3
+      KAFKA_MIN_INSYNC_REPLICAS: 2
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
+      KAFKA_ENABLE_IDEMPOTENCE: "true"
+      CLUSTER_ID: ${KAFKA_CLUSTER_ID:-MkU3OEVBNTcwNTJENDM2Qk}
+      KAFKA_OPTS: "-Djava.security.auth.login.config=/etc/kafka/jaas/kafka_server_jaas.conf"
+    volumes:
+      - kafka2-data:/var/lib/kafka/data
+      - ./kafka/jaas:/etc/kafka/jaas:ro
+    networks: [infra-net]
+    healthcheck:
+      test: ["CMD", "kafka-broker-api-versions", "--bootstrap-server", "localhost:9094",
+             "--command-config", "/etc/kafka/jaas/client.properties"]
+      interval: 15s
+      timeout: 10s
+      retries: 8
+
+  kafka3:
+    image: confluentinc/cp-kafka:7.6.1
+    container_name: kafka3
+    environment:
+      KAFKA_NODE_ID: 3
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka1:9093,2@kafka2:9095,3@kafka3:9097
+      KAFKA_LISTENERS: SASL_PLAINTEXT://0.0.0.0:9096,CONTROLLER://0.0.0.0:9097
+      KAFKA_ADVERTISED_LISTENERS: SASL_PLAINTEXT://kafka3:9096
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: SASL_PLAINTEXT:SASL_PLAINTEXT,CONTROLLER:PLAINTEXT
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_INTER_BROKER_LISTENER_NAME: SASL_PLAINTEXT
+      KAFKA_SASL_ENABLED_MECHANISMS: PLAIN
+      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: PLAIN
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 3
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 3
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 2
+      KAFKA_DEFAULT_REPLICATION_FACTOR: 3
+      KAFKA_MIN_INSYNC_REPLICAS: 2
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
+      KAFKA_ENABLE_IDEMPOTENCE: "true"
+      CLUSTER_ID: ${KAFKA_CLUSTER_ID:-MkU3OEVBNTcwNTJENDM2Qk}
+      KAFKA_OPTS: "-Djava.security.auth.login.config=/etc/kafka/jaas/kafka_server_jaas.conf"
+    volumes:
+      - kafka3-data:/var/lib/kafka/data
+      - ./kafka/jaas:/etc/kafka/jaas:ro
+    networks: [infra-net]
+    healthcheck:
+      test: ["CMD", "kafka-broker-api-versions", "--bootstrap-server", "localhost:9096",
+             "--command-config", "/etc/kafka/jaas/client.properties"]
+      interval: 15s
+      timeout: 10s
+      retries: 8
+
+  # ============================================================
+  # Redis Sentinel — 1 master + 2 replicas + 3 sentinels
+  # ============================================================
+
+  redis:
+    # Override base redis with explicit master config
+    command: >
+      redis-server
+      --maxmemory 512mb
+      --maxmemory-policy allkeys-lru
+      --save 60 1
+      --appendonly yes
+      --appendfsync everysec
+      --loglevel warning
+      --requirepass ${REDIS_PASSWORD:-redis-secret-2024}
+    volumes:
+      - redis-data:/data
+
+  redis-replica-1:
+    image: redis:7.2-alpine
+    container_name: redis-replica-1
+    command: >
+      redis-server
+      --replicaof redis 6379
+      --requirepass ${REDIS_PASSWORD:-redis-secret-2024}
+      --masterauth ${REDIS_PASSWORD:-redis-secret-2024}
+      --maxmemory 512mb
+      --maxmemory-policy allkeys-lru
+      --loglevel warning
+    volumes:
+      - redis-replica1-data:/data
+    networks: [infra-net, services-net]
+    depends_on:
+      redis:
+        condition: service_healthy
+
+  redis-replica-2:
+    image: redis:7.2-alpine
+    container_name: redis-replica-2
+    command: >
+      redis-server
+      --replicaof redis 6379
+      --requirepass ${REDIS_PASSWORD:-redis-secret-2024}
+      --masterauth ${REDIS_PASSWORD:-redis-secret-2024}
+      --maxmemory 512mb
+      --maxmemory-policy allkeys-lru
+      --loglevel warning
+    volumes:
+      - redis-replica2-data:/data
+    networks: [infra-net, services-net]
+    depends_on:
+      redis:
+        condition: service_healthy
+
+  sentinel-1:
+    image: redis:7.2-alpine
+    container_name: sentinel-1
+    command: >
+      redis-sentinel /etc/redis/sentinel.conf
+    volumes:
+      - ./config/redis/sentinel.conf:/etc/redis/sentinel.conf:ro
+    networks: [infra-net, services-net]
+    depends_on:
+      - redis
+      - redis-replica-1
+      - redis-replica-2
+
+  sentinel-2:
+    image: redis:7.2-alpine
+    container_name: sentinel-2
+    command: >
+      redis-sentinel /etc/redis/sentinel.conf
+    volumes:
+      - ./config/redis/sentinel.conf:/etc/redis/sentinel.conf:ro
+    networks: [infra-net, services-net]
+    depends_on:
+      - redis
+      - redis-replica-1
+      - redis-replica-2
+
+  sentinel-3:
+    image: redis:7.2-alpine
+    container_name: sentinel-3
+    command: >
+      redis-sentinel /etc/redis/sentinel.conf
+    volumes:
+      - ./config/redis/sentinel.conf:/etc/redis/sentinel.conf:ro
+    networks: [infra-net, services-net]
+    depends_on:
+      - redis
+      - redis-replica-1
+      - redis-replica-2
+
+  # ============================================================
+  # Eureka — second instance for peer awareness
+  # ============================================================
+
+  discovery-service-2:
+    image: ${DISCOVERY_SERVICE_IMAGE:-ecommerce/discovery-service:latest}
+    container_name: discovery-service-2
+    ports:
+      - "8762:8761"
+    depends_on:
+      config-service:
+        condition: service_healthy
+    environment:
+      SPRING_CONFIG_IMPORT: optional:configserver:http://config-service:8888
+      EUREKA_HOST: discovery-service-2
+      EUREKA_USERNAME: ${EUREKA_USERNAME:-eureka}
+      EUREKA_PASSWORD: ${EUREKA_PASSWORD:-eureka-secret-2024}
+      EUREKA_PEER_URL: http://${EUREKA_USERNAME:-eureka}:${EUREKA_PASSWORD:-eureka-secret-2024}@discovery-service:8761/eureka/
+      VAULT_ENABLED: ${VAULT_ENABLED:-true}
+      VAULT_HOST: ${VAULT_HOST:-vault}
+      VAULT_TOKEN: ${VAULT_TOKEN:-root-token}
+    networks: [services-net, infra-net]
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8761/actuator/health || exit 1"]
+      interval: 15s
+      timeout: 10s
+      retries: 8
+    restart: on-failure
+
+  # ============================================================
+  # MongoDB Replica Set — 3 nodes
+  # ============================================================
+
+  mongodb:
+    # Override single instance to be named mongo1
+    container_name: mongo1
+    command: mongod --replSet rs0 --bind_ip_all
+
+  mongo2:
+    image: mongo:7.0
+    container_name: mongo2
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: ${MONGO_USERNAME:-vanilson}
+      MONGO_INITDB_ROOT_PASSWORD: ${MONGO_PASSWORD:-vanilson}
+    command: mongod --replSet rs0 --bind_ip_all
+    volumes:
+      - mongodb2-data:/data/db
+    networks: [infra-net]
+    healthcheck:
+      test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  mongo3:
+    image: mongo:7.0
+    container_name: mongo3
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: ${MONGO_USERNAME:-vanilson}
+      MONGO_INITDB_ROOT_PASSWORD: ${MONGO_PASSWORD:-vanilson}
+    command: mongod --replSet rs0 --bind_ip_all
+    volumes:
+      - mongodb3-data:/data/db
+    networks: [infra-net]
+    healthcheck:
+      test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # Initialize replica set after all 3 nodes are healthy
+  mongo-rs-init:
+    image: mongo:7.0
+    container_name: mongo-rs-init
+    depends_on:
+      mongodb:
+        condition: service_healthy
+      mongo2:
+        condition: service_healthy
+      mongo3:
+        condition: service_healthy
+    command: >
+      mongosh --host mongo1:27017
+        -u ${MONGO_USERNAME:-vanilson}
+        -p ${MONGO_PASSWORD:-vanilson}
+        --authenticationDatabase admin
+        /scripts/mongo-replicaset-init.js
+    volumes:
+      - ./scripts/mongo-replicaset-init.js:/scripts/mongo-replicaset-init.js:ro
+    networks: [infra-net]
+    restart: "no"
+
+volumes:
+  kafka1-data:
+  kafka2-data:
+  kafka3-data:
+  redis-replica1-data:
+  redis-replica2-data:
+  mongodb2-data:
+  mongodb3-data:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,409 @@
+###############################################################
+# docker-compose.prod.yml — Production hardening overlay
+#
+# Usage: docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+#
+# Changes from dev compose:
+#   - Removes all exposed ports (except gateway:8222 and grafana:3000)
+#   - Adds resource limits per container type
+#   - Adds log rotation (json-file, max 10m, 3 files)
+#   - Sets restart: unless-stopped for all services
+#   - Adds read_only + tmpfs for stateless app containers
+#   - Removes MailHog (use real SMTP in prod)
+###############################################################
+
+services:
+
+  # ============================================================
+  # INFRASTRUCTURE — secrets, messaging, cache, databases
+  # ============================================================
+
+  vault:
+    ports: !reset []        # remove 8200 exposure in prod
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 512m
+          cpus: "0.5"
+    logging:
+      driver: json-file
+      options:
+        max-size: 10m
+        max-file: "3"
+
+  zookeeper:
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 512m
+          cpus: "0.5"
+    logging:
+      driver: json-file
+      options:
+        max-size: 10m
+        max-file: "3"
+
+  kafka:
+    ports: !reset []        # remove 9092 exposure; services use kafka:29092 on infra-net
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 2g
+          cpus: "2.0"
+    logging:
+      driver: json-file
+      options:
+        max-size: 10m
+        max-file: "3"
+
+  redis:
+    ports: !reset []        # remove 6379 exposure
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 512m
+          cpus: "0.5"
+    logging:
+      driver: json-file
+      options:
+        max-size: 10m
+        max-file: "3"
+
+  postgres-order:
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 2g
+          cpus: "2.0"
+    logging:
+      driver: json-file
+      options:
+        max-size: 10m
+        max-file: "3"
+
+  postgres-product:
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 2g
+          cpus: "2.0"
+    logging:
+      driver: json-file
+      options:
+        max-size: 10m
+        max-file: "3"
+
+  postgres-payment:
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 2g
+          cpus: "2.0"
+    logging:
+      driver: json-file
+      options:
+        max-size: 10m
+        max-file: "3"
+
+  postgres-auth:
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 2g
+          cpus: "2.0"
+    logging:
+      driver: json-file
+      options:
+        max-size: 10m
+        max-file: "3"
+
+  mongodb:
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 2g
+          cpus: "2.0"
+    logging:
+      driver: json-file
+      options:
+        max-size: 10m
+        max-file: "3"
+
+  # ============================================================
+  # OBSERVABILITY
+  # ============================================================
+
+  zipkin:
+    ports: !reset []        # remove 9411 — access through monitoring-net only
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 512m
+          cpus: "0.5"
+    logging:
+      driver: json-file
+      options:
+        max-size: 10m
+        max-file: "3"
+
+  prometheus:
+    ports: !reset []        # internal only in prod
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 1g
+          cpus: "1.0"
+    logging:
+      driver: json-file
+      options:
+        max-size: 10m
+        max-file: "3"
+
+  alertmanager:
+    ports: !reset []
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 256m
+          cpus: "0.25"
+    logging:
+      driver: json-file
+      options:
+        max-size: 10m
+        max-file: "3"
+
+  loki:
+    ports: !reset []
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 512m
+          cpus: "0.5"
+    logging:
+      driver: json-file
+      options:
+        max-size: 10m
+        max-file: "3"
+
+  promtail:
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 256m
+          cpus: "0.25"
+    logging:
+      driver: json-file
+      options:
+        max-size: 10m
+        max-file: "3"
+
+  grafana:
+    # Keep :3000 for dashboards — accessible only through VPN/firewall rule in prod
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 512m
+          cpus: "0.5"
+    logging:
+      driver: json-file
+      options:
+        max-size: 10m
+        max-file: "3"
+
+  # MailHog removed in production — use real SMTP (set MAIL_HOST, MAIL_PORT, MAIL_USERNAME, MAIL_PASSWORD)
+  mailhog:
+    deploy:
+      replicas: 0
+
+  # ============================================================
+  # SPRING CLOUD INFRASTRUCTURE
+  # ============================================================
+
+  config-service:
+    ports: !reset []        # internal only — services access via service name
+    restart: unless-stopped
+    read_only: true
+    tmpfs:
+      - /tmp
+    deploy:
+      resources:
+        limits:
+          memory: 1g
+          cpus: "1.0"
+    logging:
+      driver: json-file
+      options:
+        max-size: 10m
+        max-file: "3"
+
+  discovery-service:
+    ports: !reset []
+    restart: unless-stopped
+    read_only: true
+    tmpfs:
+      - /tmp
+    deploy:
+      resources:
+        limits:
+          memory: 1g
+          cpus: "1.0"
+    logging:
+      driver: json-file
+      options:
+        max-size: 10m
+        max-file: "3"
+
+  # ============================================================
+  # APPLICATION SERVICES — stateless, read_only + tmpfs
+  # ============================================================
+
+  gateway-api-service:
+    # Keep :8222 — external entry point
+    restart: unless-stopped
+    read_only: true
+    tmpfs:
+      - /tmp
+    deploy:
+      resources:
+        limits:
+          memory: 1g
+          cpus: "1.0"
+    logging:
+      driver: json-file
+      options:
+        max-size: 10m
+        max-file: "3"
+
+  authentication-service:
+    ports: !reset []
+    restart: unless-stopped
+    read_only: true
+    tmpfs:
+      - /tmp
+    deploy:
+      resources:
+        limits:
+          memory: 1g
+          cpus: "1.0"
+    logging:
+      driver: json-file
+      options:
+        max-size: 10m
+        max-file: "3"
+
+  customer-service:
+    ports: !reset []
+    restart: unless-stopped
+    read_only: true
+    tmpfs:
+      - /tmp
+    deploy:
+      resources:
+        limits:
+          memory: 1g
+          cpus: "1.0"
+    logging:
+      driver: json-file
+      options:
+        max-size: 10m
+        max-file: "3"
+
+  product-service:
+    ports: !reset []
+    restart: unless-stopped
+    read_only: true
+    tmpfs:
+      - /tmp
+    deploy:
+      resources:
+        limits:
+          memory: 1g
+          cpus: "1.0"
+    logging:
+      driver: json-file
+      options:
+        max-size: 10m
+        max-file: "3"
+
+  order-service:
+    ports: !reset []
+    restart: unless-stopped
+    read_only: true
+    tmpfs:
+      - /tmp
+    deploy:
+      resources:
+        limits:
+          memory: 1g
+          cpus: "1.0"
+    logging:
+      driver: json-file
+      options:
+        max-size: 10m
+        max-file: "3"
+
+  payment-service:
+    ports: !reset []
+    restart: unless-stopped
+    read_only: true
+    tmpfs:
+      - /tmp
+    deploy:
+      resources:
+        limits:
+          memory: 1g
+          cpus: "1.0"
+    logging:
+      driver: json-file
+      options:
+        max-size: 10m
+        max-file: "3"
+
+  cart-service:
+    ports: !reset []
+    restart: unless-stopped
+    read_only: true
+    tmpfs:
+      - /tmp
+    deploy:
+      resources:
+        limits:
+          memory: 1g
+          cpus: "1.0"
+    logging:
+      driver: json-file
+      options:
+        max-size: 10m
+        max-file: "3"
+
+  notification-service:
+    ports: !reset []
+    restart: unless-stopped
+    read_only: true
+    tmpfs:
+      - /tmp
+    deploy:
+      resources:
+        limits:
+          memory: 1g
+          cpus: "1.0"
+    logging:
+      driver: json-file
+      options:
+        max-size: 10m
+        max-file: "3"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,11 +42,11 @@ services:
       - vault-data:/vault/data
       - ./vault/config:/vault/config:ro
       - ./vault/policies:/vault/policies:ro
-    command: ["vault", "server", "-dev"]
+    command: [ "vault", "server", "-dev" ]
     # Production: use -config=/vault/config/vault.hcl instead of -dev
-    networks: [infra-net, services-net]
+    networks: [ infra-net, services-net ]
     healthcheck:
-      test: ["CMD-SHELL", "vault status 2>/dev/null | grep -q 'Initialized'"]
+      test: [ "CMD-SHELL", "vault status 2>/dev/null | grep -q 'Initialized'" ]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -62,9 +62,9 @@ services:
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
-    networks: [infra-net]
+    networks: [ infra-net ]
     healthcheck:
-      test: ["CMD", "nc", "-z", "localhost", "2181"]
+      test: [ "CMD", "nc", "-z", "localhost", "2181" ]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -98,9 +98,9 @@ services:
       KAFKA_OPTS: "-Djava.security.auth.login.config=/etc/kafka/jaas/kafka_server_jaas.conf"
     volumes:
       - ./kafka/jaas:/etc/kafka/jaas:ro
-    networks: [infra-net]
+    networks: [ infra-net ]
     healthcheck:
-      test: ["CMD", "kafka-broker-api-versions", "--bootstrap-server", "localhost:9092"]
+      test: [ "CMD", "kafka-broker-api-versions", "--bootstrap-server", "localhost:9092" ]
       interval: 15s
       timeout: 10s
       retries: 8
@@ -125,9 +125,9 @@ services:
       --requirepass ${REDIS_PASSWORD:-redis-secret-2024}
     volumes:
       - redis-data:/data
-    networks: [infra-net, services-net]
+    networks: [ infra-net, services-net ]
     healthcheck:
-      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD:-redis-secret-2024}", "ping"]
+      test: [ "CMD", "redis-cli", "-a", "${REDIS_PASSWORD:-redis-secret-2024}", "ping" ]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -146,9 +146,9 @@ services:
     # No external port — internal only. Access via: docker exec postgres-order psql
     volumes:
       - postgres-order-data:/var/lib/postgresql/data
-    networks: [infra-net]
+    networks: [ infra-net ]
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USERNAME:-vanilson} -d order_service_db"]
+      test: [ "CMD-SHELL", "pg_isready -U ${POSTGRES_USERNAME:-vanilson} -d order_service_db" ]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -162,9 +162,9 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-vanilson}
     volumes:
       - postgres-product-data:/var/lib/postgresql/data
-    networks: [infra-net]
+    networks: [ infra-net ]
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USERNAME:-vanilson} -d product_service_db"]
+      test: [ "CMD-SHELL", "pg_isready -U ${POSTGRES_USERNAME:-vanilson} -d product_service_db" ]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -178,9 +178,9 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-vanilson}
     volumes:
       - postgres-payment-data:/var/lib/postgresql/data
-    networks: [infra-net]
+    networks: [ infra-net ]
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USERNAME:-vanilson} -d payment_db"]
+      test: [ "CMD-SHELL", "pg_isready -U ${POSTGRES_USERNAME:-vanilson} -d payment_db" ]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -194,9 +194,9 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-vanilson}
     volumes:
       - postgres-auth-data:/var/lib/postgresql/data
-    networks: [infra-net]
+    networks: [ infra-net ]
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USERNAME:-vanilson} -d auth_db"]
+      test: [ "CMD-SHELL", "pg_isready -U ${POSTGRES_USERNAME:-vanilson} -d auth_db" ]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -211,9 +211,9 @@ services:
     volumes:
       - mongodb-data:/data/db
       - ./mongo-init.js:/docker-entrypoint-initdb.d/mongo-init.js:ro
-    networks: [infra-net]
+    networks: [ infra-net ]
     healthcheck:
-      test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
+      test: [ "CMD", "mongosh", "--eval", "db.adminCommand('ping')" ]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -229,9 +229,9 @@ services:
       - "9411:9411"
     volumes:
       - zipkin-data:/zipkin
-    networks: [monitoring-net, services-net]
+    networks: [ monitoring-net, services-net ]
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:9411/health || exit 1"]
+      test: [ "CMD-SHELL", "curl -f http://localhost:9411/health || exit 1" ]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -250,9 +250,9 @@ services:
       - "--storage.tsdb.path=/prometheus"
       - "--storage.tsdb.retention.time=15d"
       - "--web.enable-lifecycle"
-    networks: [monitoring-net, services-net]
+    networks: [ monitoring-net, services-net ]
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost:9090/-/healthy | grep -q Prometheus"]
+      test: [ "CMD-SHELL", "wget -qO- http://localhost:9090/-/healthy | grep -q Prometheus" ]
       interval: 15s
       timeout: 5s
       retries: 5
@@ -268,9 +268,9 @@ services:
     command:
       - "--config.file=/etc/alertmanager/alertmanager.yml"
       - "--storage.path=/alertmanager"
-    networks: [monitoring-net, services-net]
+    networks: [ monitoring-net, services-net ]
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost:9093/-/healthy || exit 1"]
+      test: [ "CMD-SHELL", "wget -qO- http://localhost:9093/-/healthy || exit 1" ]
       interval: 15s
       timeout: 5s
       retries: 5
@@ -284,9 +284,9 @@ services:
       - ./loki/loki-config.yml:/etc/loki/loki-config.yml:ro
       - loki-data:/tmp/loki
     command: -config.file=/etc/loki/loki-config.yml
-    networks: [monitoring-net, services-net]
+    networks: [ monitoring-net, services-net ]
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost:3100/ready || exit 1"]
+      test: [ "CMD-SHELL", "wget -qO- http://localhost:3100/ready || exit 1" ]
       interval: 15s
       timeout: 5s
       retries: 5
@@ -301,7 +301,7 @@ services:
     command: -config.file=/etc/promtail/promtail-config.yml
     depends_on:
       - loki
-    networks: [monitoring-net, services-net]
+    networks: [ monitoring-net, services-net ]
 
   grafana:
     image: grafana/grafana:10.4.2
@@ -321,7 +321,7 @@ services:
     depends_on:
       - prometheus
       - loki
-    networks: [monitoring-net]
+    networks: [ monitoring-net ]
 
   mailhog:
     image: mailhog/mailhog:v1.0.1
@@ -329,7 +329,7 @@ services:
     ports:
       - "1025:1025"
       - "8025:8025"
-    networks: [services-net]
+    networks: [ services-net ]
 
   # ============================================================
   # SPRING CLOUD INFRASTRUCTURE
@@ -344,13 +344,13 @@ services:
       - "8888:8888"
     environment:
       SPRING_PROFILES_ACTIVE: native
-      VAULT_ENABLED: ${VAULT_ENABLED:-false}
+      VAULT_ENABLED: ${VAULT_ENABLED:-true}
       VAULT_HOST: ${VAULT_HOST:-vault}
       VAULT_PORT: ${VAULT_PORT:-8200}
       VAULT_TOKEN: ${VAULT_TOKEN:-root-token}
-    networks: [services-net, infra-net]
+    networks: [ services-net, infra-net ]
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:8888/actuator/health || exit 1"]
+      test: [ "CMD-SHELL", "curl -f http://localhost:8888/actuator/health || exit 1" ]
       interval: 15s
       timeout: 10s
       retries: 8
@@ -371,12 +371,12 @@ services:
       EUREKA_HOST: discovery-service
       EUREKA_USERNAME: ${EUREKA_USERNAME:-eureka}
       EUREKA_PASSWORD: ${EUREKA_PASSWORD:-eureka-secret-2024}
-      VAULT_ENABLED: ${VAULT_ENABLED:-false}
+      VAULT_ENABLED: ${VAULT_ENABLED:-true}
       VAULT_HOST: ${VAULT_HOST:-vault}
       VAULT_TOKEN: ${VAULT_TOKEN:-root-token}
-    networks: [services-net, infra-net]
+    networks: [ services-net, infra-net ]
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:8761/actuator/health || exit 1"]
+      test: [ "CMD-SHELL", "curl -f http://localhost:8761/actuator/health || exit 1" ]
       interval: 15s
       timeout: 10s
       retries: 8
@@ -410,12 +410,12 @@ services:
       REDIS_PASSWORD: ${REDIS_PASSWORD:-redis-secret-2024}
       JWT_SECRET: ${JWT_SECRET:-bXlTdXBlclNlY3VyZVNlY3JldEtleUZvckpXVEF1dGgxMjM0NTY3ODk=}
       GATEWAY_MAX_CONCURRENT: 5000
-      VAULT_ENABLED: ${VAULT_ENABLED:-false}
+      VAULT_ENABLED: ${VAULT_ENABLED:-true}
       VAULT_HOST: ${VAULT_HOST:-vault}
       VAULT_TOKEN: ${VAULT_TOKEN:-root-token}
-    networks: [services-net, infra-net]
+    networks: [ services-net, infra-net ]
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:8222/actuator/health || exit 1"]
+      test: [ "CMD-SHELL", "curl -f http://localhost:8222/actuator/health || exit 1" ]
       interval: 15s
       timeout: 10s
       retries: 8
@@ -444,12 +444,12 @@ services:
       POSTGRES_USERNAME: ${POSTGRES_USERNAME:-vanilson}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-vanilson}
       JWT_SECRET: ${JWT_SECRET:-bXlTdXBlclNlY3VyZVNlY3JldEtleUZvckpXVEF1dGgxMjM0NTY3ODk=}
-      VAULT_ENABLED: ${VAULT_ENABLED:-false}
+      VAULT_ENABLED: ${VAULT_ENABLED:-true}
       VAULT_HOST: ${VAULT_HOST:-vault}
       VAULT_TOKEN: ${VAULT_TOKEN:-root-token}
-    networks: [services-net, infra-net]
+    networks: [ services-net, infra-net ]
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:8085/actuator/health || exit 1"]
+      test: [ "CMD-SHELL", "curl -f http://localhost:8085/actuator/health || exit 1" ]
       interval: 15s
       timeout: 10s
       retries: 8
@@ -477,12 +477,12 @@ services:
       MONGO_HOST: mongodb
       REDIS_HOST: redis
       REDIS_PASSWORD: ${REDIS_PASSWORD:-redis-secret-2024}
-      VAULT_ENABLED: ${VAULT_ENABLED:-false}
+      VAULT_ENABLED: ${VAULT_ENABLED:-true}
       VAULT_HOST: ${VAULT_HOST:-vault}
       VAULT_TOKEN: ${VAULT_TOKEN:-root-token}
-    networks: [services-net, infra-net]
+    networks: [ services-net, infra-net ]
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:8090/actuator/health || exit 1"]
+      test: [ "CMD-SHELL", "curl -f http://localhost:8090/actuator/health || exit 1" ]
       interval: 15s
       timeout: 10s
       retries: 8
@@ -515,12 +515,12 @@ services:
       KAFKA_BOOTSTRAP_SERVERS: kafka:29092
       KAFKA_USERNAME: ${KAFKA_USERNAME:-kafka}
       KAFKA_PASSWORD: ${KAFKA_PASSWORD:-kafka-secret-2024}
-      VAULT_ENABLED: ${VAULT_ENABLED:-false}
+      VAULT_ENABLED: ${VAULT_ENABLED:-true}
       VAULT_HOST: ${VAULT_HOST:-vault}
       VAULT_TOKEN: ${VAULT_TOKEN:-root-token}
-    networks: [services-net, infra-net]
+    networks: [ services-net, infra-net ]
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:8082/actuator/health || exit 1"]
+      test: [ "CMD-SHELL", "curl -f http://localhost:8082/actuator/health || exit 1" ]
       interval: 15s
       timeout: 10s
       retries: 8
@@ -552,12 +552,12 @@ services:
       KAFKA_USERNAME: ${KAFKA_USERNAME:-kafka}
       KAFKA_PASSWORD: ${KAFKA_PASSWORD:-kafka-secret-2024}
       GATEWAY_HOST: gateway-api-service
-      VAULT_ENABLED: ${VAULT_ENABLED:-false}
+      VAULT_ENABLED: ${VAULT_ENABLED:-true}
       VAULT_HOST: ${VAULT_HOST:-vault}
       VAULT_TOKEN: ${VAULT_TOKEN:-root-token}
-    networks: [services-net, infra-net]
+    networks: [ services-net, infra-net ]
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:8083/actuator/health || exit 1"]
+      test: [ "CMD-SHELL", "curl -f http://localhost:8083/actuator/health || exit 1" ]
       interval: 15s
       timeout: 10s
       retries: 8
@@ -588,12 +588,12 @@ services:
       KAFKA_BOOTSTRAP_SERVERS: kafka:29092
       KAFKA_USERNAME: ${KAFKA_USERNAME:-kafka}
       KAFKA_PASSWORD: ${KAFKA_PASSWORD:-kafka-secret-2024}
-      VAULT_ENABLED: ${VAULT_ENABLED:-false}
+      VAULT_ENABLED: ${VAULT_ENABLED:-true}
       VAULT_HOST: ${VAULT_HOST:-vault}
       VAULT_TOKEN: ${VAULT_TOKEN:-root-token}
-    networks: [services-net, infra-net]
+    networks: [ services-net, infra-net ]
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:8086/actuator/health || exit 1"]
+      test: [ "CMD-SHELL", "curl -f http://localhost:8086/actuator/health || exit 1" ]
       interval: 15s
       timeout: 10s
       retries: 8
@@ -621,12 +621,12 @@ services:
       REDIS_HOST: redis
       REDIS_PORT: 6379
       REDIS_PASSWORD: ${REDIS_PASSWORD:-redis-secret-2024}
-      VAULT_ENABLED: ${VAULT_ENABLED:-false}
+      VAULT_ENABLED: ${VAULT_ENABLED:-true}
       VAULT_HOST: ${VAULT_HOST:-vault}
       VAULT_TOKEN: ${VAULT_TOKEN:-root-token}
-    networks: [services-net, infra-net]
+    networks: [ services-net, infra-net ]
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:8091/actuator/health || exit 1"]
+      test: [ "CMD-SHELL", "curl -f http://localhost:8091/actuator/health || exit 1" ]
       interval: 15s
       timeout: 10s
       retries: 8
@@ -661,12 +661,12 @@ services:
       MAIL_PORT: 1025
       MAIL_USERNAME: noreply@vanilsonshop.io
       MAIL_PASSWORD: unused
-      VAULT_ENABLED: ${VAULT_ENABLED:-false}
+      VAULT_ENABLED: ${VAULT_ENABLED:-true}
       VAULT_HOST: ${VAULT_HOST:-vault}
       VAULT_TOKEN: ${VAULT_TOKEN:-root-token}
-    networks: [services-net, infra-net]
+    networks: [ services-net, infra-net ]
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:8040/actuator/health || exit 1"]
+      test: [ "CMD-SHELL", "curl -f http://localhost:8040/actuator/health || exit 1" ]
       interval: 15s
       timeout: 10s
       retries: 8

--- a/gateway-api-service/src/main/java/code/with/vanilson/gatewayservice/filter/JwtAuthenticationFilter.java
+++ b/gateway-api-service/src/main/java/code/with/vanilson/gatewayservice/filter/JwtAuthenticationFilter.java
@@ -23,6 +23,9 @@ import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
 import javax.crypto.SecretKey;
+import java.security.KeyFactory;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.X509EncodedKeySpec;
 import java.text.MessageFormat;
 import java.util.Base64;
 import java.util.List;
@@ -33,6 +36,10 @@ import java.util.List;
  * Global filter that runs at the highest priority (Ordered.HIGHEST_PRECEDENCE + 10).
  * Validates JWT tokens and enriches downstream requests with tenant/user headers.
  * Public endpoints (configured via gateway.public-paths) bypass authentication.
+ * <p>
+ * Supports RS256 (asymmetric) via JWT_PUBLIC_KEY env var, with HS256 fallback for
+ * backward compatibility. RS256 is preferred: gateway only needs the public key,
+ * so it cannot forge tokens.
  * <p>
  * On success: adds X-User-ID, X-Tenant-ID, X-User-Role headers for downstream services.
  * On failure: throws JwtAuthenticationException → handled by GatewayGlobalExceptionHandler.
@@ -53,17 +60,29 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
     private static final String CLAIM_ROLE = "role";
 
     private final MessageSource messageSource;
-    private final SecretKey signingKey;
+    private final Object verificationKey;  // RSAPublicKey (RS256) or SecretKey (HS256 fallback)
+    private final boolean useRsa;
     private final List<String> publicPaths;
 
     public JwtAuthenticationFilter(
             MessageSource messageSource,
-            @Value("${gateway.jwt.secret}") String jwtSecret,
+            @Value("${gateway.jwt.public-key:}") String publicKeyBase64,
+            @Value("${gateway.jwt.secret:}")     String jwtSecret,
             @Value("${gateway.public-paths:/api/v1/auth/**,/actuator/**}") List<String> publicPaths) {
+
         this.messageSource = messageSource;
-        byte[] keyBytes = Base64.getDecoder().decode(jwtSecret);
-        this.signingKey = Keys.hmacShaKeyFor(keyBytes);
-        this.publicPaths = publicPaths;
+        this.publicPaths   = publicPaths;
+
+        if (publicKeyBase64 != null && !publicKeyBase64.isBlank()) {
+            this.verificationKey = loadRsaPublicKey(publicKeyBase64);
+            this.useRsa          = true;
+            log.info("[JwtAuthenticationFilter] Initialized with RS256 public key verification");
+        } else {
+            byte[] keyBytes = Base64.getDecoder().decode(jwtSecret);
+            this.verificationKey = Keys.hmacShaKeyFor(keyBytes);
+            this.useRsa          = false;
+            log.warn("[JwtAuthenticationFilter] Falling back to HS256 — set JWT_PUBLIC_KEY for RS256");
+        }
     }
 
     @Override
@@ -95,9 +114,14 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
         String token = authHeader.substring(BEARER_PREFIX.length());
 
         try {
-            Claims claims = Jwts.parser()
-                    .verifyWith(signingKey)
-                    .build()
+            var parserBuilder = Jwts.parser();
+            if (useRsa) {
+                parserBuilder.verifyWith((RSAPublicKey) verificationKey);
+            } else {
+                parserBuilder.verifyWith((SecretKey) verificationKey);
+            }
+
+            Claims claims = parserBuilder.build()
                     .parseSignedClaims(token)
                     .getPayload();
 
@@ -169,7 +193,6 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
 
     @Override
     public int getOrder() {
-        // Run before rate limiting and routing filters
         return Ordered.HIGHEST_PRECEDENCE + 10;
     }
 
@@ -178,5 +201,19 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
             String normalizedPattern = pattern.replace("/**", "");
             return path.startsWith(normalizedPattern);
         });
+    }
+
+    private static RSAPublicKey loadRsaPublicKey(String base64Pem) {
+        try {
+            String clean = base64Pem
+                    .replace("-----BEGIN PUBLIC KEY-----", "")
+                    .replace("-----END PUBLIC KEY-----", "")
+                    .replaceAll("\\s", "");
+            byte[] keyBytes = Base64.getDecoder().decode(clean);
+            return (RSAPublicKey) KeyFactory.getInstance("RSA")
+                    .generatePublic(new X509EncodedKeySpec(keyBytes));
+        } catch (Exception ex) {
+            throw new IllegalStateException("Failed to load RSA public key — check JWT_PUBLIC_KEY", ex);
+        }
     }
 }

--- a/helm/ecommerce/Chart.yaml
+++ b/helm/ecommerce/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v2
+name: ecommerce
+description: SaaS E-Commerce Microservices Platform — Spring Boot 3.2.5 with 10 services
+type: application
+version: 1.0.0
+appVersion: "1.0.0"
+keywords:
+  - ecommerce
+  - microservices
+  - spring-boot
+  - kafka
+  - mongodb
+  - postgresql
+maintainers:
+  - name: Platform Team
+    email: platform@vanilsonshop.io
+home: https://github.com/edsonwade/e-commerce
+sources:
+  - https://github.com/edsonwade/e-commerce

--- a/helm/ecommerce/templates/NOTES.txt
+++ b/helm/ecommerce/templates/NOTES.txt
@@ -1,0 +1,52 @@
+🚀 E-Commerce Platform deployed successfully!
+
+Release: {{ .Release.Name }}
+Namespace: {{ .Values.global.namespace }}
+Chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ SERVICE ENDPOINTS
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+{{- if .Values.ingress.enabled }}
+  API Gateway:   https://{{ .Values.ingress.host }}/api/v1/
+  Grafana:       https://{{ .Values.ingress.host }}/grafana
+{{- else }}
+  API Gateway (port-forward):
+    kubectl port-forward svc/gateway-api-service 8222:8222 -n {{ .Values.global.namespace }}
+    Then: http://localhost:8222/api/v1/
+
+  Grafana (port-forward):
+    kubectl port-forward svc/grafana 3000:3000 -n {{ .Values.global.namespace }}
+    Then: http://localhost:3000
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ POST-INSTALL CHECKLIST
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+1. Initialize Vault secrets:
+   kubectl exec -n {{ .Values.global.namespace }} vault-0 -- /vault/scripts/vault-init.sh
+
+2. Initialize MongoDB replica set:
+   kubectl exec -n {{ .Values.global.namespace }} mongodb-0 -- \
+     mongosh --file /scripts/mongo-replicaset-init.js
+
+3. Verify all pods are running:
+   kubectl get pods -n {{ .Values.global.namespace }}
+
+4. Check service health:
+   kubectl get pods -n {{ .Values.global.namespace }} -l tier=application
+
+5. View logs:
+   kubectl logs -f -l app=gateway-api-service -n {{ .Values.global.namespace }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ UPGRADE
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  # Staging
+  helm upgrade {{ .Release.Name }} ./helm/ecommerce -f values-staging.yaml -n {{ .Values.global.namespace }}
+
+  # Production
+  helm upgrade {{ .Release.Name }} ./helm/ecommerce -f values-production.yaml -n {{ .Values.global.namespace }}

--- a/helm/ecommerce/templates/_helpers.tpl
+++ b/helm/ecommerce/templates/_helpers.tpl
@@ -1,0 +1,77 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "ecommerce.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "ecommerce.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart label.
+*/}}
+{{- define "ecommerce.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels applied to all resources.
+*/}}
+{{- define "ecommerce.labels" -}}
+helm.sh/chart: {{ include "ecommerce.chart" . }}
+{{ include "ecommerce.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels — used by Deployment/Service selectors.
+*/}}
+{{- define "ecommerce.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "ecommerce.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Service-specific selector labels.
+Usage: {{ include "ecommerce.serviceSelectorLabels" (dict "name" "gateway-api-service") }}
+*/}}
+{{- define "ecommerce.serviceSelectorLabels" -}}
+app: {{ .name }}
+tier: application
+{{- end }}
+
+{{/*
+Create the name of the service account to use.
+*/}}
+{{- define "ecommerce.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "ecommerce.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Image reference — combines registry, repository, and tag.
+Usage: {{ include "ecommerce.image" (dict "global" .Values.global "service" .Values.services.gateway) }}
+*/}}
+{{- define "ecommerce.image" -}}
+{{- printf "%s/%s:%s" .global.imageRegistry .service.image.repository .service.image.tag }}
+{{- end }}

--- a/helm/ecommerce/templates/configmap.yaml
+++ b/helm/ecommerce/templates/configmap.yaml
@@ -1,0 +1,21 @@
+{{- range $name, $svc := .Values.services }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $name }}-config
+  namespace: {{ $.Values.global.namespace }}
+  labels:
+    app: {{ $name }}
+    {{ include "ecommerce.labels" $ | nindent 4 }}
+data:
+  SPRING_CONFIG_IMPORT: "optional:configserver:http://config-service:8888"
+  EUREKA_HOST: "discovery-service"
+  VAULT_ENABLED: "true"
+  VAULT_HOST: "vault"
+  VAULT_PORT: "8200"
+  VAULT_SCHEME: "http"
+  KAFKA_BOOTSTRAP_SERVERS: "kafka1:9092,kafka2:9094,kafka3:9096"
+  REDIS_SENTINEL_MASTER: "mymaster"
+  REDIS_SENTINEL_NODES: "sentinel-1:26379,sentinel-2:26379,sentinel-3:26379"
+{{- end }}

--- a/helm/ecommerce/templates/deployment.yaml
+++ b/helm/ecommerce/templates/deployment.yaml
@@ -1,0 +1,69 @@
+{{- range $name, $svc := .Values.services }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $name }}
+  namespace: {{ $.Values.global.namespace }}
+  labels:
+    app: {{ $name }}
+    tier: application
+    {{ include "ecommerce.labels" $ | nindent 4 }}
+spec:
+  replicas: {{ $svc.replicaCount | default 1 }}
+  selector:
+    matchLabels:
+      app: {{ $name }}
+  template:
+    metadata:
+      labels:
+        app: {{ $name }}
+        tier: application
+    spec:
+      containers:
+        - name: {{ $name }}
+          image: {{ printf "%s/%s:%s" $.Values.global.imageRegistry $svc.image.repository $svc.image.tag }}
+          imagePullPolicy: {{ $.Values.global.imagePullPolicy }}
+          ports:
+            - containerPort: {{ $svc.port }}
+              protocol: TCP
+          resources:
+            requests:
+              cpu: {{ $svc.resources.requests.cpu }}
+              memory: {{ $svc.resources.requests.memory }}
+            limits:
+              cpu: {{ $svc.resources.limits.cpu }}
+              memory: {{ $svc.resources.limits.memory }}
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: {{ $svc.port }}
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: {{ $svc.port }}
+            initialDelaySeconds: 90
+            periodSeconds: 15
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /actuator/health
+              port: {{ $svc.port }}
+            failureThreshold: 30
+            periodSeconds: 10
+          envFrom:
+            - configMapRef:
+                name: {{ $name }}-config
+            - secretRef:
+                name: {{ $name }}-secret
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: "kubernetes"
+            - name: MANAGEMENT_TRACING_SAMPLING_PROBABILITY
+              value: {{ $.Values.global.tracingSamplingRate | quote }}
+            - name: LOGGING_LEVEL_ROOT
+              value: {{ $.Values.global.logLevel }}
+{{- end }}

--- a/helm/ecommerce/templates/hpa.yaml
+++ b/helm/ecommerce/templates/hpa.yaml
@@ -1,0 +1,27 @@
+{{- range $name, $svc := .Values.services }}
+{{- if and $svc.hpa $svc.hpa.enabled }}
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ $name }}-hpa
+  namespace: {{ $.Values.global.namespace }}
+  labels:
+    app: {{ $name }}
+    {{ include "ecommerce.labels" $ | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ $name }}
+  minReplicas: {{ $svc.hpa.minReplicas | default 1 }}
+  maxReplicas: {{ $svc.hpa.maxReplicas | default 5 }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ $svc.hpa.targetCPUUtilizationPercentage | default 75 }}
+{{- end }}
+{{- end }}

--- a/helm/ecommerce/templates/ingress.yaml
+++ b/helm/ecommerce/templates/ingress.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.ingress.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ecommerce-ingress
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    {{ include "ecommerce.labels" . | nindent 4 }}
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    nginx.ingress.kubernetes.io/limit-rps: "100"
+    nginx.ingress.kubernetes.io/proxy-body-size: "10m"
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "30"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "60"
+    {{- if and .Values.ingress.tls .Values.ingress.tls.certManager }}
+    cert-manager.io/cluster-issuer: {{ .Values.ingress.tls.clusterIssuer | default "letsencrypt-prod" }}
+    {{- end }}
+spec:
+  ingressClassName: {{ .Values.ingress.className | default "nginx" }}
+  {{- if and .Values.ingress.tls .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host }}
+      secretName: {{ .Values.ingress.tls.secretName | default "ecommerce-tls" }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: /api(/|$)(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: gateway-api-service
+                port:
+                  number: 8222
+          - path: /grafana(/|$)(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: grafana
+                port:
+                  number: 3000
+{{- end }}

--- a/helm/ecommerce/templates/namespace.yaml
+++ b/helm/ecommerce/templates/namespace.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.global.namespace }}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.global.namespace }}
+  labels:
+    {{ include "ecommerce.labels" . | nindent 4 }}
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: {{ .Values.global.namespace }}-quota
+  namespace: {{ .Values.global.namespace }}
+spec:
+  hard:
+    requests.cpu: "20"
+    requests.memory: 20Gi
+    limits.cpu: "40"
+    limits.memory: 40Gi
+    pods: "100"
+    services: "30"
+    persistentvolumeclaims: "20"
+{{- end }}

--- a/helm/ecommerce/templates/pdb.yaml
+++ b/helm/ecommerce/templates/pdb.yaml
@@ -1,0 +1,18 @@
+{{- range $name, $svc := .Values.services }}
+{{- if $svc.pdb }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ $name }}-pdb
+  namespace: {{ $.Values.global.namespace }}
+  labels:
+    app: {{ $name }}
+    {{ include "ecommerce.labels" $ | nindent 4 }}
+spec:
+  minAvailable: {{ $svc.pdb.minAvailable | default 1 }}
+  selector:
+    matchLabels:
+      app: {{ $name }}
+{{- end }}
+{{- end }}

--- a/helm/ecommerce/templates/secret.yaml
+++ b/helm/ecommerce/templates/secret.yaml
@@ -1,0 +1,53 @@
+{{/*
+Secrets are managed externally via Vault or Sealed Secrets.
+This template creates ExternalSecret resources that pull from Vault.
+Requires external-secrets operator: https://external-secrets.io/
+*/}}
+{{- range $name, $svc := .Values.services }}
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ $name }}-secret
+  namespace: {{ $.Values.global.namespace }}
+  labels:
+    app: {{ $name }}
+    {{ include "ecommerce.labels" $ | nindent 4 }}
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: {{ $name }}-secret
+    creationPolicy: Owner
+  data:
+    - secretKey: POSTGRES_PASSWORD
+      remoteRef:
+        key: secret/ecommerce/{{ $name }}
+        property: postgres_password
+    - secretKey: MONGO_PASSWORD
+      remoteRef:
+        key: secret/ecommerce/{{ $name }}
+        property: mongo_password
+    - secretKey: JWT_SECRET
+      remoteRef:
+        key: secret/ecommerce/shared
+        property: jwt_secret
+    - secretKey: KAFKA_PASSWORD
+      remoteRef:
+        key: secret/ecommerce/shared
+        property: kafka_password
+    - secretKey: REDIS_PASSWORD
+      remoteRef:
+        key: secret/ecommerce/shared
+        property: redis_password
+    - secretKey: VAULT_TOKEN
+      remoteRef:
+        key: secret/ecommerce/shared
+        property: vault_app_token
+    - secretKey: EUREKA_PASSWORD
+      remoteRef:
+        key: secret/ecommerce/shared
+        property: eureka_password
+{{- end }}

--- a/helm/ecommerce/templates/service.yaml
+++ b/helm/ecommerce/templates/service.yaml
@@ -1,0 +1,20 @@
+{{- range $name, $svc := .Values.services }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $name }}
+  namespace: {{ $.Values.global.namespace }}
+  labels:
+    app: {{ $name }}
+    {{ include "ecommerce.labels" $ | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    app: {{ $name }}
+  ports:
+    - name: http
+      port: {{ $svc.port }}
+      targetPort: {{ $svc.port }}
+      protocol: TCP
+{{- end }}

--- a/helm/ecommerce/templates/statefulset.yaml
+++ b/helm/ecommerce/templates/statefulset.yaml
@@ -1,0 +1,200 @@
+---
+# PostgreSQL StatefulSets — one per service database
+{{- $pgDatabases := dict
+  "postgres-order"   (dict "db" "order_service_db"   "port" 5432 "storage" "10Gi")
+  "postgres-product" (dict "db" "product_service_db" "port" 5433 "storage" "10Gi")
+  "postgres-payment" (dict "db" "payment_db"         "port" 5434 "storage" "20Gi")
+  "postgres-auth"    (dict "db" "auth_db"             "port" 5435 "storage" "10Gi")
+}}
+{{- range $name, $cfg := $pgDatabases }}
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ $name }}
+  namespace: {{ $.Values.global.namespace }}
+  labels:
+    app: {{ $name }}
+    component: database
+spec:
+  serviceName: {{ $name }}
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ $name }}
+  template:
+    metadata:
+      labels:
+        app: {{ $name }}
+        component: database
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:15-alpine
+          ports:
+            - containerPort: {{ $cfg.port }}
+          env:
+            - name: POSTGRES_DB
+              value: {{ $cfg.db }}
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-credentials
+                  key: username
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-credentials
+                  key: password
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "$(POSTGRES_USER)", "-d", "$(POSTGRES_DB)"]
+            initialDelaySeconds: 10
+            periodSeconds: 5
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: standard
+        resources:
+          requests:
+            storage: {{ $cfg.storage }}
+{{- end }}
+---
+# MongoDB StatefulSet — 3-node replica set
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mongodb
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    app: mongodb
+    component: database
+spec:
+  serviceName: mongodb
+  replicas: 3
+  selector:
+    matchLabels:
+      app: mongodb
+  template:
+    metadata:
+      labels:
+        app: mongodb
+        component: database
+    spec:
+      containers:
+        - name: mongodb
+          image: mongo:7.0
+          command: ["mongod", "--replSet", "rs0", "--bind_ip_all"]
+          ports:
+            - containerPort: 27017
+          env:
+            - name: MONGO_INITDB_ROOT_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: mongodb-credentials
+                  key: username
+            - name: MONGO_INITDB_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mongodb-credentials
+                  key: password
+          volumeMounts:
+            - name: data
+              mountPath: /data/db
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+          readinessProbe:
+            exec:
+              command: ["mongosh", "--eval", "db.adminCommand('ping')"]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: standard
+        resources:
+          requests:
+            storage: 20Gi
+---
+# Redis StatefulSet — master instance (Sentinel handles HA)
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redis
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    app: redis
+    component: cache
+spec:
+  serviceName: redis
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+        component: cache
+    spec:
+      containers:
+        - name: redis
+          image: redis:7.2-alpine
+          command:
+            - redis-server
+            - "--maxmemory"
+            - "512mb"
+            - "--maxmemory-policy"
+            - "allkeys-lru"
+            - "--appendonly"
+            - "yes"
+            - "--appendfsync"
+            - "everysec"
+            - "--requirepass"
+            - "$(REDIS_PASSWORD)"
+          ports:
+            - containerPort: 6379
+          env:
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: redis-credentials
+                  key: password
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: standard
+        resources:
+          requests:
+            storage: 2Gi

--- a/helm/ecommerce/values-production.yaml
+++ b/helm/ecommerce/values-production.yaml
@@ -1,0 +1,97 @@
+# values-production.yaml — Production environment overrides
+# Usage: helm upgrade --install ecommerce ./helm/ecommerce -f values-production.yaml -n ecommerce
+
+global:
+  logLevel: INFO
+  tracingSamplingRate: "0.1"   # 10% tracing in production
+
+ingress:
+  enabled: true
+  host: ecommerce.vanilsonshop.io
+  tls:
+    enabled: true
+    certManager: true
+    secretName: ecommerce-prod-tls
+    clusterIssuer: letsencrypt-prod
+
+services:
+  gateway-api-service:
+    replicaCount: 3
+    resources:
+      requests:
+        cpu: 250m
+        memory: 512Mi
+      limits:
+        cpu: 1000m
+        memory: 1Gi
+    hpa:
+      minReplicas: 3
+      maxReplicas: 10
+    pdb:
+      minAvailable: 2
+
+  authentication-service:
+    replicaCount: 2
+    hpa:
+      minReplicas: 2
+      maxReplicas: 5
+    pdb:
+      minAvailable: 1
+
+  customer-service:
+    replicaCount: 2
+    hpa:
+      minReplicas: 2
+      maxReplicas: 6
+    pdb:
+      minAvailable: 1
+
+  product-service:
+    replicaCount: 2
+    hpa:
+      minReplicas: 2
+      maxReplicas: 6
+    pdb:
+      minAvailable: 1
+
+  order-service:
+    replicaCount: 3
+    hpa:
+      minReplicas: 3
+      maxReplicas: 8
+    pdb:
+      minAvailable: 2
+
+  payment-service:
+    replicaCount: 3
+    hpa:
+      minReplicas: 3
+      maxReplicas: 8
+    pdb:
+      minAvailable: 2
+
+  cart-service:
+    replicaCount: 2
+    hpa:
+      minReplicas: 2
+      maxReplicas: 8
+    pdb:
+      minAvailable: 1
+
+  notification-service:
+    replicaCount: 2
+    hpa:
+      minReplicas: 2
+      maxReplicas: 5
+    pdb:
+      minAvailable: 1
+
+  config-service:
+    replicaCount: 2
+    pdb:
+      minAvailable: 1
+
+  discovery-service:
+    replicaCount: 2
+    pdb:
+      minAvailable: 1

--- a/helm/ecommerce/values-staging.yaml
+++ b/helm/ecommerce/values-staging.yaml
@@ -1,0 +1,105 @@
+# values-staging.yaml — Staging environment overrides
+# Usage: helm upgrade --install ecommerce ./helm/ecommerce -f values-staging.yaml -n ecommerce-staging
+
+global:
+  logLevel: DEBUG
+  tracingSamplingRate: "1.0"   # 100% tracing in staging
+
+ingress:
+  enabled: true
+  host: staging.ecommerce.vanilsonshop.io
+  tls:
+    enabled: true
+    selfSigned: true
+    secretName: ecommerce-staging-tls
+
+# All services: 1 replica, smaller resources for staging cost savings
+services:
+  gateway-api-service:
+    replicaCount: 1
+    resources:
+      requests:
+        cpu: 125m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+    hpa:
+      minReplicas: 1
+      maxReplicas: 3
+
+  authentication-service:
+    replicaCount: 1
+    resources:
+      requests:
+        cpu: 125m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+
+  customer-service:
+    replicaCount: 1
+    resources:
+      requests:
+        cpu: 125m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+
+  product-service:
+    replicaCount: 1
+    resources:
+      requests:
+        cpu: 125m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+
+  order-service:
+    replicaCount: 1
+    resources:
+      requests:
+        cpu: 125m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+
+  payment-service:
+    replicaCount: 1
+    resources:
+      requests:
+        cpu: 125m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+
+  cart-service:
+    replicaCount: 1
+    resources:
+      requests:
+        cpu: 125m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+
+  notification-service:
+    replicaCount: 1
+    resources:
+      requests:
+        cpu: 125m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+
+  config-service:
+    replicaCount: 1
+
+  discovery-service:
+    replicaCount: 1

--- a/helm/ecommerce/values.yaml
+++ b/helm/ecommerce/values.yaml
@@ -1,0 +1,222 @@
+# values.yaml — Default values (dev environment)
+# Override with values-staging.yaml or values-production.yaml
+
+global:
+  imageRegistry: ghcr.io/vanilsonshop
+  imagePullPolicy: IfNotPresent
+  logLevel: DEBUG
+  tracingSamplingRate: "1.0"
+  namespace: ecommerce
+
+ingress:
+  enabled: false
+  className: nginx
+  host: ecommerce.local
+  tls:
+    enabled: false
+    secretName: ecommerce-tls
+
+services:
+  gateway-api-service:
+    image:
+      repository: gateway-api-service
+      tag: latest
+    replicaCount: 1
+    port: 8222
+    resources:
+      requests:
+        cpu: 250m
+        memory: 512Mi
+      limits:
+        cpu: 1000m
+        memory: 1Gi
+    hpa:
+      enabled: true
+      minReplicas: 1
+      maxReplicas: 5
+      targetCPUUtilizationPercentage: 70
+    pdb:
+      minAvailable: 1
+
+  authentication-service:
+    image:
+      repository: authentication-service
+      tag: latest
+    replicaCount: 1
+    port: 8085
+    resources:
+      requests:
+        cpu: 250m
+        memory: 512Mi
+      limits:
+        cpu: 1000m
+        memory: 1Gi
+    hpa:
+      enabled: true
+      minReplicas: 1
+      maxReplicas: 3
+      targetCPUUtilizationPercentage: 70
+    pdb:
+      minAvailable: 1
+
+  customer-service:
+    image:
+      repository: customer-service
+      tag: latest
+    replicaCount: 1
+    port: 8090
+    resources:
+      requests:
+        cpu: 250m
+        memory: 512Mi
+      limits:
+        cpu: 1000m
+        memory: 1Gi
+    hpa:
+      enabled: true
+      minReplicas: 1
+      maxReplicas: 4
+      targetCPUUtilizationPercentage: 75
+    pdb:
+      minAvailable: 1
+
+  product-service:
+    image:
+      repository: product-service
+      tag: latest
+    replicaCount: 1
+    port: 8082
+    resources:
+      requests:
+        cpu: 250m
+        memory: 512Mi
+      limits:
+        cpu: 1000m
+        memory: 1Gi
+    hpa:
+      enabled: true
+      minReplicas: 1
+      maxReplicas: 4
+      targetCPUUtilizationPercentage: 75
+    pdb:
+      minAvailable: 1
+
+  order-service:
+    image:
+      repository: order-service
+      tag: latest
+    replicaCount: 1
+    port: 8083
+    resources:
+      requests:
+        cpu: 250m
+        memory: 512Mi
+      limits:
+        cpu: 1000m
+        memory: 1Gi
+    hpa:
+      enabled: true
+      minReplicas: 1
+      maxReplicas: 5
+      targetCPUUtilizationPercentage: 75
+    pdb:
+      minAvailable: 1
+
+  payment-service:
+    image:
+      repository: payment-service
+      tag: latest
+    replicaCount: 1
+    port: 8086
+    resources:
+      requests:
+        cpu: 250m
+        memory: 512Mi
+      limits:
+        cpu: 1000m
+        memory: 1Gi
+    hpa:
+      enabled: true
+      minReplicas: 1
+      maxReplicas: 5
+      targetCPUUtilizationPercentage: 75
+    pdb:
+      minAvailable: 1
+
+  cart-service:
+    image:
+      repository: cart-service
+      tag: latest
+    replicaCount: 1
+    port: 8091
+    resources:
+      requests:
+        cpu: 250m
+        memory: 512Mi
+      limits:
+        cpu: 1000m
+        memory: 1Gi
+    hpa:
+      enabled: true
+      minReplicas: 1
+      maxReplicas: 5
+      targetCPUUtilizationPercentage: 70
+    pdb:
+      minAvailable: 1
+
+  notification-service:
+    image:
+      repository: notification-service
+      tag: latest
+    replicaCount: 1
+    port: 8040
+    resources:
+      requests:
+        cpu: 250m
+        memory: 512Mi
+      limits:
+        cpu: 1000m
+        memory: 1Gi
+    hpa:
+      enabled: true
+      minReplicas: 1
+      maxReplicas: 3
+      targetCPUUtilizationPercentage: 80
+    pdb:
+      minAvailable: 1
+
+  config-service:
+    image:
+      repository: config-service
+      tag: latest
+    replicaCount: 1
+    port: 8888
+    resources:
+      requests:
+        cpu: 250m
+        memory: 512Mi
+      limits:
+        cpu: 500m
+        memory: 768Mi
+    hpa:
+      enabled: false
+    pdb:
+      minAvailable: 1
+
+  discovery-service:
+    image:
+      repository: discovery-service
+      tag: latest
+    replicaCount: 1
+    port: 8761
+    resources:
+      requests:
+        cpu: 250m
+        memory: 512Mi
+      limits:
+        cpu: 500m
+        memory: 768Mi
+    hpa:
+      enabled: false
+    pdb:
+      minAvailable: 1

--- a/k8s/deployments/all-services-deployments.yml
+++ b/k8s/deployments/all-services-deployments.yml
@@ -1,0 +1,540 @@
+---
+# ============================================================
+# Order Service — 3 replicas (critical business service)
+# ============================================================
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: order-service
+  namespace: ecommerce
+  labels:
+    app: order-service
+    tier: application
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: order-service
+  template:
+    metadata:
+      labels:
+        app: order-service
+        tier: application
+    spec:
+      containers:
+        - name: order-service
+          image: ghcr.io/vanilsonshop/order-service:latest
+          ports:
+            - containerPort: 8083
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8083
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8083
+            initialDelaySeconds: 90
+            periodSeconds: 15
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8083
+            failureThreshold: 30
+            periodSeconds: 10
+          envFrom:
+            - configMapRef:
+                name: order-service-config
+            - secretRef:
+                name: order-service-secret
+---
+# ============================================================
+# Payment Service — 3 replicas (critical financial service)
+# ============================================================
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payment-service
+  namespace: ecommerce
+  labels:
+    app: payment-service
+    tier: application
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: payment-service
+  template:
+    metadata:
+      labels:
+        app: payment-service
+        tier: application
+    spec:
+      containers:
+        - name: payment-service
+          image: ghcr.io/vanilsonshop/payment-service:latest
+          ports:
+            - containerPort: 8086
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8086
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8086
+            initialDelaySeconds: 90
+            periodSeconds: 15
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8086
+            failureThreshold: 30
+            periodSeconds: 10
+          envFrom:
+            - configMapRef:
+                name: payment-service-config
+            - secretRef:
+                name: payment-service-secret
+---
+# ============================================================
+# Authentication Service — 2 replicas
+# ============================================================
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: authentication-service
+  namespace: ecommerce
+  labels:
+    app: authentication-service
+    tier: application
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: authentication-service
+  template:
+    metadata:
+      labels:
+        app: authentication-service
+        tier: application
+    spec:
+      containers:
+        - name: authentication-service
+          image: ghcr.io/vanilsonshop/authentication-service:latest
+          ports:
+            - containerPort: 8085
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8085
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8085
+            initialDelaySeconds: 90
+            periodSeconds: 15
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8085
+            failureThreshold: 30
+            periodSeconds: 10
+          envFrom:
+            - configMapRef:
+                name: authentication-service-config
+            - secretRef:
+                name: authentication-service-secret
+---
+# ============================================================
+# Customer Service — 2 replicas
+# ============================================================
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: customer-service
+  namespace: ecommerce
+  labels:
+    app: customer-service
+    tier: application
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: customer-service
+  template:
+    metadata:
+      labels:
+        app: customer-service
+        tier: application
+    spec:
+      containers:
+        - name: customer-service
+          image: ghcr.io/vanilsonshop/customer-service:latest
+          ports:
+            - containerPort: 8090
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8090
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8090
+            initialDelaySeconds: 90
+            periodSeconds: 15
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8090
+            failureThreshold: 30
+            periodSeconds: 10
+          envFrom:
+            - configMapRef:
+                name: customer-service-config
+            - secretRef:
+                name: customer-service-secret
+---
+# ============================================================
+# Product Service — 2 replicas
+# ============================================================
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: product-service
+  namespace: ecommerce
+  labels:
+    app: product-service
+    tier: application
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: product-service
+  template:
+    metadata:
+      labels:
+        app: product-service
+        tier: application
+    spec:
+      containers:
+        - name: product-service
+          image: ghcr.io/vanilsonshop/product-service:latest
+          ports:
+            - containerPort: 8082
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8082
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8082
+            initialDelaySeconds: 90
+            periodSeconds: 15
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8082
+            failureThreshold: 30
+            periodSeconds: 10
+          envFrom:
+            - configMapRef:
+                name: product-service-config
+            - secretRef:
+                name: product-service-secret
+---
+# ============================================================
+# Cart Service — 2 replicas
+# ============================================================
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cart-service
+  namespace: ecommerce
+  labels:
+    app: cart-service
+    tier: application
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: cart-service
+  template:
+    metadata:
+      labels:
+        app: cart-service
+        tier: application
+    spec:
+      containers:
+        - name: cart-service
+          image: ghcr.io/vanilsonshop/cart-service:latest
+          ports:
+            - containerPort: 8091
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8091
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8091
+            initialDelaySeconds: 90
+            periodSeconds: 15
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8091
+            failureThreshold: 30
+            periodSeconds: 10
+          envFrom:
+            - configMapRef:
+                name: cart-service-config
+            - secretRef:
+                name: cart-service-secret
+---
+# ============================================================
+# Notification Service — 2 replicas
+# ============================================================
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: notification-service
+  namespace: ecommerce
+  labels:
+    app: notification-service
+    tier: application
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: notification-service
+  template:
+    metadata:
+      labels:
+        app: notification-service
+        tier: application
+    spec:
+      containers:
+        - name: notification-service
+          image: ghcr.io/vanilsonshop/notification-service:latest
+          ports:
+            - containerPort: 8040
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8040
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8040
+            initialDelaySeconds: 90
+            periodSeconds: 15
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8040
+            failureThreshold: 30
+            periodSeconds: 10
+          envFrom:
+            - configMapRef:
+                name: notification-service-config
+            - secretRef:
+                name: notification-service-secret
+---
+# ============================================================
+# Config Service — 2 replicas (must start first)
+# ============================================================
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: config-service
+  namespace: ecommerce
+  labels:
+    app: config-service
+    tier: infrastructure
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: config-service
+  template:
+    metadata:
+      labels:
+        app: config-service
+        tier: infrastructure
+    spec:
+      containers:
+        - name: config-service
+          image: ghcr.io/vanilsonshop/config-service:latest
+          ports:
+            - containerPort: 8888
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: 500m
+              memory: 768Mi
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8888
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8888
+            initialDelaySeconds: 60
+            periodSeconds: 15
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8888
+            failureThreshold: 30
+            periodSeconds: 10
+          envFrom:
+            - configMapRef:
+                name: config-service-config
+            - secretRef:
+                name: config-service-secret
+---
+# ============================================================
+# Discovery Service — 2 replicas (peer-aware Eureka)
+# ============================================================
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: discovery-service
+  namespace: ecommerce
+  labels:
+    app: discovery-service
+    tier: infrastructure
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: discovery-service
+  template:
+    metadata:
+      labels:
+        app: discovery-service
+        tier: infrastructure
+    spec:
+      containers:
+        - name: discovery-service
+          image: ghcr.io/vanilsonshop/discovery-service:latest
+          ports:
+            - containerPort: 8761
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: 500m
+              memory: 768Mi
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8761
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8761
+            initialDelaySeconds: 60
+            periodSeconds: 15
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8761
+            failureThreshold: 30
+            periodSeconds: 10
+          envFrom:
+            - configMapRef:
+                name: discovery-service-config
+            - secretRef:
+                name: discovery-service-secret

--- a/k8s/deployments/gateway-deployment.yml
+++ b/k8s/deployments/gateway-deployment.yml
@@ -1,0 +1,57 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gateway-api-service
+  namespace: ecommerce
+  labels:
+    app: gateway-api-service
+    tier: application
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: gateway-api-service
+  template:
+    metadata:
+      labels:
+        app: gateway-api-service
+        tier: application
+    spec:
+      containers:
+        - name: gateway-api-service
+          image: ghcr.io/vanilsonshop/gateway-api-service:latest
+          ports:
+            - containerPort: 8222
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8222
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8222
+            initialDelaySeconds: 90
+            periodSeconds: 15
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8222
+            failureThreshold: 30
+            periodSeconds: 10
+          envFrom:
+            - configMapRef:
+                name: gateway-api-service-config
+            - secretRef:
+                name: gateway-api-service-secret

--- a/k8s/hpa/all-hpa.yml
+++ b/k8s/hpa/all-hpa.yml
@@ -1,0 +1,210 @@
+---
+# Gateway HPA: min=3 max=10 targetCPU=70%
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: gateway-api-service-hpa
+  namespace: ecommerce
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: gateway-api-service
+  minReplicas: 3
+  maxReplicas: 10
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+---
+# Order Service HPA: min=3 max=8 targetCPU=75%
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: order-service-hpa
+  namespace: ecommerce
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: order-service
+  minReplicas: 3
+  maxReplicas: 8
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 75
+---
+# Payment Service HPA: min=3 max=8 targetCPU=75%
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: payment-service-hpa
+  namespace: ecommerce
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: payment-service
+  minReplicas: 3
+  maxReplicas: 8
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 75
+---
+# Auth Service HPA: min=2 max=5 targetCPU=70%
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: authentication-service-hpa
+  namespace: ecommerce
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: authentication-service
+  minReplicas: 2
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+---
+# Customer Service HPA: min=2 max=6 targetCPU=75%
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: customer-service-hpa
+  namespace: ecommerce
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: customer-service
+  minReplicas: 2
+  maxReplicas: 6
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 75
+---
+# Product Service HPA: min=2 max=6 targetCPU=75%
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: product-service-hpa
+  namespace: ecommerce
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: product-service
+  minReplicas: 2
+  maxReplicas: 6
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 75
+---
+# Cart Service HPA: min=2 max=8 targetCPU=70% (high burst traffic)
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: cart-service-hpa
+  namespace: ecommerce
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: cart-service
+  minReplicas: 2
+  maxReplicas: 8
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+---
+# Notification Service HPA: min=2 max=5 targetCPU=80%
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: notification-service-hpa
+  namespace: ecommerce
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: notification-service
+  minReplicas: 2
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80
+---
+# Config Service HPA: min=2 max=3 targetCPU=80%
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: config-service-hpa
+  namespace: ecommerce
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: config-service
+  minReplicas: 2
+  maxReplicas: 3
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80
+---
+# Discovery Service HPA: min=2 max=3 targetCPU=80%
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: discovery-service-hpa
+  namespace: ecommerce
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: discovery-service
+  minReplicas: 2
+  maxReplicas: 3
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80

--- a/k8s/ingress.yml
+++ b/k8s/ingress.yml
@@ -1,0 +1,38 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ecommerce-ingress
+  namespace: ecommerce
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    nginx.ingress.kubernetes.io/limit-rps: "100"
+    nginx.ingress.kubernetes.io/proxy-body-size: "10m"
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "30"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "60"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - ecommerce.vanilsonshop.io
+      secretName: ecommerce-tls
+  rules:
+    - host: ecommerce.vanilsonshop.io
+      http:
+        paths:
+          - path: /api(/|$)(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: gateway-api-service
+                port:
+                  number: 8222
+          - path: /grafana(/|$)(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: grafana
+                port:
+                  number: 3000

--- a/k8s/istio/authorization-policy.yml
+++ b/k8s/istio/authorization-policy.yml
@@ -1,0 +1,103 @@
+---
+# Default deny-all AuthorizationPolicy — no traffic allowed unless explicitly permitted
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: deny-all
+  namespace: ecommerce
+spec:
+  {}   # empty spec = deny all
+
+---
+# Allow Istio ingress gateway → gateway-api-service
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: allow-ingress-to-gateway
+  namespace: ecommerce
+spec:
+  selector:
+    matchLabels:
+      app: gateway-api-service
+  action: ALLOW
+  rules:
+    - from:
+        - source:
+            principals:
+              - "cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account"
+
+---
+# Allow gateway-api-service → all application services
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: allow-gateway-to-services
+  namespace: ecommerce
+spec:
+  selector:
+    matchLabels:
+      tier: application
+  action: ALLOW
+  rules:
+    - from:
+        - source:
+            principals:
+              - "cluster.local/ns/ecommerce/sa/gateway-api-service"
+
+---
+# Allow Prometheus → all services (metrics scraping)
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: allow-prometheus-scraping
+  namespace: ecommerce
+spec:
+  selector:
+    matchLabels:
+      tier: application
+  action: ALLOW
+  rules:
+    - from:
+        - source:
+            principals:
+              - "cluster.local/ns/monitoring/sa/prometheus"
+      to:
+        - operation:
+            paths: ["/actuator/prometheus"]
+            methods: ["GET"]
+
+---
+# Allow order-service → product-service (inventory check via Feign)
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: allow-order-to-product
+  namespace: ecommerce
+spec:
+  selector:
+    matchLabels:
+      app: product-service
+  action: ALLOW
+  rules:
+    - from:
+        - source:
+            principals:
+              - "cluster.local/ns/ecommerce/sa/order-service"
+
+---
+# Allow order-service → customer-service (customer lookup)
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: allow-order-to-customer
+  namespace: ecommerce
+spec:
+  selector:
+    matchLabels:
+      app: customer-service
+  action: ALLOW
+  rules:
+    - from:
+        - source:
+            principals:
+              - "cluster.local/ns/ecommerce/sa/order-service"

--- a/k8s/istio/destination-rule.yml
+++ b/k8s/istio/destination-rule.yml
@@ -1,0 +1,169 @@
+---
+# DestinationRule for gateway-api-service
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: gateway-api-service
+  namespace: ecommerce
+spec:
+  host: gateway-api-service
+  trafficPolicy:
+    connectionPool:
+      tcp:
+        maxConnections: 100
+      http:
+        h2UpgradePolicy: UPGRADE
+        http1MaxPendingRequests: 100
+        http2MaxRequests: 1000
+    outlierDetection:
+      consecutive5xxErrors: 5
+      interval: 30s
+      baseEjectionTime: 30s
+      maxEjectionPercent: 50
+---
+# DestinationRule for order-service
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: order-service
+  namespace: ecommerce
+spec:
+  host: order-service
+  trafficPolicy:
+    connectionPool:
+      tcp:
+        maxConnections: 100
+      http:
+        h2UpgradePolicy: UPGRADE
+        http1MaxPendingRequests: 100
+    outlierDetection:
+      consecutive5xxErrors: 5
+      interval: 30s
+      baseEjectionTime: 30s
+      maxEjectionPercent: 50
+---
+# DestinationRule for payment-service
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: payment-service
+  namespace: ecommerce
+spec:
+  host: payment-service
+  trafficPolicy:
+    connectionPool:
+      tcp:
+        maxConnections: 100
+      http:
+        h2UpgradePolicy: UPGRADE
+        http1MaxPendingRequests: 100
+    outlierDetection:
+      consecutive5xxErrors: 3   # stricter for financial service
+      interval: 15s
+      baseEjectionTime: 60s
+      maxEjectionPercent: 30
+---
+# DestinationRule for authentication-service
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: authentication-service
+  namespace: ecommerce
+spec:
+  host: authentication-service
+  trafficPolicy:
+    connectionPool:
+      tcp:
+        maxConnections: 50
+      http:
+        h2UpgradePolicy: UPGRADE
+        http1MaxPendingRequests: 50
+    outlierDetection:
+      consecutive5xxErrors: 5
+      interval: 30s
+      baseEjectionTime: 30s
+      maxEjectionPercent: 50
+---
+# DestinationRule for customer-service
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: customer-service
+  namespace: ecommerce
+spec:
+  host: customer-service
+  trafficPolicy:
+    connectionPool:
+      tcp:
+        maxConnections: 100
+      http:
+        h2UpgradePolicy: UPGRADE
+        http1MaxPendingRequests: 100
+    outlierDetection:
+      consecutive5xxErrors: 5
+      interval: 30s
+      baseEjectionTime: 30s
+      maxEjectionPercent: 50
+---
+# DestinationRule for product-service
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: product-service
+  namespace: ecommerce
+spec:
+  host: product-service
+  trafficPolicy:
+    connectionPool:
+      tcp:
+        maxConnections: 100
+      http:
+        h2UpgradePolicy: UPGRADE
+        http1MaxPendingRequests: 100
+    outlierDetection:
+      consecutive5xxErrors: 5
+      interval: 30s
+      baseEjectionTime: 30s
+      maxEjectionPercent: 50
+---
+# DestinationRule for cart-service
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: cart-service
+  namespace: ecommerce
+spec:
+  host: cart-service
+  trafficPolicy:
+    connectionPool:
+      tcp:
+        maxConnections: 200
+      http:
+        h2UpgradePolicy: UPGRADE
+        http1MaxPendingRequests: 200
+    outlierDetection:
+      consecutive5xxErrors: 5
+      interval: 30s
+      baseEjectionTime: 30s
+      maxEjectionPercent: 50
+---
+# DestinationRule for notification-service
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: notification-service
+  namespace: ecommerce
+spec:
+  host: notification-service
+  trafficPolicy:
+    connectionPool:
+      tcp:
+        maxConnections: 50
+      http:
+        h2UpgradePolicy: UPGRADE
+        http1MaxPendingRequests: 50
+    outlierDetection:
+      consecutive5xxErrors: 5
+      interval: 30s
+      baseEjectionTime: 30s
+      maxEjectionPercent: 50

--- a/k8s/istio/peer-authentication.yml
+++ b/k8s/istio/peer-authentication.yml
@@ -1,0 +1,12 @@
+---
+# Enforce STRICT mTLS for all pods in the ecommerce namespace.
+# All service-to-service communication must use mutual TLS.
+# Istio automatically provisions and rotates certificates.
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: default
+  namespace: ecommerce
+spec:
+  mtls:
+    mode: STRICT

--- a/k8s/istio/virtual-service.yml
+++ b/k8s/istio/virtual-service.yml
@@ -1,0 +1,69 @@
+---
+# VirtualService for gateway-api-service — main external entry point
+# Supports canary deployments via weight-based routing
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: gateway-api-service
+  namespace: ecommerce
+spec:
+  hosts:
+    - gateway-api-service
+    - ecommerce.vanilsonshop.io
+  gateways:
+    - ecommerce-gateway
+    - mesh
+  http:
+    # Canary: route 10% to canary, 90% to stable (set gateway-api-service-canary replicas > 0 to enable)
+    - match:
+        - headers:
+            x-canary:
+              exact: "true"
+      route:
+        - destination:
+            host: gateway-api-service
+            subset: canary
+          weight: 100
+    # Default: all traffic to stable
+    - route:
+        - destination:
+            host: gateway-api-service
+            subset: stable
+          weight: 90
+        - destination:
+            host: gateway-api-service
+            subset: canary
+          weight: 10
+      timeout: 30s
+      retries:
+        attempts: 3
+        perTryTimeout: 10s
+        retryOn: 5xx,gateway-error,reset,retriable-4xx
+---
+# Istio Gateway for external traffic
+apiVersion: networking.istio.io/v1beta1
+kind: Gateway
+metadata:
+  name: ecommerce-gateway
+  namespace: ecommerce
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+    - port:
+        number: 443
+        name: https
+        protocol: HTTPS
+      tls:
+        mode: SIMPLE
+        credentialName: ecommerce-tls
+      hosts:
+        - ecommerce.vanilsonshop.io
+    - port:
+        number: 80
+        name: http
+        protocol: HTTP
+      tls:
+        httpsRedirect: true
+      hosts:
+        - ecommerce.vanilsonshop.io

--- a/k8s/namespace.yml
+++ b/k8s/namespace.yml
@@ -1,0 +1,22 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ecommerce
+  labels:
+    app.kubernetes.io/managed-by: helm
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: ecommerce-quota
+  namespace: ecommerce
+spec:
+  hard:
+    requests.cpu: "20"
+    requests.memory: 20Gi
+    limits.cpu: "40"
+    limits.memory: 40Gi
+    pods: "100"
+    services: "30"
+    persistentvolumeclaims: "20"

--- a/k8s/network-policies/database-policy.yml
+++ b/k8s/network-policies/database-policy.yml
@@ -1,0 +1,129 @@
+---
+# Allow order-service → postgres-order (5432)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-order-to-postgres
+  namespace: ecommerce
+spec:
+  podSelector:
+    matchLabels:
+      app: postgres-order
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: order-service
+      ports:
+        - protocol: TCP
+          port: 5432
+---
+# Allow product-service → postgres-product (5433)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-product-to-postgres
+  namespace: ecommerce
+spec:
+  podSelector:
+    matchLabels:
+      app: postgres-product
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: product-service
+      ports:
+        - protocol: TCP
+          port: 5433
+---
+# Allow payment-service → postgres-payment (5434)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-payment-to-postgres
+  namespace: ecommerce
+spec:
+  podSelector:
+    matchLabels:
+      app: postgres-payment
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: payment-service
+      ports:
+        - protocol: TCP
+          port: 5434
+---
+# Allow authentication-service → postgres-auth (5435)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-auth-to-postgres
+  namespace: ecommerce
+spec:
+  podSelector:
+    matchLabels:
+      app: postgres-auth
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: authentication-service
+      ports:
+        - protocol: TCP
+          port: 5435
+---
+# Allow customer-service and notification-service → MongoDB (27017)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-services-to-mongodb
+  namespace: ecommerce
+spec:
+  podSelector:
+    matchLabels:
+      app: mongodb
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: customer-service
+        - podSelector:
+            matchLabels:
+              app: notification-service
+      ports:
+        - protocol: TCP
+          port: 27017
+---
+# Allow all application services → Redis (6379)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-services-to-redis
+  namespace: ecommerce
+spec:
+  podSelector:
+    matchLabels:
+      app: redis
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              tier: application
+      ports:
+        - protocol: TCP
+          port: 6379

--- a/k8s/network-policies/default-deny.yml
+++ b/k8s/network-policies/default-deny.yml
@@ -1,0 +1,12 @@
+---
+# Default deny-all ingress for the ecommerce namespace.
+# All traffic is blocked unless explicitly allowed by other NetworkPolicy rules.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: ecommerce
+spec:
+  podSelector: {}        # applies to ALL pods in namespace
+  policyTypes:
+    - Ingress

--- a/k8s/network-policies/gateway-policy.yml
+++ b/k8s/network-policies/gateway-policy.yml
@@ -1,0 +1,37 @@
+---
+# Allow external ingress to the gateway on port 8222
+# Allow gateway to reach all application services
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-gateway-ingress
+  namespace: ecommerce
+spec:
+  podSelector:
+    matchLabels:
+      app: gateway-api-service
+  policyTypes:
+    - Ingress
+  ingress:
+    - {}   # allow from anywhere (NGINX Ingress controller or internet)
+      ports:
+        - protocol: TCP
+          port: 8222
+---
+# Allow all services to receive ingress from the gateway
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-from-gateway
+  namespace: ecommerce
+spec:
+  podSelector:
+    matchLabels:
+      tier: application   # label applied to all app services (not infra)
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: gateway-api-service

--- a/k8s/network-policies/kafka-policy.yml
+++ b/k8s/network-policies/kafka-policy.yml
@@ -1,0 +1,50 @@
+---
+# Allow all application services → Kafka brokers (9092)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-services-to-kafka
+  namespace: ecommerce
+spec:
+  podSelector:
+    matchLabels:
+      app: kafka
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              tier: application
+      ports:
+        - protocol: TCP
+          port: 9092
+        - protocol: TCP
+          port: 9094   # broker2
+        - protocol: TCP
+          port: 9096   # broker3
+---
+# Allow inter-broker communication (KRaft controller port 9093)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-kafka-internal
+  namespace: ecommerce
+spec:
+  podSelector:
+    matchLabels:
+      app: kafka
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: kafka
+      ports:
+        - protocol: TCP
+          port: 9093
+        - protocol: TCP
+          port: 9095
+        - protocol: TCP
+          port: 9097

--- a/k8s/network-policies/prometheus-policy.yml
+++ b/k8s/network-policies/prometheus-policy.yml
@@ -1,0 +1,39 @@
+---
+# Allow Prometheus to scrape metrics from all application services
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-prometheus-scraping
+  namespace: ecommerce
+spec:
+  podSelector:
+    matchLabels:
+      tier: application   # all app services expose /actuator/prometheus
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: prometheus
+      ports:
+        - protocol: TCP
+          port: 8222   # gateway
+        - protocol: TCP
+          port: 8888   # config-service
+        - protocol: TCP
+          port: 8761   # discovery-service
+        - protocol: TCP
+          port: 8085   # authentication-service
+        - protocol: TCP
+          port: 8090   # customer-service
+        - protocol: TCP
+          port: 8082   # product-service
+        - protocol: TCP
+          port: 8083   # order-service
+        - protocol: TCP
+          port: 8086   # payment-service
+        - protocol: TCP
+          port: 8091   # cart-service
+        - protocol: TCP
+          port: 8040   # notification-service

--- a/k8s/pdb/all-pdb.yml
+++ b/k8s/pdb/all-pdb.yml
@@ -1,0 +1,120 @@
+---
+# Gateway PDB: minAvailable=2 (ensures 2 always up during rolling updates)
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: gateway-api-service-pdb
+  namespace: ecommerce
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app: gateway-api-service
+---
+# Order Service PDB: minAvailable=2
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: order-service-pdb
+  namespace: ecommerce
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app: order-service
+---
+# Payment Service PDB: minAvailable=2 (financial critical)
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: payment-service-pdb
+  namespace: ecommerce
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app: payment-service
+---
+# Auth Service PDB: minAvailable=1
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: authentication-service-pdb
+  namespace: ecommerce
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: authentication-service
+---
+# Customer Service PDB: minAvailable=1
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: customer-service-pdb
+  namespace: ecommerce
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: customer-service
+---
+# Product Service PDB: minAvailable=1
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: product-service-pdb
+  namespace: ecommerce
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: product-service
+---
+# Cart Service PDB: minAvailable=1
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: cart-service-pdb
+  namespace: ecommerce
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: cart-service
+---
+# Notification Service PDB: minAvailable=1
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: notification-service-pdb
+  namespace: ecommerce
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: notification-service
+---
+# Config Service PDB: minAvailable=1
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: config-service-pdb
+  namespace: ecommerce
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: config-service
+---
+# Discovery Service PDB: minAvailable=1
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: discovery-service-pdb
+  namespace: ecommerce
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: discovery-service

--- a/k8s/services/all-services.yml
+++ b/k8s/services/all-services.yml
@@ -1,0 +1,170 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: gateway-api-service
+  namespace: ecommerce
+  labels:
+    app: gateway-api-service
+spec:
+  type: ClusterIP
+  selector:
+    app: gateway-api-service
+  ports:
+    - port: 8222
+      targetPort: 8222
+      protocol: TCP
+      name: http
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: authentication-service
+  namespace: ecommerce
+  labels:
+    app: authentication-service
+spec:
+  type: ClusterIP
+  selector:
+    app: authentication-service
+  ports:
+    - port: 8085
+      targetPort: 8085
+      protocol: TCP
+      name: http
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: customer-service
+  namespace: ecommerce
+  labels:
+    app: customer-service
+spec:
+  type: ClusterIP
+  selector:
+    app: customer-service
+  ports:
+    - port: 8090
+      targetPort: 8090
+      protocol: TCP
+      name: http
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: product-service
+  namespace: ecommerce
+  labels:
+    app: product-service
+spec:
+  type: ClusterIP
+  selector:
+    app: product-service
+  ports:
+    - port: 8082
+      targetPort: 8082
+      protocol: TCP
+      name: http
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: order-service
+  namespace: ecommerce
+  labels:
+    app: order-service
+spec:
+  type: ClusterIP
+  selector:
+    app: order-service
+  ports:
+    - port: 8083
+      targetPort: 8083
+      protocol: TCP
+      name: http
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: payment-service
+  namespace: ecommerce
+  labels:
+    app: payment-service
+spec:
+  type: ClusterIP
+  selector:
+    app: payment-service
+  ports:
+    - port: 8086
+      targetPort: 8086
+      protocol: TCP
+      name: http
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cart-service
+  namespace: ecommerce
+  labels:
+    app: cart-service
+spec:
+  type: ClusterIP
+  selector:
+    app: cart-service
+  ports:
+    - port: 8091
+      targetPort: 8091
+      protocol: TCP
+      name: http
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: notification-service
+  namespace: ecommerce
+  labels:
+    app: notification-service
+spec:
+  type: ClusterIP
+  selector:
+    app: notification-service
+  ports:
+    - port: 8040
+      targetPort: 8040
+      protocol: TCP
+      name: http
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: config-service
+  namespace: ecommerce
+  labels:
+    app: config-service
+spec:
+  type: ClusterIP
+  selector:
+    app: config-service
+  ports:
+    - port: 8888
+      targetPort: 8888
+      protocol: TCP
+      name: http
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: discovery-service
+  namespace: ecommerce
+  labels:
+    app: discovery-service
+spec:
+  type: ClusterIP
+  selector:
+    app: discovery-service
+  ports:
+    - port: 8761
+      targetPort: 8761
+      protocol: TCP
+      name: http

--- a/kafka/jaas/client.properties
+++ b/kafka/jaas/client.properties
@@ -1,0 +1,3 @@
+security.protocol=SASL_PLAINTEXT
+sasl.mechanism=PLAIN
+sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="kafka" password="kafka-secret-2024";

--- a/notification-service/src/main/java/code/with/vanilson/notification/config/NotificationConfig.java
+++ b/notification-service/src/main/java/code/with/vanilson/notification/config/NotificationConfig.java
@@ -1,13 +1,16 @@
 package code.with.vanilson.notification.config;
 
+import jakarta.annotation.PreDestroy;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.MessageSource;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.support.ResourceBundleMessageSource;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.config.KafkaListenerEndpointRegistry;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -42,6 +45,9 @@ public class NotificationConfig {
 
     @Value("${spring.kafka.bootstrap-servers:localhost:9092}")
     private String bootstrapServers;
+
+    @Autowired
+    private KafkaListenerEndpointRegistry kafkaListenerEndpointRegistry;
 
     // -------------------------------------------------------
     // MessageSource
@@ -78,6 +84,7 @@ public class NotificationConfig {
     /**
      * Listener container factory with:
      * - MANUAL_IMMEDIATE ack mode → offset committed only after @KafkaListener method returns
+     * - setStopImmediate(false): finish processing the current poll batch before stopping
      * - DefaultErrorHandler with FixedBackOff(1000ms, 3 retries) → after 3 failures sends to DLQ
      */
     @Bean
@@ -91,6 +98,7 @@ public class NotificationConfig {
 
         // MANUAL_IMMEDIATE: offset committed immediately when Acknowledgment.acknowledge() is called
         factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL_IMMEDIATE);
+        factory.getContainerProperties().setStopImmediate(false);
 
         // Error handler: retry 3x with 1s delay, then route to {topic}.DLQ
         DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(kafkaTemplate,
@@ -105,5 +113,20 @@ public class NotificationConfig {
         // Concurrency = 3: one thread per partition group (payment, order)
         factory.setConcurrency(3);
         return factory;
+    }
+
+    /**
+     * Graceful shutdown — called during Spring context close (SIGTERM / actuator /shutdown).
+     * Stops all listener containers so in-flight messages are acknowledged before the JVM exits.
+     * Works with server.shutdown=graceful and spring.lifecycle.timeout-per-shutdown-phase=30s.
+     */
+    @PreDestroy
+    public void onDestroy() {
+        kafkaListenerEndpointRegistry.getListenerContainers()
+                .forEach(container -> {
+                    if (container.isRunning()) {
+                        container.stop();
+                    }
+                });
     }
 }

--- a/notification-service/src/main/java/code/with/vanilson/notification/kafka/DlqConsumer.java
+++ b/notification-service/src/main/java/code/with/vanilson/notification/kafka/DlqConsumer.java
@@ -20,8 +20,7 @@ public class DlqConsumer {
             groupId = "paymentDlqGroup",
             containerFactory = "kafkaListenerContainerFactory")
     public void consumePaymentDlq(ConsumerRecord<String, Object> record) {
-        log.error("DLQ event received — topic={}, partition={}, offset={}, payload={}",
-                record.topic(), record.partition(), record.offset(), record.value());
+        dqlEventLog(record);
         dlqEventRepository.save(
                 DlqEvent.of(record.topic(), record.partition(), record.offset(), record.value()));
     }
@@ -31,9 +30,13 @@ public class DlqConsumer {
             groupId = "orderDlqGroup",
             containerFactory = "kafkaListenerContainerFactory")
     public void consumeOrderDlq(ConsumerRecord<String, Object> record) {
-        log.error("DLQ event received — topic={}, partition={}, offset={}, payload={}",
-                record.topic(), record.partition(), record.offset(), record.value());
+        dqlEventLog(record);
         dlqEventRepository.save(
                 DlqEvent.of(record.topic(), record.partition(), record.offset(), record.value()));
+    }
+
+    private static void dqlEventLog(ConsumerRecord<String, Object> record) {
+        log.error("DLQ event received — topic={}, partition={}, offset={}, payload={}",
+                record.topic(), record.partition(), record.offset(), record.value());
     }
 }

--- a/order-service/src/main/java/code/with/vanilson/orderservice/OrderRepository.java
+++ b/order-service/src/main/java/code/with/vanilson/orderservice/OrderRepository.java
@@ -19,7 +19,16 @@ public interface OrderRepository extends JpaRepository<Order, Integer> {
 
     /**
      * Finds an order by its client-facing correlationId.
-     * Used by the status polling endpoint: GET /orders/status/{correlationId}
+     * Used internally by the Kafka saga consumer (OrderSagaConsumer.updateStatus)
+     * where no tenant context is available — intentionally unscoped.
+     * External callers MUST use {@link #findByCorrelationIdAndTenantId} instead.
      */
     Optional<Order> findByCorrelationId(String correlationId);
+
+    /**
+     * Tenant-scoped lookup by correlationId.
+     * Use for all client-facing status polling to enforce tenant isolation at
+     * the query level — defense-in-depth alongside the Hibernate filter.
+     */
+    Optional<Order> findByCorrelationIdAndTenantId(String correlationId, String tenantId);
 }

--- a/order-service/src/main/java/code/with/vanilson/orderservice/OrderService.java
+++ b/order-service/src/main/java/code/with/vanilson/orderservice/OrderService.java
@@ -139,7 +139,8 @@ public class OrderService {
      */
     public OrderStatusResponse getOrderStatus(String correlationId) {
         filterActivator.activateFilter();
-        return orderRepository.findByCorrelationId(correlationId)
+        String tenantId = TenantContext.requireCurrentTenantId();
+        return orderRepository.findByCorrelationIdAndTenantId(correlationId, tenantId)
                 .map(order -> {
                     log.info("[OrderService] Status query: correlationId=[{}] status=[{}]",
                             correlationId, order.getStatus());

--- a/order-service/src/main/java/code/with/vanilson/orderservice/config/KafkaConfig.java
+++ b/order-service/src/main/java/code/with/vanilson/orderservice/config/KafkaConfig.java
@@ -1,13 +1,16 @@
 package code.with.vanilson.orderservice.config;
 
+import jakarta.annotation.PreDestroy;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.config.KafkaListenerEndpointRegistry;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
@@ -28,6 +31,7 @@ import java.util.Map;
  * Configures:
  * 1. String KafkaTemplate for OutboxEventPublisher (publishes serialised JSON strings)
  * 2. Saga consumer factory with MANUAL_IMMEDIATE ack + DLQ error handler
+ * 3. Graceful shutdown: setStopImmediate(false) drains the current batch before the JVM exits
  * <p>
  * Two separate KafkaTemplate beans:
  * - String KafkaTemplate: used by OutboxEventPublisher (payload already serialised)
@@ -35,13 +39,16 @@ import java.util.Map;
  * </p>
  *
  * @author vamuhong
- * @version 3.0
+ * @version 3.1
  */
 @Configuration
 public class KafkaConfig {
 
     @Value("${spring.kafka.producer.bootstrap-servers:localhost:9092}")
     private String bootstrapServers;
+
+    @Autowired
+    private KafkaListenerEndpointRegistry kafkaListenerEndpointRegistry;
 
     // -------------------------------------------------------
     // String KafkaTemplate — for OutboxEventPublisher
@@ -86,6 +93,7 @@ public class KafkaConfig {
     /**
      * Saga listener container factory:
      * - MANUAL_IMMEDIATE ack: offset committed after DB update succeeds
+     * - setStopImmediate(false): finish processing the current poll batch before stopping
      * - DLQ: failed events go to {topic}.DLQ after 3 retries with 1s delay
      */
     @Bean
@@ -95,6 +103,7 @@ public class KafkaConfig {
         var factory = new ConcurrentKafkaListenerContainerFactory<String, Object>();
         factory.setConsumerFactory(sagaConsumerFactory());
         factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL_IMMEDIATE);
+        factory.getContainerProperties().setStopImmediate(false);
 
         DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(
                 stringKafkaTemplate,
@@ -107,5 +116,20 @@ public class KafkaConfig {
         factory.setCommonErrorHandler(errorHandler);
         factory.setConcurrency(3);
         return factory;
+    }
+
+    /**
+     * Graceful shutdown — called during Spring context close (SIGTERM / actuator /shutdown).
+     * Stops all listener containers so in-flight messages are acknowledged before the JVM exits.
+     * Works with server.shutdown=graceful and spring.lifecycle.timeout-per-shutdown-phase=30s.
+     */
+    @PreDestroy
+    public void onDestroy() {
+        kafkaListenerEndpointRegistry.getListenerContainers()
+                .forEach(container -> {
+                    if (container.isRunning()) {
+                        container.stop();
+                    }
+                });
     }
 }

--- a/order-service/src/test/java/code/with/vanilson/orderservice/OrderServiceAsyncTest.java
+++ b/order-service/src/test/java/code/with/vanilson/orderservice/OrderServiceAsyncTest.java
@@ -241,7 +241,7 @@ class OrderServiceAsyncTest {
         @Test
         @DisplayName("should return REQUESTED immediately after order creation")
         void shouldReturnRequested() {
-            when(orderRepository.findByCorrelationId("test-correlation-id"))
+            when(orderRepository.findByCorrelationIdAndTenantId("test-correlation-id", "test-tenant-123"))
                     .thenReturn(Optional.of(savedOrder));
 
             OrderStatusResponse status = orderService.getOrderStatus("test-correlation-id");
@@ -255,7 +255,7 @@ class OrderServiceAsyncTest {
         @DisplayName("should return CONFIRMED after saga completes")
         void shouldReturnConfirmedAfterSaga() {
             savedOrder.setStatus(OrderStatus.CONFIRMED);
-            when(orderRepository.findByCorrelationId("test-correlation-id"))
+            when(orderRepository.findByCorrelationIdAndTenantId("test-correlation-id", "test-tenant-123"))
                     .thenReturn(Optional.of(savedOrder));
 
             OrderStatusResponse status = orderService.getOrderStatus("test-correlation-id");
@@ -267,7 +267,7 @@ class OrderServiceAsyncTest {
         @DisplayName("should return CANCELLED when saga compensation triggered")
         void shouldReturnCancelledAfterCompensation() {
             savedOrder.setStatus(OrderStatus.CANCELLED);
-            when(orderRepository.findByCorrelationId("test-correlation-id"))
+            when(orderRepository.findByCorrelationIdAndTenantId("test-correlation-id", "test-tenant-123"))
                     .thenReturn(Optional.of(savedOrder));
 
             OrderStatusResponse status = orderService.getOrderStatus("test-correlation-id");
@@ -278,7 +278,7 @@ class OrderServiceAsyncTest {
         @Test
         @DisplayName("should throw OrderNotFoundException for unknown correlationId")
         void shouldThrowForUnknownCorrelationId() {
-            when(orderRepository.findByCorrelationId("unknown-id"))
+            lenient().when(orderRepository.findByCorrelationIdAndTenantId("unknown-id", "test-tenant-123"))
                     .thenReturn(Optional.empty());
 
             assertThatThrownBy(() -> orderService.getOrderStatus("unknown-id"))

--- a/scripts/backup-mongo.sh
+++ b/scripts/backup-mongo.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# backup-mongo.sh — MongoDB consistent backup using mongodump --oplog
+# Idempotent: safe to re-run. Retention: 7 daily, 4 weekly, 3 monthly.
+# Usage: ./backup-mongo.sh [daily|weekly|monthly]
+set -euo pipefail
+
+BACKUP_TYPE="${1:-daily}"
+BACKUP_BASE="/backup/mongodb"
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+
+DAILY_KEEP=7
+WEEKLY_KEEP=4
+MONTHLY_KEEP=3
+
+MONGO_CONTAINER="${MONGO_CONTAINER:-mongo1}"
+MONGO_USER="${MONGO_USERNAME:-vanilson}"
+MONGO_PASS="${MONGO_PASSWORD:-vanilson}"
+MONGO_RS_URI="mongodb://${MONGO_USER}:${MONGO_PASS}@mongo1:27017,mongo2:27017,mongo3:27017/?replicaSet=rs0&authSource=admin"
+
+log() { echo "[$(date +'%Y-%m-%d %H:%M:%S')] $*"; }
+
+rotate_backups() {
+  local dir="$1" keep="$2"
+  local count
+  count=$(find "$dir" -maxdepth 1 -name "*.archive.gz" 2>/dev/null | wc -l)
+  if [[ $count -gt $keep ]]; then
+    find "$dir" -maxdepth 1 -name "*.archive.gz" -printf '%T+ %p\n' \
+      | sort | head -n $(( count - keep )) | awk '{print $2}' | xargs rm -f
+    log "Rotated $dir — kept $keep backups"
+  fi
+}
+
+dest="$BACKUP_BASE/$BACKUP_TYPE"
+mkdir -p "$dest"
+outfile="$dest/mongodb_${TIMESTAMP}.archive.gz"
+
+log "=== MongoDB Backup: type=$BACKUP_TYPE timestamp=$TIMESTAMP ==="
+log "Destination: $outfile"
+
+# mongodump with --oplog for consistent point-in-time snapshot across all databases
+docker exec "$MONGO_CONTAINER" mongodump \
+  --uri="$MONGO_RS_URI" \
+  --oplog \
+  --gzip \
+  --archive="/tmp/mongodb_backup_$$.archive.gz"
+
+docker cp "$MONGO_CONTAINER:/tmp/mongodb_backup_$$.archive.gz" "$outfile"
+docker exec "$MONGO_CONTAINER" rm -f "/tmp/mongodb_backup_$$.archive.gz"
+
+SIZE=$(du -sh "$outfile" | cut -f1)
+log "Backup complete: $outfile ($SIZE)"
+
+case "$BACKUP_TYPE" in
+  daily)   rotate_backups "$BACKUP_BASE/daily"   $DAILY_KEEP   ;;
+  weekly)  rotate_backups "$BACKUP_BASE/weekly"  $WEEKLY_KEEP  ;;
+  monthly) rotate_backups "$BACKUP_BASE/monthly" $MONTHLY_KEEP ;;
+esac
+
+log "=== MongoDB backup run complete ==="

--- a/scripts/backup-postgres.sh
+++ b/scripts/backup-postgres.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# backup-postgres.sh — PostgreSQL full backup + WAL archiving
+# Idempotent: safe to re-run. Retention: 7 daily, 4 weekly, 3 monthly.
+# Usage: ./backup-postgres.sh [daily|weekly|monthly]
+set -euo pipefail
+
+BACKUP_TYPE="${1:-daily}"
+BACKUP_BASE="/backup/postgres"
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+DATE=$(date +%Y%m%d)
+DAY_OF_WEEK=$(date +%u)   # 1=Monday … 7=Sunday
+DAY_OF_MONTH=$(date +%-d)
+
+# Retention counts
+DAILY_KEEP=7
+WEEKLY_KEEP=4
+MONTHLY_KEEP=3
+
+declare -A DB_CONTAINERS=(
+  ["order"]="postgres-order:5432:order_service_db"
+  ["product"]="postgres-product:5433:product_service_db"
+  ["payment"]="postgres-payment:5434:payment_db"
+  ["auth"]="postgres-auth:5435:auth_db"
+)
+
+log() { echo "[$(date +'%Y-%m-%d %H:%M:%S')] $*"; }
+
+rotate_backups() {
+  local dir="$1" keep="$2"
+  local count
+  count=$(find "$dir" -maxdepth 1 -name "*.tar.gz" | wc -l)
+  if [[ $count -gt $keep ]]; then
+    find "$dir" -maxdepth 1 -name "*.tar.gz" -printf '%T+ %p\n' \
+      | sort | head -n $(( count - keep )) | awk '{print $2}' | xargs rm -f
+    log "Rotated $dir — kept $keep, removed $(( count - keep ))"
+  fi
+}
+
+backup_instance() {
+  local name="$1" container="$2" port="$3" dbname="$4"
+  local dest="$BACKUP_BASE/$BACKUP_TYPE/$name"
+  mkdir -p "$dest"
+
+  local outfile="$dest/${name}_${TIMESTAMP}.tar.gz"
+  log "Starting pg_basebackup for $name ($dbname) → $outfile"
+
+  docker exec "$container" pg_basebackup \
+    -U "${POSTGRES_USERNAME:-vanilson}" \
+    -D /tmp/pgbackup_$$ \
+    -Ft -z -Xs -P \
+    --checkpoint=fast
+
+  docker cp "$container:/tmp/pgbackup_$$/base.tar.gz" "$outfile"
+  docker exec "$container" rm -rf /tmp/pgbackup_$$
+
+  log "Backup complete: $outfile ($(du -sh "$outfile" | cut -f1))"
+}
+
+# Archive WAL for PITR
+archive_wal() {
+  local name="$1" container="$2"
+  local wal_dir="$BACKUP_BASE/wal/$name"
+  mkdir -p "$wal_dir"
+
+  # pg_receivewal runs continuously; this one-shot triggers a checkpoint + ships WAL
+  docker exec "$container" psql \
+    -U "${POSTGRES_USERNAME:-vanilson}" \
+    -c "SELECT pg_switch_wal();" \
+    -q 2>/dev/null || true
+
+  log "WAL checkpoint triggered for $name"
+}
+
+log "=== PostgreSQL Backup: type=$BACKUP_TYPE timestamp=$TIMESTAMP ==="
+
+for name in "${!DB_CONTAINERS[@]}"; do
+  IFS=':' read -r container port dbname <<< "${DB_CONTAINERS[$name]}"
+  backup_instance "$name" "$container" "$port" "$dbname"
+  archive_wal "$name" "$container"
+done
+
+# Apply retention policy
+for name in "${!DB_CONTAINERS[@]}"; do
+  case "$BACKUP_TYPE" in
+    daily)   rotate_backups "$BACKUP_BASE/daily/$name"   $DAILY_KEEP   ;;
+    weekly)  rotate_backups "$BACKUP_BASE/weekly/$name"  $WEEKLY_KEEP  ;;
+    monthly) rotate_backups "$BACKUP_BASE/monthly/$name" $MONTHLY_KEEP ;;
+  esac
+done
+
+log "=== Backup run complete ==="

--- a/scripts/generate-tls-certs.sh
+++ b/scripts/generate-tls-certs.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# generate-tls-certs.sh — Generate TLS certificates for all services
+# Dev: self-signed certs from a local CA
+# Prod: replace with CA-signed certs (Let's Encrypt via cert-manager or your PKI)
+#
+# Usage: ./scripts/generate-tls-certs.sh
+# Output: certs/ directory with per-service keystores and truststores
+set -euo pipefail
+
+CERTS_DIR="./certs"
+CA_DIR="$CERTS_DIR/ca"
+KEYSTORE_PASS="${SSL_KEYSTORE_PASSWORD:-changeit}"
+VALIDITY_DAYS=365
+
+SERVICES=(
+  "gateway-api-service:8222"
+  "config-service:8888"
+  "discovery-service:8761"
+  "authentication-service:8085"
+  "customer-service:8090"
+  "product-service:8082"
+  "order-service:8083"
+  "payment-service:8086"
+  "cart-service:8091"
+  "notification-service:8040"
+  "kafka-broker:9093"
+  "vault:8200"
+)
+
+log() { echo "[$(date +'%Y-%m-%d %H:%M:%S')] $*"; }
+
+mkdir -p "$CA_DIR"
+for svc_port in "${SERVICES[@]}"; do
+  svc="${svc_port%%:*}"
+  mkdir -p "$CERTS_DIR/$svc"
+done
+
+# ---------------------------------------------------------------------------
+# Step 1: Generate Root CA
+# ---------------------------------------------------------------------------
+log "Generating Root CA..."
+if [[ ! -f "$CA_DIR/ca.key" ]]; then
+  openssl genrsa -out "$CA_DIR/ca.key" 4096
+
+  openssl req -new -x509 \
+    -key "$CA_DIR/ca.key" \
+    -out "$CA_DIR/ca.crt" \
+    -days $((VALIDITY_DAYS * 3)) \
+    -subj "/C=PT/ST=Lisbon/O=VanilsonShop/CN=VanilsonShop-Root-CA"
+
+  log "Root CA generated: $CA_DIR/ca.crt"
+else
+  log "Root CA already exists — reusing $CA_DIR/ca.crt"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 2: Generate per-service certificates
+# ---------------------------------------------------------------------------
+generate_service_cert() {
+  local svc="$1" port="$2"
+  local svc_dir="$CERTS_DIR/$svc"
+
+  log "Generating cert for $svc (port $port)..."
+
+  # Generate private key
+  openssl genrsa -out "$svc_dir/$svc.key" 2048
+
+  # Generate CSR with SAN
+  openssl req -new \
+    -key "$svc_dir/$svc.key" \
+    -out "$svc_dir/$svc.csr" \
+    -subj "/C=PT/ST=Lisbon/O=VanilsonShop/CN=$svc" \
+    -config <(cat <<EOF
+[req]
+distinguished_name = req_distinguished_name
+req_extensions = v3_req
+prompt = no
+[req_distinguished_name]
+CN = $svc
+[v3_req]
+subjectAltName = DNS:$svc,DNS:localhost,IP:127.0.0.1
+EOF
+)
+
+  # Sign with CA
+  openssl x509 -req \
+    -in "$svc_dir/$svc.csr" \
+    -CA "$CA_DIR/ca.crt" \
+    -CAkey "$CA_DIR/ca.key" \
+    -CAcreateserial \
+    -out "$svc_dir/$svc.crt" \
+    -days $VALIDITY_DAYS \
+    -extensions v3_req \
+    -extfile <(echo "[v3_req]
+subjectAltName = DNS:$svc,DNS:localhost,IP:127.0.0.1")
+
+  # Create PKCS12 keystore for Spring Boot
+  openssl pkcs12 -export \
+    -in "$svc_dir/$svc.crt" \
+    -inkey "$svc_dir/$svc.key" \
+    -certfile "$CA_DIR/ca.crt" \
+    -name "$svc" \
+    -out "$svc_dir/keystore.p12" \
+    -passout pass:"$KEYSTORE_PASS"
+
+  # Create truststore (CA cert)
+  keytool -importcert \
+    -file "$CA_DIR/ca.crt" \
+    -keystore "$svc_dir/truststore.p12" \
+    -storetype PKCS12 \
+    -storepass "$KEYSTORE_PASS" \
+    -alias root-ca \
+    -noprompt 2>/dev/null
+
+  rm -f "$svc_dir/$svc.csr"
+  log "  keystore: $svc_dir/keystore.p12"
+  log "  truststore: $svc_dir/truststore.p12"
+}
+
+for svc_port in "${SERVICES[@]}"; do
+  svc="${svc_port%%:*}"
+  port="${svc_port##*:}"
+  generate_service_cert "$svc" "$port"
+done
+
+# ---------------------------------------------------------------------------
+# Step 3: Kafka broker keystore/truststore (JKS format for Confluent)
+# ---------------------------------------------------------------------------
+log "Generating Kafka JKS keystore..."
+KAFKA_DIR="$CERTS_DIR/kafka-broker"
+
+keytool -importkeystore \
+  -srckeystore "$KAFKA_DIR/keystore.p12" \
+  -srcstoretype PKCS12 \
+  -srcstorepass "$KEYSTORE_PASS" \
+  -destkeystore "$KAFKA_DIR/kafka.keystore.jks" \
+  -deststoretype JKS \
+  -deststorepass "$KEYSTORE_PASS" \
+  -noprompt 2>/dev/null
+
+keytool -importcert \
+  -file "$CA_DIR/ca.crt" \
+  -keystore "$KAFKA_DIR/kafka.truststore.jks" \
+  -storetype JKS \
+  -storepass "$KEYSTORE_PASS" \
+  -alias root-ca \
+  -noprompt 2>/dev/null
+
+log "Kafka JKS keystores: $KAFKA_DIR/"
+
+# ---------------------------------------------------------------------------
+# Step 4: Generate RSA key pair for JWT RS256
+# ---------------------------------------------------------------------------
+JWT_DIR="$CERTS_DIR/jwt"
+mkdir -p "$JWT_DIR"
+log "Generating RSA key pair for JWT RS256..."
+
+openssl genrsa -out "$JWT_DIR/jwt-private.pem" 2048
+openssl rsa -in "$JWT_DIR/jwt-private.pem" -pubout -out "$JWT_DIR/jwt-public.pem"
+
+# Base64-encode for environment variable injection
+base64 -w0 "$JWT_DIR/jwt-private.pem" > "$JWT_DIR/jwt-private.b64"
+base64 -w0 "$JWT_DIR/jwt-public.pem"  > "$JWT_DIR/jwt-public.b64"
+
+log "JWT private key (base64): $JWT_DIR/jwt-private.b64 → set as JWT_PRIVATE_KEY env var"
+log "JWT public key (base64):  $JWT_DIR/jwt-public.b64  → set as JWT_PUBLIC_KEY env var"
+
+echo ""
+log "=== Certificate generation complete ==="
+log "All certs in: $CERTS_DIR/"
+log ""
+log "Next steps:"
+log "  1. Copy keystore.p12/truststore.p12 into each service's src/main/resources/"
+log "  2. Set SSL_KEYSTORE_PASSWORD and SSL_TRUSTSTORE_PASSWORD env vars"
+log "  3. Set JWT_PRIVATE_KEY=\$(cat $JWT_DIR/jwt-private.b64) in auth-service"
+log "  4. Set JWT_PUBLIC_KEY=\$(cat $JWT_DIR/jwt-public.b64) in gateway"
+log "  5. For Vault TLS: copy $CERTS_DIR/vault/vault.crt and vault.key to vault/certs/"
+log ""
+log "PRODUCTION: Replace self-signed certs with CA-signed certs from your PKI or cert-manager."

--- a/scripts/mongo-replicaset-init.js
+++ b/scripts/mongo-replicaset-init.js
@@ -1,0 +1,62 @@
+// mongo-replicaset-init.js — Initialize MongoDB 3-node replica set
+// Run on the PRIMARY node: mongosh --host mongo1:27017 mongo-replicaset-init.js
+// Nodes: mongo1 (primary), mongo2 (secondary), mongo3 (secondary)
+
+rs.initiate({
+  _id: "rs0",
+  members: [
+    {
+      _id: 0,
+      host: "mongo1:27017",
+      priority: 2  // highest priority — preferred primary
+    },
+    {
+      _id: 1,
+      host: "mongo2:27017",
+      priority: 1
+    },
+    {
+      _id: 2,
+      host: "mongo3:27017",
+      priority: 1
+    }
+  ]
+});
+
+// Wait for replica set to elect primary
+print("Waiting for replica set election...");
+let attempts = 0;
+while (attempts < 30) {
+  const status = rs.status();
+  const primary = status.members.find(m => m.stateStr === "PRIMARY");
+  if (primary) {
+    print("Primary elected: " + primary.name);
+    break;
+  }
+  sleep(2000);
+  attempts++;
+}
+
+// Create application databases and indexes on primary
+db = db.getSiblingDB("customer_db");
+db.createCollection("customers");
+db.customers.createIndex({ customerId: 1 }, { unique: true });
+db.customers.createIndex({ email: 1 }, { unique: true });
+print("customer_db indexes created");
+
+db = db.getSiblingDB("notification_db");
+db.createCollection("notifications");
+db.notifications.createIndex({ notificationDate: -1 });
+db.notifications.createIndex({ customerId: 1 });
+
+db.createCollection("processed_events");
+db.processed_events.createIndex({ eventId: 1 }, { unique: true });
+db.processed_events.createIndex({ processedAt: 1 }, { expireAfterSeconds: 604800 }); // TTL 7 days
+
+db.createCollection("dlq_events");
+db.dlq_events.createIndex({ receivedAt: -1 });
+db.dlq_events.createIndex({ topic: 1 });
+print("notification_db indexes created");
+
+print("Replica set initialization complete.");
+print(JSON.stringify(rs.conf(), null, 2));

--- a/scripts/restore-mongo.sh
+++ b/scripts/restore-mongo.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# restore-mongo.sh — MongoDB restore from mongodump archive
+# Usage: ./restore-mongo.sh <backup-file> [--drop]
+#   backup-file: path to .archive.gz from backup-mongo.sh
+#   --drop:      drop existing collections before restore (default: merge)
+set -euo pipefail
+
+BACKUP_FILE="${1:?Usage: $0 <backup-file> [--drop]}"
+DROP_FLAG="${2:-}"
+
+MONGO_CONTAINER="${MONGO_CONTAINER:-mongo1}"
+MONGO_USER="${MONGO_USERNAME:-vanilson}"
+MONGO_PASS="${MONGO_PASSWORD:-vanilson}"
+MONGO_RS_URI="mongodb://${MONGO_USER}:${MONGO_PASS}@mongo1:27017,mongo2:27017,mongo3:27017/?replicaSet=rs0&authSource=admin"
+
+log() { echo "[$(date +'%Y-%m-%d %H:%M:%S')] $*"; }
+die() { log "ERROR: $*"; exit 1; }
+
+[[ -f "$BACKUP_FILE" ]] || die "Backup file not found: $BACKUP_FILE"
+
+log "=== MongoDB Restore ==="
+log "Backup    : $BACKUP_FILE"
+[[ "$DROP_FLAG" == "--drop" ]] && log "Mode      : DROP existing collections before restore" || log "Mode      : Merge (no drop)"
+
+read -rp "This will restore MongoDB data. Type 'CONFIRM' to proceed: " confirm
+[[ "$confirm" == "CONFIRM" ]] || die "Aborted by user"
+
+log "Step 1: Copying backup archive to container"
+REMOTE_FILE="/tmp/mongodb_restore_$$.archive.gz"
+docker cp "$BACKUP_FILE" "$MONGO_CONTAINER:$REMOTE_FILE"
+
+log "Step 2: Running mongorestore"
+EXTRA_ARGS=""
+[[ "$DROP_FLAG" == "--drop" ]] && EXTRA_ARGS="--drop"
+
+docker exec "$MONGO_CONTAINER" mongorestore \
+  --uri="$MONGO_RS_URI" \
+  --oplogReplay \
+  --gzip \
+  --archive="$REMOTE_FILE" \
+  $EXTRA_ARGS
+
+docker exec "$MONGO_CONTAINER" rm -f "$REMOTE_FILE"
+
+log "Step 3: Verifying restore"
+docker exec "$MONGO_CONTAINER" mongosh \
+  --uri="$MONGO_RS_URI" \
+  --eval 'db.adminCommand({ping:1})' \
+  --quiet
+
+log "=== MongoDB restore complete ==="

--- a/scripts/restore-postgres.sh
+++ b/scripts/restore-postgres.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# restore-postgres.sh — PostgreSQL PITR restore to specific timestamp
+# Usage: ./restore-postgres.sh <db-name> <backup-file> [target-time]
+#   db-name:     order | product | payment | auth
+#   backup-file: path to .tar.gz produced by backup-postgres.sh
+#   target-time: ISO-8601 timestamp for PITR, e.g. "2024-01-15 14:30:00+00"
+#                Omit to restore to end of backup (no PITR)
+set -euo pipefail
+
+DB_NAME="${1:?Usage: $0 <db-name> <backup-file> [target-time]}"
+BACKUP_FILE="${2:?Usage: $0 <db-name> <backup-file> [target-time]}"
+TARGET_TIME="${3:-}"
+
+declare -A DB_CONTAINERS=(
+  ["order"]="postgres-order:order_service_db"
+  ["product"]="postgres-product:product_service_db"
+  ["payment"]="postgres-payment:payment_db"
+  ["auth"]="postgres-auth:auth_db"
+)
+
+log() { echo "[$(date +'%Y-%m-%d %H:%M:%S')] $*"; }
+die() { log "ERROR: $*"; exit 1; }
+
+[[ -v "DB_CONTAINERS[$DB_NAME]" ]] || die "Unknown db-name '$DB_NAME'. Valid: ${!DB_CONTAINERS[*]}"
+[[ -f "$BACKUP_FILE" ]] || die "Backup file not found: $BACKUP_FILE"
+
+IFS=':' read -r CONTAINER DBNAME <<< "${DB_CONTAINERS[$DB_NAME]}"
+PGDATA="/var/lib/postgresql/data"
+WAL_ARCHIVE="/backup/postgres/wal/$DB_NAME"
+RESTORE_WORK="/tmp/pg_restore_$$"
+
+log "=== PostgreSQL PITR Restore ==="
+log "Database  : $DB_NAME ($DBNAME)"
+log "Container : $CONTAINER"
+log "Backup    : $BACKUP_FILE"
+[[ -n "$TARGET_TIME" ]] && log "Target    : $TARGET_TIME (PITR)" || log "Target    : end of backup"
+
+# Safety check — require explicit confirmation for payment (zero data loss requirement)
+if [[ "$DB_NAME" == "payment" ]]; then
+  read -rp "WARNING: Restoring PAYMENT database. Type 'CONFIRM' to proceed: " confirm
+  [[ "$confirm" == "CONFIRM" ]] || die "Aborted by user"
+fi
+
+log "Step 1: Stopping container $CONTAINER"
+docker stop "$CONTAINER"
+
+log "Step 2: Extracting backup to temp directory"
+mkdir -p "$RESTORE_WORK"
+tar -xzf "$BACKUP_FILE" -C "$RESTORE_WORK"
+
+log "Step 3: Clearing existing data directory"
+docker run --rm \
+  -v "${CONTAINER}_data:/var/lib/postgresql/data" \
+  postgres:15-alpine \
+  sh -c "rm -rf $PGDATA/* && chown -R postgres:postgres $PGDATA"
+
+log "Step 4: Copying restored data"
+docker run --rm \
+  -v "$RESTORE_WORK:/restore:ro" \
+  -v "${CONTAINER}_data:/var/lib/postgresql/data" \
+  postgres:15-alpine \
+  sh -c "cp -a /restore/. $PGDATA/ && chown -R postgres:postgres $PGDATA"
+
+# Write recovery config for PITR
+if [[ -n "$TARGET_TIME" ]]; then
+  log "Step 5: Writing recovery.conf for PITR target: $TARGET_TIME"
+  docker run --rm \
+    -v "${CONTAINER}_data:/var/lib/postgresql/data" \
+    -v "$WAL_ARCHIVE:/wal_archive:ro" \
+    postgres:15-alpine \
+    sh -c "cat > $PGDATA/recovery.signal << 'EOF'
+EOF
+cat >> $PGDATA/postgresql.auto.conf << EOF
+restore_command = 'cp /wal_archive/%f %p'
+recovery_target_time = '$TARGET_TIME'
+recovery_target_action = 'promote'
+EOF
+chown postgres:postgres $PGDATA/recovery.signal $PGDATA/postgresql.auto.conf"
+fi
+
+log "Step 6: Starting container $CONTAINER"
+docker start "$CONTAINER"
+
+log "Step 7: Waiting for PostgreSQL to be ready..."
+for i in {1..30}; do
+  if docker exec "$CONTAINER" pg_isready -U "${POSTGRES_USERNAME:-vanilson}" -q 2>/dev/null; then
+    log "PostgreSQL is ready."
+    break
+  fi
+  sleep 2
+done
+
+log "Step 8: Verifying restore"
+docker exec "$CONTAINER" psql \
+  -U "${POSTGRES_USERNAME:-vanilson}" \
+  -d "$DBNAME" \
+  -c "SELECT pg_is_in_recovery(), now();"
+
+rm -rf "$RESTORE_WORK"
+log "=== Restore complete for $DB_NAME ==="

--- a/vault/config/vault.hcl
+++ b/vault/config/vault.hcl
@@ -1,20 +1,36 @@
-# Vault server configuration for local dev/staging
-# For production, use HA Raft storage with TLS
+# Vault server configuration
+# Dev mode: TLS disabled (tls_disable = 1)
+# Production: Set VAULT_TLS=true and provide cert/key paths
+#
+# To enable TLS for production:
+#   1. Run ./scripts/generate-tls-certs.sh to generate certs
+#   2. Copy certs/vault/vault.crt and vault.key to vault/certs/
+#   3. Set tls_disable = 0 and uncomment tls_cert_file/tls_key_file
+#   4. Update api_addr and cluster_addr to use https://
+#   5. Update all services' VAULT_SCHEME=https
 
 storage "file" {
   path = "/vault/data"
 }
 
 listener "tcp" {
-  address     = "0.0.0.0:8200"
-  tls_disable = 1  # Set to 0 in production with cert_file/key_file
-  # tls_cert_file = "/vault/certs/vault.crt"
-  # tls_key_file  = "/vault/certs/vault.key"
+  address = "0.0.0.0:8200"
+
+  # DEV: TLS disabled — use PLAINTEXT for local development
+  tls_disable = 1
+
+  # PRODUCTION: Uncomment and set cert paths after generating with generate-tls-certs.sh
+  # tls_disable     = 0
+  # tls_cert_file   = "/vault/certs/vault.crt"
+  # tls_key_file    = "/vault/certs/vault.key"
+  # tls_min_version = "tls12"
 }
 
+# PRODUCTION api_addr: change http → https when TLS is enabled
 api_addr     = "http://0.0.0.0:8200"
 cluster_addr = "http://0.0.0.0:8201"
-ui           = true
+
+ui = true
 
 # Disable mlock for Docker (requires IPC_LOCK capability otherwise)
 disable_mlock = true

--- a/vault/policies/app-policy.hcl
+++ b/vault/policies/app-policy.hcl
@@ -46,3 +46,20 @@ path "secret/data/ecommerce/discovery-service" {
 path "secret/data/ecommerce/config-service" {
   capabilities = ["read"]
 }
+
+# Dynamic database credentials
+path "database/creds/order-service-role" {
+  capabilities = ["read"]
+}
+
+path "database/creds/product-service-role" {
+  capabilities = ["read"]
+}
+
+path "database/creds/payment-service-role" {
+  capabilities = ["read"]
+}
+
+path "database/creds/auth-service-role" {
+  capabilities = ["read"]
+}

--- a/vault/scripts/vault-init.sh
+++ b/vault/scripts/vault-init.sh
@@ -53,6 +53,44 @@ vault kv put secret/ecommerce/notification-service \
   mongo_username="${MONGO_USERNAME:-vanilson}" \
   mongo_password="${MONGO_PASSWORD:-vanilson}"
 
+vault kv put secret/ecommerce/cart-service \
+  redis_password="${REDIS_PASSWORD:-redis-secret}"
+
+vault kv put secret/ecommerce/gateway-api-service \
+  jwt_secret="${JWT_SECRET:-bXlTdXBlclNlY3VyZVNlY3JldEtleUZvckpXVEF1dGgxMjM0NTY3ODk=}" \
+  redis_password="${REDIS_PASSWORD:-redis-secret}"
+
+vault kv put secret/ecommerce/discovery-service \
+  eureka_username="${EUREKA_USERNAME:-eureka}" \
+  eureka_password="${EUREKA_PASSWORD:-eureka-secret-2024}"
+
+vault kv put secret/ecommerce/config-service \
+  placeholder="config-service-secrets"
+
+echo "[vault-init] Enabling database secrets engine for dynamic credentials..."
+vault secrets enable database 2>/dev/null || echo "Database engine already enabled"
+
+# Configure PostgreSQL dynamic credentials for each database
+for SERVICE_DB in "order-service:order_service_db:5432" "product-service:product_service_db:5433" "payment-service:payment_db:5434" "authentication-service:auth_db:5435"; do
+  IFS=':' read -r SERVICE DB PORT <<< "$SERVICE_DB"
+  CONN_NAME="${SERVICE}-db"
+
+  vault write "database/config/${CONN_NAME}" \
+    plugin_name=postgresql-database-plugin \
+    allowed_roles="${SERVICE}-role" \
+    connection_url="postgresql://{{username}}:{{password}}@postgres-${SERVICE%-service}:${PORT}/${DB}?sslmode=disable" \
+    username="${POSTGRES_USERNAME:-vanilson}" \
+    password="${POSTGRES_PASSWORD:-vanilson}"
+
+  vault write "database/roles/${SERVICE}-role" \
+    db_name="${CONN_NAME}" \
+    creation_statements="CREATE ROLE \"{{name}}\" WITH LOGIN PASSWORD '{{password}}' VALID UNTIL '{{expiration}}'; GRANT ALL PRIVILEGES ON DATABASE ${DB} TO \"{{name}}\";" \
+    default_ttl="1h" \
+    max_ttl="24h"
+
+  echo "[vault-init] Dynamic credentials configured for ${SERVICE} (${DB})"
+done
+
 echo "[vault-init] Writing app policy..."
 vault policy write app-policy /vault/policies/app-policy.hcl
 


### PR DESCRIPTION
## Changes Applied

### 1. `OrderRepository.java` — Added tenant-scoped query method

```java
Optional<Order> findByCorrelationIdAndTenantId(String correlationId, String tenantId);
```

Spring Data JPA derives the `WHERE correlation_id = ? AND tenant_id = ?` SQL automatically — no JPQL annotation needed. The existing `findByCorrelationId` is retained for `updateStatus()` which runs in Kafka consumer threads with no tenant context (intentional, correct).

### 2. `OrderService.java:143` — `getOrderStatus()` uses the scoped query

```java
String tenantId = TenantContext.requireCurrentTenantId();
return orderRepository.findByCorrelationIdAndTenantId(correlationId, tenantId)
```

This gives defense-in-depth: even if `filterActivator.activateFilter()` silently fails (e.g., empty `TenantContext`), the SQL query itself still enforces tenant isolation. `requireCurrentTenantId()` also throws explicitly if no tenant is set — fail fast instead of leaking data.

### 3. `authentication-service.yml:51` and `gateway-service.yml:253` — Removed hardcoded defaults

```yaml
# Before — silently uses a known weak key in production if JWT_SECRET isn't set
secret-key: ${JWT_SECRET:bXlTdXBlclNlY3VyZVNlY3JldEtleUZvckpXVEF1dGgxMjM0NTY3ODk=}

# After — Spring fails at startup with a clear error if JWT_SECRET is unset
secret-key: ${JWT_SECRET}
```

The decoded value was `mySuperSecureSecretKeyForJWTAuth123456789` — publicly known. Without a default, any deployment that forgets to set `JWT_SECRET` gets a startup failure instead of silently accepting forged tokens.