### PR TITLE
### Summary

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -308,11 +308,11 @@ jobs:
       - name: Rollback on smoke test failure
         if: failure() && steps.deploy.outcome == 'success'
         run: |
-          REVISIONS=$(helm list -n ecommerce-staging --filter 'ecommerce' -o json | jq '.[0].revision | tonumber')
+          REVISIONS=$(helm list -n ecommerce-staging --filter '^ecommerce$' -o json | jq '.[0].revision // 0 | tonumber')
           if [ "$REVISIONS" -gt 1 ]; then
             helm rollback ecommerce --namespace ecommerce-staging
           else
-            echo "No previous version to rollback to (current revision is $REVISIONS)"
+            echo "No previous version to rollback (current revision is $REVISIONS)"
           fi
 
   # ============================================================

--- a/helm/ecommerce/templates/namespace.yaml
+++ b/helm/ecommerce/templates/namespace.yaml
@@ -1,12 +1,4 @@
 {{- if .Values.global.namespace }}
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ .Values.global.namespace }}
-  labels:
-    {{ include "ecommerce.labels" . | nindent 4 }}
----
 apiVersion: v1
 kind: ResourceQuota
 metadata:


### PR DESCRIPTION
- Fixed a namespace conflict in the CI/CD pipeline that caused the Helm deployment to fail with "namespaces already exists".
- Refined the rollback logic in the CI/CD pipeline to be more robust against empty or single-revision Helm releases.

### Changes
- Removed the `Namespace` resource from `helm/ecommerce/templates/namespace.yaml`. This avoids a conflict with Helm's `--create-namespace` flag, which is used in the CI/CD pipeline. The `ResourceQuota` is still maintained within the chart.
- Updated `.github/workflows/ci-cd.yml` to use a more robust regex-based filter and safer `jq` parsing when checking for Helm revisions before rollback. This prevents potential failures if the release list is empty or the revision count is exactly one.

### Verification
- Ran `helm lint` on the modified chart and confirmed it passes without errors.
- Verified that all Kubernetes resources in the Helm templates still correctly reference the `global.namespace` variable.
- Confirmed that the `helm upgrade --install` commands in `ci-cd.yml` now correctly manage namespaces without resource conflicts.