### PR TITLE
### Summary

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -249,7 +249,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: '3.14.0'
+
       - name: Create Kind cluster
+        id: kind
         uses: helm/kind-action@v1.10.0
         with:
           cluster_name: ecommerce-staging
@@ -262,11 +268,6 @@ jobs:
         run: |
           kubectl wait --for=condition=Ready node --all --timeout=120s
           kubectl cluster-info
-
-      - name: Set up Helm
-        uses: azure/setup-helm@v4
-        with:
-          version: '3.14.0'
 
       # No --wait: services will never reach Running in Kind (no databases,
       # no Kafka, no Vault). --wait would poll the API server until the
@@ -281,6 +282,8 @@ jobs:
             --set global.imageRegistry=${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }} \
             --set global.namespace=ecommerce-staging \
             --timeout 2m
+        env:
+          KUBECONFIG: ${{ steps.kind.outputs.kubeconfig }}
 
       # Smoke tests: verify chart manifests were accepted by the API server.
       # HTTP health checks are not possible in Kind CI (services need real
@@ -331,6 +334,12 @@ jobs:
         with:
           version: '3.14.0'
 
+      - name: Set Kubernetes context
+        uses: azure/k8s-set-context@v4
+        with:
+          method: kubeconfig
+          kubeconfig: ${{ secrets.PROD_KUBECONFIG }}
+
       - name: Deploy to production
         run: |
           helm upgrade --install ecommerce ./helm/ecommerce \
@@ -342,5 +351,3 @@ jobs:
             --timeout 15m \
             --wait \
             --atomic   # auto-rollback on failure
-        env:
-          KUBECONFIG: ${{ secrets.PROD_KUBECONFIG }}


### PR DESCRIPTION
- Fixed the "Kubernetes cluster unreachable" error in the CI/CD pipeline by correcting how the Kubernetes configuration (`KUBECONFIG`) is handled.
- Ensured that Helm always has a valid cluster context in both staging (Kind) and production environments.

### Changes
- Modified `.github/workflows/ci-cd.yml` to use `azure/k8s-set-context@v4` in the `deploy-prod` job, which properly saves the kubeconfig secret to a file rather than setting the environment variable to the raw content.
- Updated the `staging` job in `.github/workflows/ci-cd.yml` to explicitly set `KUBECONFIG` using the output from `helm/kind-action`, preventing it from being lost or overwritten.
- Reordered the `staging` job steps to set up Helm before creating the Kind cluster for better reliability.

### Verification
- Ran `lint` on the modified `ci-cd.yml` file to ensure YAML syntax and structure are correct.
- Verified that both `staging` and `deploy-prod` jobs now have explicit and robust mechanisms for discovering the Kubernetes cluster.