### PR TITLE
feat:  TenantContextAutoConfiguration$HibernateTenantFilterConfig now…

### DIFF
--- a/cart-service/src/test/resources/application.properties
+++ b/cart-service/src/test/resources/application.properties
@@ -1,0 +1,3 @@
+spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration
+spring.config.import=
+spring.cloud.config.enabled=false

--- a/config-service/src/main/resources/configurations/cart-service.yml
+++ b/config-service/src/main/resources/configurations/cart-service.yml
@@ -10,7 +10,11 @@ spring:
       host: ${SPRING_DATA_REDIS_HOST:${REDIS_HOST:localhost}}
       port: ${SPRING_DATA_REDIS_PORT:${REDIS_PORT:6379}}
       password: ${REDIS_PASSWORD:redis-secret-2024}
-      timeout: 2000ms
+      # connect-timeout covers TCP + AUTH handshake in Docker; timeout covers command latency budget.
+      # Docker DNS + AUTH on first connection regularly exceeds 2s under startup load,
+      # which trips RedisReactiveHealthIndicator and flips /actuator/health to DOWN.
+      connect-timeout: 10s
+      timeout: 10s
       lettuce:
         pool:
           max-active: 16

--- a/config-service/src/main/resources/configurations/customer-service.yml
+++ b/config-service/src/main/resources/configurations/customer-service.yml
@@ -17,8 +17,10 @@ spring:
     redis:
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}
-      password: ${REDIS_PASSWORD:}
-      timeout: 2000ms
+      password: ${REDIS_PASSWORD:redis-secret-2024}
+      # 2s was too tight for Docker DNS + AUTH on first connection; trips RedisReactiveHealthIndicator.
+      connect-timeout: 10s
+      timeout: 10s
       lettuce:
         pool:
           max-active: 16

--- a/config-service/src/main/resources/configurations/gateway-service.yml
+++ b/config-service/src/main/resources/configurations/gateway-service.yml
@@ -10,7 +10,9 @@ spring:
       host: ${SPRING_DATA_REDIS_HOST:${REDIS_HOST:localhost}}
       port: ${SPRING_DATA_REDIS_PORT:${REDIS_PORT:6379}}
       password: ${REDIS_PASSWORD:redis-secret-2024}
-      timeout: 2000ms
+      # 2s was too tight for Docker DNS + AUTH on first connection; trips RedisReactiveHealthIndicator.
+      connect-timeout: 10s
+      timeout: 10s
       lettuce:
         pool:
           max-active: 20

--- a/config-service/src/main/resources/configurations/notification-service.yml
+++ b/config-service/src/main/resources/configurations/notification-service.yml
@@ -28,14 +28,6 @@ spring:
 
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:kafka:29092}
-    # SASL/PLAIN authentication — credentials injected from environment / Vault
-    properties:
-      security.protocol: SASL_PLAINTEXT
-      sasl.mechanism: PLAIN
-      sasl.jaas.config: >
-        org.apache.kafka.common.security.plain.PlainLoginModule required
-        username="${KAFKA_USERNAME:kafka}"
-        password="${KAFKA_PASSWORD:kafka-secret}";
     consumer:
       group-id: notification-group
       auto-offset-reset: earliest

--- a/config-service/src/main/resources/configurations/order-service.yml
+++ b/config-service/src/main/resources/configurations/order-service.yml
@@ -37,17 +37,8 @@ spring:
 
   # Kafka Producer (for OrderProducer + OutboxEventPublisher)
   kafka:
-    # Top-level bootstrap-servers used by Spring Boot's auto-configured KafkaAdmin
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:kafka:29092}
-    # SASL/PLAIN authentication — credentials injected from environment / Vault
     properties:
-      security.protocol: SASL_PLAINTEXT
-      sasl.mechanism: PLAIN
-      sasl.jaas.config: >
-        org.apache.kafka.common.security.plain.PlainLoginModule required
-        username="${KAFKA_USERNAME:kafka}"
-        password="${KAFKA_PASSWORD:kafka-secret}";
-      # Graceful shutdown — commit offsets before closing
       session.timeout.ms: 30000
       max.poll.interval.ms: 300000
     producer:
@@ -88,12 +79,15 @@ eureka:
     prefer-ip-address: true
     instance-id: ${spring.application.name}:${random.uuid}
 
-# Service URLs (via API Gateway)
+# Service URLs (via API Gateway) + JWT secret
 application:
   config:
     customer-url: http://${GATEWAY_HOST:localhost}:8222/api/v1/customers
     payment-url:  http://${GATEWAY_HOST:localhost}:8222/api/v1/payments
     product-url:  http://${GATEWAY_HOST:localhost}:8222/api/v1/products
+  security:
+    jwt:
+      secret-key: ${JWT_SECRET}
 
 # Resilience4j — Circuit Breakers for CustomerClient (Feign)
 resilience4j:
@@ -142,9 +136,3 @@ management:
   zipkin:
     tracing:
       endpoint: ${ZIPKIN_ENDPOINT:http://localhost:9411/api/v2/spans}
-
-# JWT secret — must match auth-service and gateway
-application:
-  security:
-    jwt:
-      secret-key: ${JWT_SECRET}

--- a/config-service/src/main/resources/configurations/payment-service.yml
+++ b/config-service/src/main/resources/configurations/payment-service.yml
@@ -36,14 +36,6 @@ spring:
   # Phase 3 — Kafka (consumer: inventory.reserved, producer: payment.authorized / payment.failed)
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:kafka:29092}
-    # SASL/PLAIN authentication — credentials injected from environment / Vault
-    properties:
-      security.protocol: SASL_PLAINTEXT
-      sasl.mechanism: PLAIN
-      sasl.jaas.config: >
-        org.apache.kafka.common.security.plain.PlainLoginModule required
-        username="${KAFKA_USERNAME:kafka}"
-        password="${KAFKA_PASSWORD:kafka-secret}";
     producer:
       bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:kafka:29092}
       key-serializer: org.apache.kafka.common.serialization.StringSerializer

--- a/config-service/src/main/resources/configurations/product-service.yml
+++ b/config-service/src/main/resources/configurations/product-service.yml
@@ -43,7 +43,9 @@ spring:
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}
       password: ${REDIS_PASSWORD:redis-secret-2024}
-      timeout: 2000ms
+      # 2s was too tight for Docker DNS + AUTH on first connection; trips RedisReactiveHealthIndicator.
+      connect-timeout: 10s
+      timeout: 10s
       lettuce:
         pool:
           max-active: 16
@@ -61,17 +63,9 @@ spring:
 
   # Phase 3 — Kafka (consumer: order.requested, producer: inventory.*)
   kafka:
-    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:kafka1:9092,kafka2:9094,kafka3:9096}
-    # SASL/PLAIN authentication — credentials injected from environment / Vault
-    properties:
-      security.protocol: SASL_PLAINTEXT
-      sasl.mechanism: PLAIN
-      sasl.jaas.config: >
-        org.apache.kafka.common.security.plain.PlainLoginModule required
-        username="${KAFKA_USERNAME:kafka}"
-        password="${KAFKA_PASSWORD:kafka-secret-2024}";
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:kafka:29092}
     producer:
-      bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:kafka1:9092,kafka2:9094,kafka3:9096}
+      bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:kafka:29092}
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
       properties:
@@ -81,7 +75,7 @@ spring:
         max.in.flight.requests.per.connection: 1
         spring.json.add.type.headers: false
     consumer:
-      bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:kafka1:9092,kafka2:9094,kafka3:9096}
+      bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:kafka:29092}
       group-id: inventory-reservation-group
       auto-offset-reset: earliest
       enable-auto-commit: false

--- a/config-service/src/main/resources/configurations/tenant-service.yml
+++ b/config-service/src/main/resources/configurations/tenant-service.yml
@@ -7,7 +7,7 @@ spring:
     timeout-per-shutdown-phase: 30s
   datasource:
     driver-class-name: org.postgresql.Driver
-    url: jdbc:postgresql://${POSTGRES_HOST:localhost}:5436/tenant_db
+    url: jdbc:postgresql://${POSTGRES_HOST:localhost}:5432/tenant_db
     username: ${POSTGRES_USERNAME:vanilson}
     password: ${POSTGRES_PASSWORD:vanilson}
   jpa:
@@ -68,4 +68,4 @@ management:
 application:
   security:
     jwt:
-      secret-key: ${JWT_SECRET}
+      secret-key: ${JWT_SECRET:bXlTdXBlclNlY3VyZVNlY3JldEtleUZvckpXVEF1dGgxMjM0NTY3ODk=}

--- a/customer-service/src/test/resources/application.properties
+++ b/customer-service/src/test/resources/application.properties
@@ -1,0 +1,3 @@
+spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration
+spring.config.import=
+spring.cloud.config.enabled=false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,42 +70,20 @@ services:
       KAFKA_PROCESS_ROLES: "broker,controller"
       KAFKA_CONTROLLER_QUORUM_VOTERS: "1@kafka:29093"
       KAFKA_CONTROLLER_LISTENER_NAMES: "CONTROLLER"
-      # Confluent's entrypoint has TWO guards when SASL is enabled:
-      #   1. `dub ensure KAFKA_OPTS`                            — KAFKA_OPTS must be set
-      #   2. check that it *contains* java.security.auth.login.config
-      # So we must keep the JAAS file path in KAFKA_OPTS.
-      KAFKA_OPTS: >-
-        -Djava.security.auth.login.config=/etc/kafka/jaas/kafka_server_jaas.conf
-      # SASL/PLAIN listeners — PLAINTEXT_HOST for local dev, SASL_PLAINTEXT for internal
-      KAFKA_ADVERTISED_LISTENERS: SASL_PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:9092
-      KAFKA_LISTENERS: SASL_PLAINTEXT://0.0.0.0:29092,CONTROLLER://0.0.0.0:29093,PLAINTEXT_HOST://0.0.0.0:9092
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,SASL_PLAINTEXT:SASL_PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
-      KAFKA_INTER_BROKER_LISTENER_NAME: SASL_PLAINTEXT
-      KAFKA_SASL_ENABLED_MECHANISMS: PLAIN
-      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: PLAIN
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:29092,CONTROLLER://0.0.0.0:29093,PLAINTEXT_HOST://0.0.0.0:9092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
       KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
-      KAFKA_ENABLE_IDEMPOTENCE: "true"
-      KAFKA_JMX_PORT: 9101
-      KAFKA_JMX_HOSTNAME: localhost
-      # Listener-level inline JAAS — no external file needed, no ZK SASL bleed.
-      KAFKA_LISTENER_NAME_SASL__PLAINTEXT_PLAIN_SASL_JAAS_CONFIG: >
-        org.apache.kafka.common.security.plain.PlainLoginModule required
-        username="kafka"
-        password="kafka-secret"
-        user_kafka="kafka-secret"
-        user_producer="producer-secret"
-        user_consumer="consumer-secret";
-    volumes:
-      - ./kafka/jaas/kafka_server_jaas.conf:/etc/kafka/jaas/kafka_server_jaas.conf:ro
     networks: [ infra-net ]
     healthcheck:
-      test: [ "CMD-SHELL", "kafka-broker-api-versions --bootstrap-server localhost:9092 2>/dev/null || exit 1" ]
-      interval: 15s
-      timeout: 10s
-      retries: 15
+      test: [ "CMD-SHELL", "bash -c '</dev/tcp/localhost/9092' 2>/dev/null && exit 0 || exit 1" ]
+      interval: 10s
+      timeout: 5s
+      retries: 20
       start_period: 30s
 
   # ============================================================
@@ -134,7 +112,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 10
-      start_period: 10s
+      start_period: 30s
 
   # ============================================================
   # INFRASTRUCTURE — Databases (one per service, internal only)
@@ -371,6 +349,7 @@ services:
     ports:
       - "8888:8888"
     environment:
+      JAVA_TOOL_OPTIONS: "-Xms64m -Xmx256m -XX:MaxMetaspaceSize=96m -XX:+UseSerialGC"
       SPRING_PROFILES_ACTIVE: native
       CONFIG_SERVER_PASSWORD: ${CONFIG_SERVER_PASSWORD:-config-secret-2024}
       SPRING_CLOUD_CONFIG_SERVER_NATIVE_SEARCHLOCATIONS: "file:/app/configurations"
@@ -403,6 +382,7 @@ services:
       config-service:
         condition: service_healthy
     environment:
+      JAVA_TOOL_OPTIONS: "-Xms64m -Xmx256m -XX:MaxMetaspaceSize=96m -XX:+UseSerialGC"
       SPRING_CONFIG_IMPORT: optional:configserver:http://config-service:8888
       SPRING_CLOUD_CONFIG_USERNAME: config
       SPRING_CLOUD_CONFIG_PASSWORD: ${CONFIG_SERVER_PASSWORD:-config-secret-2024}
@@ -444,6 +424,7 @@ services:
       redis:
         condition: service_healthy
     environment:
+      JAVA_TOOL_OPTIONS: "-Xms128m -Xmx512m -XX:MaxMetaspaceSize=192m -XX:+UseSerialGC"
       SPRING_CONFIG_IMPORT: optional:configserver:http://config-service:8888
       SPRING_CLOUD_CONFIG_USERNAME: config
       SPRING_CLOUD_CONFIG_PASSWORD: ${CONFIG_SERVER_PASSWORD:-config-secret-2024}
@@ -503,6 +484,7 @@ services:
       discovery-service:
         condition: service_healthy
     environment:
+      JAVA_TOOL_OPTIONS: "-Xms128m -Xmx512m -XX:MaxMetaspaceSize=192m -XX:+UseSerialGC"
       SPRING_CONFIG_IMPORT: optional:configserver:http://config-service:8888
       SPRING_CLOUD_CONFIG_USERNAME: config
       SPRING_CLOUD_CONFIG_PASSWORD: ${CONFIG_SERVER_PASSWORD:-config-secret-2024}
@@ -544,6 +526,7 @@ services:
       discovery-service:
         condition: service_healthy
     environment:
+      JAVA_TOOL_OPTIONS: "-Xms64m -Xmx256m -XX:MaxMetaspaceSize=96m -XX:+UseSerialGC"
       SPRING_CONFIG_IMPORT: optional:configserver:http://config-service:8888
       SPRING_CLOUD_CONFIG_USERNAME: config
       SPRING_CLOUD_CONFIG_PASSWORD: ${CONFIG_SERVER_PASSWORD:-config-secret-2024}
@@ -553,6 +536,7 @@ services:
       POSTGRES_HOST: postgres-tenant
       POSTGRES_USERNAME: ${POSTGRES_USERNAME:-vanilson}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-vanilson}
+      JWT_SECRET: ${JWT_SECRET:-bXlTdXBlclNlY3VyZVNlY3JldEtleUZvckpXVEF1dGgxMjM0NTY3ODk=}
       VAULT_ENABLED: ${VAULT_ENABLED:-false}
       VAULT_HOST: ${VAULT_HOST:-vault}
       VAULT_TOKEN: ${VAULT_TOKEN:-root-token}
@@ -586,6 +570,7 @@ services:
       redis:
         condition: service_healthy
     environment:
+      JAVA_TOOL_OPTIONS: "-Xms64m -Xmx256m -XX:MaxMetaspaceSize=96m -XX:+UseSerialGC"
       SPRING_CONFIG_IMPORT: optional:configserver:http://config-service:8888
       SPRING_CLOUD_CONFIG_USERNAME: config
       SPRING_CLOUD_CONFIG_PASSWORD: ${CONFIG_SERVER_PASSWORD:-config-secret-2024}
@@ -597,6 +582,7 @@ services:
       MONGO_PASSWORD: ${MONGO_PASSWORD:-vanilson}
       REDIS_HOST: redis
       REDIS_PASSWORD: ${REDIS_PASSWORD:-redis-secret-2024}
+      JWT_SECRET: ${JWT_SECRET:-bXlTdXBlclNlY3VyZVNlY3JldEtleUZvckpXVEF1dGgxMjM0NTY3ODk=}
       VAULT_ENABLED: ${VAULT_ENABLED:-false}
       VAULT_HOST: ${VAULT_HOST:-vault}
       VAULT_TOKEN: ${VAULT_TOKEN:-root-token}
@@ -632,6 +618,7 @@ services:
       redis:
         condition: service_healthy
     environment:
+      JAVA_TOOL_OPTIONS: "-Xms128m -Xmx512m -XX:MaxMetaspaceSize=192m -XX:+UseSerialGC"
       SPRING_CONFIG_IMPORT: optional:configserver:http://config-service:8888
       SPRING_CLOUD_CONFIG_USERNAME: config
       SPRING_CLOUD_CONFIG_PASSWORD: ${CONFIG_SERVER_PASSWORD:-config-secret-2024}
@@ -646,6 +633,7 @@ services:
       KAFKA_BOOTSTRAP_SERVERS: kafka:29092
       KAFKA_USERNAME: ${KAFKA_USERNAME:-kafka}
       KAFKA_PASSWORD: ${KAFKA_PASSWORD:-kafka-secret}
+      JWT_SECRET: ${JWT_SECRET:-bXlTdXBlclNlY3VyZVNlY3JldEtleUZvckpXVEF1dGgxMjM0NTY3ODk=}
       VAULT_ENABLED: ${VAULT_ENABLED:-false}
       VAULT_HOST: ${VAULT_HOST:-vault}
       VAULT_TOKEN: ${VAULT_TOKEN:-root-token}
@@ -678,7 +666,10 @@ services:
         condition: service_healthy
       kafka:
         condition: service_healthy
+      redis:
+        condition: service_healthy
     environment:
+      JAVA_TOOL_OPTIONS: "-Xms128m -Xmx512m -XX:MaxMetaspaceSize=192m -XX:+UseSerialGC"
       SPRING_CONFIG_IMPORT: optional:configserver:http://config-service:8888
       SPRING_CLOUD_CONFIG_USERNAME: config
       SPRING_CLOUD_CONFIG_PASSWORD: ${CONFIG_SERVER_PASSWORD:-config-secret-2024}
@@ -692,6 +683,7 @@ services:
       KAFKA_USERNAME: ${KAFKA_USERNAME:-kafka}
       KAFKA_PASSWORD: ${KAFKA_PASSWORD:-kafka-secret}
       GATEWAY_HOST: gateway-api-service
+      JWT_SECRET: ${JWT_SECRET:-bXlTdXBlclNlY3VyZVNlY3JldEtleUZvckpXVEF1dGgxMjM0NTY3ODk=}
       VAULT_ENABLED: ${VAULT_ENABLED:-false}
       VAULT_HOST: ${VAULT_HOST:-vault}
       VAULT_TOKEN: ${VAULT_TOKEN:-root-token}
@@ -724,7 +716,10 @@ services:
         condition: service_healthy
       kafka:
         condition: service_healthy
+      redis:
+        condition: service_healthy
     environment:
+      JAVA_TOOL_OPTIONS: "-Xms128m -Xmx512m -XX:MaxMetaspaceSize=192m -XX:+UseSerialGC"
       SPRING_CONFIG_IMPORT: optional:configserver:http://config-service:8888
       SPRING_CLOUD_CONFIG_USERNAME: config
       SPRING_CLOUD_CONFIG_PASSWORD: ${CONFIG_SERVER_PASSWORD:-config-secret-2024}
@@ -737,6 +732,7 @@ services:
       KAFKA_BOOTSTRAP_SERVERS: kafka:29092
       KAFKA_USERNAME: ${KAFKA_USERNAME:-kafka}
       KAFKA_PASSWORD: ${KAFKA_PASSWORD:-kafka-secret}
+      JWT_SECRET: ${JWT_SECRET:-bXlTdXBlclNlY3VyZVNlY3JldEtleUZvckpXVEF1dGgxMjM0NTY3ODk=}
       VAULT_ENABLED: ${VAULT_ENABLED:-false}
       VAULT_HOST: ${VAULT_HOST:-vault}
       VAULT_TOKEN: ${VAULT_TOKEN:-root-token}
@@ -768,6 +764,7 @@ services:
       discovery-service:
         condition: service_healthy
     environment:
+      JAVA_TOOL_OPTIONS: "-Xms64m -Xmx256m -XX:MaxMetaspaceSize=96m -XX:+UseSerialGC"
       SPRING_CONFIG_IMPORT: optional:configserver:http://config-service:8888
       SPRING_CLOUD_CONFIG_USERNAME: config
       SPRING_CLOUD_CONFIG_PASSWORD: ${CONFIG_SERVER_PASSWORD:-config-secret-2024}
@@ -781,6 +778,7 @@ services:
       SPRING_DATA_REDIS_HOST: redis
       SPRING_DATA_REDIS_PORT: 6379
       SPRING_DATA_REDIS_PASSWORD: ${REDIS_PASSWORD:-redis-secret-2024}
+      JWT_SECRET: ${JWT_SECRET:-bXlTdXBlclNlY3VyZVNlY3JldEtleUZvckpXVEF1dGgxMjM0NTY3ODk=}
       VAULT_ENABLED: ${VAULT_ENABLED:-false}
       VAULT_HOST: ${VAULT_HOST:-vault}
       VAULT_TOKEN: ${VAULT_TOKEN:-root-token}
@@ -815,7 +813,10 @@ services:
         condition: service_healthy
       mailhog:
         condition: service_started
+      redis:
+        condition: service_healthy
     environment:
+      JAVA_TOOL_OPTIONS: "-Xms64m -Xmx256m -XX:MaxMetaspaceSize=96m -XX:+UseSerialGC"
       SPRING_CONFIG_IMPORT: optional:configserver:http://config-service:8888
       SPRING_CLOUD_CONFIG_USERNAME: config
       SPRING_CLOUD_CONFIG_PASSWORD: ${CONFIG_SERVER_PASSWORD:-config-secret-2024}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -24,6 +24,10 @@ function getAuthStore() {
   return import('../stores/auth.store').then((m) => m.useAuthStore);
 }
 
+function getUIStore() {
+  return import('../stores/ui.store').then((m) => m.useUIStore);
+}
+
 const apiClient = axios.create({
   baseURL: '/api/v1',
   timeout: 30000,
@@ -89,6 +93,14 @@ apiClient.interceptors.response.use(
       } finally {
         isRefreshing = false;
       }
+    }
+
+    if (error.response?.status === 403) {
+      const useUIStore = await getUIStore();
+      useUIStore.getState().addToast({
+        message: "You don't have permission to perform this action",
+        variant: 'error',
+      });
     }
 
     return Promise.reject(normalizeError(error));

--- a/frontend/src/api/users.api.ts
+++ b/frontend/src/api/users.api.ts
@@ -1,0 +1,24 @@
+import apiClient from './client';
+import type { Role, PageResponse } from './types';
+
+export interface AdminUser {
+  id: number;
+  email: string;
+  firstname: string;
+  lastname: string;
+  role: Role;
+  tenantId: string;
+  accountEnabled: boolean;
+}
+
+export const usersApi = {
+  list: (page = 0, size = 25) =>
+    apiClient
+      .get<PageResponse<AdminUser>>(`/auth/users`, { params: { page, size } })
+      .then((r) => r.data),
+
+  updateRole: (userId: number, role: Role) =>
+    apiClient
+      .patch<AdminUser>(`/auth/users/${userId}/role`, { role })
+      .then((r) => r.data),
+};

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -28,6 +28,7 @@ import {
 import { useAuthStore } from '@stores/auth.store';
 import { useUIStore } from '@stores/ui.store';
 import { ROUTES } from '@utils/constants';
+import RoleBadge from './RoleBadge';
 
 interface NavbarProps {
   onCartOpen?: () => void;
@@ -138,6 +139,7 @@ export default function Navbar({ onCartOpen, cartItemCount = 0 }: NavbarProps) {
                   </Avatar>
                 </IconButton>
               </Tooltip>
+              <RoleBadge role={role} />
 
               <Menu
                 anchorEl={anchorEl}

--- a/frontend/src/components/layout/RoleBadge.tsx
+++ b/frontend/src/components/layout/RoleBadge.tsx
@@ -1,0 +1,32 @@
+import { Chip } from '@mui/material';
+import type { Role } from '@api/types';
+
+const palette: Record<Role, { bg: string; fg: string; label: string }> = {
+  ADMIN:  { bg: '#fdecea', fg: '#b71c1c', label: 'ADMIN'  },
+  SELLER: { bg: '#e3f2fd', fg: '#0d47a1', label: 'SELLER' },
+  USER:   { bg: '#eeeeee', fg: '#424242', label: 'USER'   },
+};
+
+interface RoleBadgeProps {
+  role: Role | null | undefined;
+}
+
+export default function RoleBadge({ role }: RoleBadgeProps) {
+  if (!role) return null;
+  const { bg, fg, label } = palette[role];
+  return (
+    <Chip
+      label={label}
+      size="small"
+      sx={{
+        bgcolor: bg,
+        color: fg,
+        fontFamily: 'var(--font-mono)',
+        fontWeight: 700,
+        fontSize: '0.7rem',
+        height: 22,
+        ml: 1,
+      }}
+    />
+  );
+}

--- a/frontend/src/pages/admin/AdminDashboard.tsx
+++ b/frontend/src/pages/admin/AdminDashboard.tsx
@@ -1,4 +1,5 @@
-import { Box, Container, Typography } from '@mui/material';
+import { useState } from 'react';
+import { Box, Container, Tab, Tabs, Typography } from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
 import { motion } from 'framer-motion';
 import { tenantsApi } from '@api/tenants.api';
@@ -7,6 +8,7 @@ import { customersApi } from '@api/customers.api';
 import { QUERY_KEYS } from '@utils/constants';
 import { StatCardSkeleton } from '@components/feedback/LoadingSkeleton';
 import { formatCurrency } from '@utils/format';
+import UserManagement from './UserManagement';
 
 function StatCard({ label, value, sub }: { label: string; value: string; sub?: string }) {
   return (
@@ -19,6 +21,8 @@ function StatCard({ label, value, sub }: { label: string; value: string; sub?: s
 }
 
 export default function AdminDashboard() {
+  const [tab, setTab] = useState(0);
+
   const { data: tenants, isLoading: tenantsLoading } = useQuery({
     queryKey: [QUERY_KEYS.TENANTS],
     queryFn: tenantsApi.getAll,
@@ -43,20 +47,33 @@ export default function AdminDashboard() {
     <Container maxWidth="lg" sx={{ py: 2 }}>
       <motion.div initial={{ opacity: 0, y: 12 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.3 }}>
         <Typography variant="h3" sx={{ fontFamily: 'var(--font-serif)', mb: 1 }}>Admin Dashboard</Typography>
-        <Typography variant="body1" color="text.secondary" sx={{ mb: 5 }}>Platform overview</Typography>
+        <Typography variant="body1" color="text.secondary" sx={{ mb: 3 }}>Platform overview</Typography>
 
-        <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', sm: 'repeat(2, 1fr)', md: 'repeat(4, 1fr)' }, gap: 2.5, mb: 6 }}>
-          {isLoading ? (
-            [1, 2, 3, 4].map((i) => <StatCardSkeleton key={i} />)
-          ) : (
-            <>
-              <StatCard label="TOTAL TENANTS" value={String(tenants?.length ?? 0)} sub={`${activeTenants} active`} />
-              <StatCard label="TOTAL REVENUE" value={formatCurrency(totalRevenue)} />
-              <StatCard label="TOTAL CUSTOMERS" value={String(customers?.length ?? 0)} />
-              <StatCard label="TOTAL PAYMENTS" value={String(payments?.length ?? 0)} />
-            </>
-          )}
-        </Box>
+        <Tabs
+          value={tab}
+          onChange={(_, v) => setTab(v)}
+          sx={{ mb: 3, borderBottom: '1px solid', borderColor: 'divider' }}
+        >
+          <Tab label="Overview" />
+          <Tab label="Users" />
+        </Tabs>
+
+        {tab === 0 && (
+          <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', sm: 'repeat(2, 1fr)', md: 'repeat(4, 1fr)' }, gap: 2.5, mb: 6 }}>
+            {isLoading ? (
+              [1, 2, 3, 4].map((i) => <StatCardSkeleton key={i} />)
+            ) : (
+              <>
+                <StatCard label="TOTAL TENANTS" value={String(tenants?.length ?? 0)} sub={`${activeTenants} active`} />
+                <StatCard label="TOTAL REVENUE" value={formatCurrency(totalRevenue)} />
+                <StatCard label="TOTAL CUSTOMERS" value={String(customers?.length ?? 0)} />
+                <StatCard label="TOTAL PAYMENTS" value={String(payments?.length ?? 0)} />
+              </>
+            )}
+          </Box>
+        )}
+
+        {tab === 1 && <UserManagement />}
       </motion.div>
     </Container>
   );

--- a/frontend/src/pages/admin/UserManagement.tsx
+++ b/frontend/src/pages/admin/UserManagement.tsx
@@ -1,0 +1,97 @@
+import { Box, MenuItem, Select, Typography } from '@mui/material';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { usersApi, type AdminUser } from '@api/users.api';
+import type { Role } from '@api/types';
+import RoleBadge from '@components/layout/RoleBadge';
+import DataTable, { type Column } from '@components/data-display/DataTable';
+import { TableSkeleton } from '@components/feedback/LoadingSkeleton';
+import { useUIStore } from '@stores/ui.store';
+import { useAuthStore } from '@stores/auth.store';
+
+const USERS_KEY = ['admin-users'] as const;
+
+export default function UserManagement() {
+  const qc = useQueryClient();
+  const addToast = useUIStore((s) => s.addToast);
+  const currentEmail = useAuthStore((s) => s.email);
+
+  const { data, isLoading } = useQuery({
+    queryKey: USERS_KEY,
+    queryFn: () => usersApi.list(0, 50),
+    staleTime: 60_000,
+  });
+
+  const mutate = useMutation({
+    mutationFn: ({ id, role }: { id: number; role: Role }) => usersApi.updateRole(id, role),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: USERS_KEY });
+      addToast({ message: 'Role updated', variant: 'success' });
+    },
+    onError: () => addToast({ message: 'Failed to update role', variant: 'error' }),
+  });
+
+  const columns: Column<AdminUser>[] = [
+    {
+      key: 'email',
+      label: 'Email',
+      render: (r) => <Typography variant="body2" sx={{ fontWeight: 500 }}>{r.email}</Typography>,
+    },
+    {
+      key: 'name',
+      label: 'Name',
+      render: (r) => (
+        <Typography variant="body2" color="text.secondary">
+          {r.firstname} {r.lastname}
+        </Typography>
+      ),
+    },
+    {
+      key: 'tenantId',
+      label: 'Tenant',
+      render: (r) => (
+        <Typography variant="caption" sx={{ fontFamily: 'var(--font-mono)', color: 'text.secondary' }}>
+          {r.tenantId}
+        </Typography>
+      ),
+    },
+    {
+      key: 'role',
+      label: 'Role',
+      render: (r) => <RoleBadge role={r.role} />,
+    },
+    {
+      key: 'change',
+      label: 'Change',
+      render: (r) => (
+        <Select
+          size="small"
+          value={r.role}
+          disabled={r.email === currentEmail || mutate.isPending}
+          onChange={(e) => mutate.mutate({ id: r.id, role: e.target.value as Role })}
+          sx={{ minWidth: 120, fontFamily: 'var(--font-mono)', fontSize: '0.75rem' }}
+        >
+          <MenuItem value="USER">USER</MenuItem>
+          <MenuItem value="SELLER">SELLER</MenuItem>
+          <MenuItem value="ADMIN">ADMIN</MenuItem>
+        </Select>
+      ),
+    },
+  ];
+
+  if (isLoading) {
+    return (
+      <Box sx={{ mt: 3 }}>
+        <TableSkeleton rows={6} cols={5} />
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ mt: 2 }}>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+        Promote or demote platform users. Your own account cannot be changed here.
+      </Typography>
+      <DataTable columns={columns} rows={data?.content ?? []} />
+    </Box>
+  );
+}

--- a/notification-service/src/main/java/code/with/vanilson/notification/NotificationApplication.java
+++ b/notification-service/src/main/java/code/with/vanilson/notification/NotificationApplication.java
@@ -6,7 +6,7 @@ import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
 
-@SpringBootApplication(exclude = {DataSourceAutoConfiguration.class, MongoAutoConfiguration.class, UserDetailsServiceAutoConfiguration.class})
+@SpringBootApplication(exclude = {DataSourceAutoConfiguration.class, UserDetailsServiceAutoConfiguration.class})
 public class NotificationApplication {
     public static void main(String[] args) {
         SpringApplication.run(NotificationApplication.class, args);

--- a/notification-service/src/main/resources/application.yml
+++ b/notification-service/src/main/resources/application.yml
@@ -5,9 +5,4 @@ spring:
     name: notification-service
   data:
     mongodb:
-      uri: mongodb+srv://${data.mongodb.username}:${data.mongodb.password}@dev.4ezbsq2.mongodb.net/notification_service_db
-
-data:
-  mongodb:
-    username: ${MONGODB_USERNAME}
-    password: ${MONGODB_PASSWORD}
+      uri: mongodb://${MONGO_USERNAME:vanilson}:${MONGO_PASSWORD:vanilson}@${MONGO_HOST:localhost}:27017/notification_db?authSource=admin

--- a/order-service/src/test/resources/application.properties
+++ b/order-service/src/test/resources/application.properties
@@ -1,0 +1,3 @@
+spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration
+spring.config.import=
+spring.cloud.config.enabled=false

--- a/payment-service/src/test/resources/application.properties
+++ b/payment-service/src/test/resources/application.properties
@@ -1,0 +1,3 @@
+spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration
+spring.config.import=
+spring.cloud.config.enabled=false

--- a/product-service/src/main/resources/db/migration/product/postgres/V6__insert_catalog_products.sql
+++ b/product-service/src/main/resources/db/migration/product/postgres/V6__insert_catalog_products.sql
@@ -1,0 +1,193 @@
+-- =============================================================================
+-- V6 — Seed the public electronics/hardware catalog so a user that just
+-- registered + logged in already sees a populated product list.
+--
+-- All rows belong to 'default-tenant' (matches V4 backfill) and are stamped
+-- with created_by='system' (matches V5 NOT NULL constraint).
+--
+-- Organization follows the 11 top-level groups: Peripherals, Accessories,
+-- Gaming, Office, Networking, Hardware (PC Components), Power, Smart Tech,
+-- Portability, Monitors/Displays, Printing.
+-- =============================================================================
+
+-- =========================================================================
+-- 1) Categories — insert the ones missing from V2 (Keyboards / Monitors /
+--    Screens / Mice / Accessories already exist). ON CONFLICT keeps V6
+--    re-runnable if a category was added manually.
+-- =========================================================================
+INSERT INTO category (id, description, name, tenant_id) VALUES
+    (nextval('category_seq'), 'Headsets, microphones and speakers',            'Audio',             'default-tenant'),
+    (nextval('category_seq'), 'Webcams, ring lights and streaming gear',       'Video & Streaming', 'default-tenant'),
+    (nextval('category_seq'), 'Hubs, adapters, docks and cables',              'Connectivity',      'default-tenant'),
+    (nextval('category_seq'), 'SSDs, HDDs, pen drives and memory cards',       'Storage',           'default-tenant'),
+    (nextval('category_seq'), 'Mousepads, stands and cable organizers',        'Desk Setup',        'default-tenant'),
+    (nextval('category_seq'), 'Gaming chairs, controllers, RGB and extras',    'Gaming Gear',       'default-tenant'),
+    (nextval('category_seq'), 'Office combos, printers, scanners and mics',    'Office Equipment',  'default-tenant'),
+    (nextval('category_seq'), 'Routers, extenders and switches',               'Networking',        'default-tenant'),
+    (nextval('category_seq'), 'RAM, GPU, CPU, motherboards, PSU and coolers',  'PC Components',     'default-tenant'),
+    (nextval('category_seq'), 'Chargers, powerbanks and UPS',                  'Power',             'default-tenant'),
+    (nextval('category_seq'), 'Smartwatches, smart lamps and smart-home gear', 'Smart Tech',        'default-tenant'),
+    (nextval('category_seq'), 'Backpacks, bags and foldable stands',           'Portability',       'default-tenant'),
+    (nextval('category_seq'), 'Ink, toner and specialty paper',                'Printing',          'default-tenant')
+ON CONFLICT (name) DO NOTHING;
+
+-- =========================================================================
+-- 2) Peripherals — Keyboards
+-- =========================================================================
+INSERT INTO product (id, available_quantity, description, name, price, category_id, tenant_id, created_by) VALUES
+    (nextval('product_seq'), 40, 'Full-size mechanical keyboard, blue switches, aluminium frame',   'Obsidian MX Pro Mechanical Keyboard', 139.99, (SELECT id FROM category WHERE name = 'Keyboards'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 35, 'Per-key RGB mechanical gaming keyboard with 1ms polling',         'Neon Strike RGB Gaming Keyboard',     169.99, (SELECT id FROM category WHERE name = 'Keyboards'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 30, '2.4GHz and Bluetooth wireless low-profile keyboard',              'AirType Wireless Keyboard',           119.99, (SELECT id FROM category WHERE name = 'Keyboards'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 25, 'Split ergonomic keyboard with tented design and wrist rest',      'ErgoSplit Ergonomic Keyboard',        189.99, (SELECT id FROM category WHERE name = 'Keyboards'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 45, '75 percent compact hot-swappable keyboard, PBT keycaps',          'Pebble 75 Compact Keyboard',          129.99, (SELECT id FROM category WHERE name = 'Keyboards'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 50, '60 percent ultra-compact keyboard for minimal desk setups',       'Pebble 60 Mini Keyboard',             109.99, (SELECT id FROM category WHERE name = 'Keyboards'), 'default-tenant', 'system');
+
+-- =========================================================================
+-- 3) Peripherals — Mice
+-- =========================================================================
+INSERT INTO product (id, available_quantity, description, name, price, category_id, tenant_id, created_by) VALUES
+    (nextval('product_seq'), 60, '26K DPI optical gaming mouse with 8 programmable buttons',        'Raven X Gaming Mouse',            79.99, (SELECT id FROM category WHERE name = 'Mice'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 55, 'Silent-click wireless mouse with 90-hour battery life',           'WhisperGlide Wireless Mouse',     49.99, (SELECT id FROM category WHERE name = 'Mice'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 40, 'Vertical ergonomic mouse to reduce wrist strain',                 'ErgoVert Ergonomic Mouse',        59.99, (SELECT id FROM category WHERE name = 'Mice'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 45, '58g ultra-light honeycomb-shell esports mouse',                   'FeatherLite Ultra-Light Mouse',   69.99, (SELECT id FROM category WHERE name = 'Mice'), 'default-tenant', 'system');
+
+-- =========================================================================
+-- 4) Peripherals — Audio
+-- =========================================================================
+INSERT INTO product (id, available_quantity, description, name, price, category_id, tenant_id, created_by) VALUES
+    (nextval('product_seq'), 30, '7.1 surround gaming headset with detachable mic',                 'Obsidian Gaming Headset 7.1',     99.99,  (SELECT id FROM category WHERE name = 'Audio'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 35, 'Bluetooth 5.3 over-ear headphones with 40h battery',              'AirPulse BT Headphones',          129.99, (SELECT id FROM category WHERE name = 'Audio'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 25, 'USB cardioid condenser microphone for podcasting',                'StudioOne USB Microphone',        89.99,  (SELECT id FROM category WHERE name = 'Audio'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 40, '2.1 desktop speaker set with subwoofer',                          'BassLine 2.1 Speakers',           74.99,  (SELECT id FROM category WHERE name = 'Audio'), 'default-tenant', 'system');
+
+-- =========================================================================
+-- 5) Peripherals — Video & Streaming
+-- =========================================================================
+INSERT INTO product (id, available_quantity, description, name, price, category_id, tenant_id, created_by) VALUES
+    (nextval('product_seq'), 35, '1080p autofocus webcam with stereo mics',                         'ClearView HD Webcam',             59.99,  (SELECT id FROM category WHERE name = 'Video & Streaming'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 25, '4K 60fps streaming webcam with privacy shutter',                  'StreamCam 4K Pro',                149.99, (SELECT id FROM category WHERE name = 'Video & Streaming'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 30, '10-inch LED ring light with phone mount and tripod',              'GlowRing Ring Light Kit',         39.99,  (SELECT id FROM category WHERE name = 'Video & Streaming'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 20, '4K HDMI capture card with USB-C passthrough',                     'CaptureLink 4K Capture Card',     119.99, (SELECT id FROM category WHERE name = 'Video & Streaming'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 45, 'Adjustable aluminium desktop tripod for webcam or phone',         'FlexiStand Desk Tripod',          24.99,  (SELECT id FROM category WHERE name = 'Video & Streaming'), 'default-tenant', 'system');
+
+-- =========================================================================
+-- 6) Accessories — Connectivity
+-- =========================================================================
+INSERT INTO product (id, available_quantity, description, name, price, category_id, tenant_id, created_by) VALUES
+    (nextval('product_seq'), 80, '7-in-1 USB-C hub with HDMI, SD and 100W PD pass-through',         'PortMaster 7-in-1 USB-C Hub',     49.99,  (SELECT id FROM category WHERE name = 'Connectivity'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 100,'USB-C to HDMI 4K 60Hz adapter',                                   'LinkUp USB-C to HDMI Adapter',    19.99,  (SELECT id FROM category WHERE name = 'Connectivity'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 20, 'Triple-display Thunderbolt 4 docking station',                    'DockStation TB4 Pro',             229.99, (SELECT id FROM category WHERE name = 'Connectivity'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 150,'2m braided HDMI 2.1 cable, 8K @60Hz',                             'BraidLine HDMI 2.1 Cable 2m',     12.99,  (SELECT id FROM category WHERE name = 'Connectivity'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 150,'1m USB-C to USB-C fast charging cable, 100W',                     'BraidLine USB-C Cable 100W',      9.99,   (SELECT id FROM category WHERE name = 'Connectivity'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 120,'3m Cat 6a shielded Ethernet cable',                               'NetLink Cat6a Ethernet 3m',       8.99,   (SELECT id FROM category WHERE name = 'Connectivity'), 'default-tenant', 'system');
+
+-- =========================================================================
+-- 7) Accessories — Storage
+-- =========================================================================
+INSERT INTO product (id, available_quantity, description, name, price, category_id, tenant_id, created_by) VALUES
+    (nextval('product_seq'), 40, '1TB internal SATA SSD, 560MB/s read',                             'VaultDisk 1TB Internal SSD',      69.99,  (SELECT id FROM category WHERE name = 'Storage'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 30, '1TB portable USB 3.2 external SSD',                               'PocketVault 1TB External SSD',    109.99, (SELECT id FROM category WHERE name = 'Storage'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 35, '4TB USB-C external hard drive',                                   'ArchiveOne 4TB External HDD',     99.99,  (SELECT id FROM category WHERE name = 'Storage'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 120,'128GB USB 3.2 pen drive, metal body',                             'Carbon 128GB Pen Drive',          14.99,  (SELECT id FROM category WHERE name = 'Storage'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 100,'256GB microSD UHS-I V30 card with adapter',                       'MicroVault 256GB SD Card',        29.99,  (SELECT id FROM category WHERE name = 'Storage'), 'default-tenant', 'system');
+
+-- =========================================================================
+-- 8) Accessories — Desk Setup
+-- =========================================================================
+INSERT INTO product (id, available_quantity, description, name, price, category_id, tenant_id, created_by) VALUES
+    (nextval('product_seq'), 80, 'XL cloth desk mat with stitched edges, 900x400mm',                'DeskShield XL Mousepad',          19.99, (SELECT id FROM category WHERE name = 'Desk Setup'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 60, 'RGB gaming mousepad with 14 lighting modes, 800x300mm',           'NeonDesk RGB Mousepad',           34.99, (SELECT id FROM category WHERE name = 'Desk Setup'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 50, 'Aluminium ventilated laptop stand, 6 angles',                     'AirLift Laptop Stand',            29.99, (SELECT id FROM category WHERE name = 'Desk Setup'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 40, 'Single-arm gas-spring monitor mount, VESA 75/100',                'SkyArm Monitor Stand',            59.99, (SELECT id FROM category WHERE name = 'Desk Setup'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 100,'Under-desk cable management tray with Velcro straps',             'TidyRoute Cable Organizer',       17.99, (SELECT id FROM category WHERE name = 'Desk Setup'), 'default-tenant', 'system');
+
+-- =========================================================================
+-- 9) Gaming — Gear
+-- =========================================================================
+INSERT INTO product (id, available_quantity, description, name, price, category_id, tenant_id, created_by) VALUES
+    (nextval('product_seq'), 30, 'Wireless keyboard and mouse gaming combo',                        'Raven Combo Wireless Gaming Set', 129.99, (SELECT id FROM category WHERE name = 'Gaming Gear'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 15, 'High-back ergonomic gaming chair with lumbar support',            'ThroneRX Gaming Chair',           299.99, (SELECT id FROM category WHERE name = 'Gaming Gear'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 40, 'Wireless gamepad with Hall-effect sticks',                        'Storm Wireless Controller',       64.99,  (SELECT id FROM category WHERE name = 'Gaming Gear'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 25, 'XXL desk mat 900x400mm, water-resistant surface',                 'Arena XXL Gaming Mat',            39.99,  (SELECT id FROM category WHERE name = 'Gaming Gear'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 50, 'Blue-light filter gaming glasses, anti-glare',                    'NightVision Gaming Glasses',      29.99,  (SELECT id FROM category WHERE name = 'Gaming Gear'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 45, 'Laptop cooling pad with 5 silent fans',                           'CoolBase Laptop Cooling Pad',     34.99,  (SELECT id FROM category WHERE name = 'Gaming Gear'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 35, 'Dual headset stand with USB-A and 3.5mm jack',                    'DoubleHook Headset Stand',        24.99,  (SELECT id FROM category WHERE name = 'Gaming Gear'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 60, '5m RGB LED strip kit with remote and app control',                'GlowEdge RGB LED Strip 5m',       22.99,  (SELECT id FROM category WHERE name = 'Gaming Gear'), 'default-tenant', 'system');
+
+-- =========================================================================
+-- 10) Office / Productivity
+-- =========================================================================
+INSERT INTO product (id, available_quantity, description, name, price, category_id, tenant_id, created_by) VALUES
+    (nextval('product_seq'), 40, 'Wireless keyboard + mouse office combo, silent keys',             'OfficeDuo Wireless Combo',        59.99,  (SELECT id FROM category WHERE name = 'Office Equipment'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 30, '1080p meeting webcam with 110-degree FOV and AI framing',         'MeetCam Pro Webcam',              89.99,  (SELECT id FROM category WHERE name = 'Office Equipment'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 20, 'XLR broadcast microphone for studio and podcasts',                'StudioCast XLR Microphone',       199.99, (SELECT id FROM category WHERE name = 'Office Equipment'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 15, 'All-in-one colour inkjet printer with Wi-Fi',                     'InkFlow AIO Colour Printer',      159.99, (SELECT id FROM category WHERE name = 'Office Equipment'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 18, 'Flatbed A4 document scanner with ADF',                            'PageScan A4 Document Scanner',    189.99, (SELECT id FROM category WHERE name = 'Office Equipment'), 'default-tenant', 'system');
+
+-- =========================================================================
+-- 11) Networking / Internet
+-- =========================================================================
+INSERT INTO product (id, available_quantity, description, name, price, category_id, tenant_id, created_by) VALUES
+    (nextval('product_seq'), 25, 'Wi-Fi 6 dual-band AX3000 router, 1GbE WAN',                       'MeshLink AX3000 Wi-Fi 6 Router',  129.99, (SELECT id FROM category WHERE name = 'Networking'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 40, 'Wi-Fi 6 dual-band range extender, wall-plug',                     'MeshLink AX1800 Extender',        59.99,  (SELECT id FROM category WHERE name = 'Networking'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 30, 'PCIe Wi-Fi 6 + Bluetooth 5.2 network card',                       'PulseWave PCIe Wi-Fi 6 Card',     44.99,  (SELECT id FROM category WHERE name = 'Networking'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 35, '8-port gigabit desktop Ethernet switch',                          'SwitchBox 8-Port Gigabit Switch', 39.99,  (SELECT id FROM category WHERE name = 'Networking'), 'default-tenant', 'system');
+
+-- =========================================================================
+-- 12) Hardware — PC Components
+-- =========================================================================
+INSERT INTO product (id, available_quantity, description, name, price, category_id, tenant_id, created_by) VALUES
+    (nextval('product_seq'), 50, '32GB (2x16) DDR5-6000 CL36 desktop RAM kit',                      'PulseRAM DDR5-6000 32GB Kit',     149.99,  (SELECT id FROM category WHERE name = 'PC Components'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 40, '2TB NVMe PCIe 4.0 SSD, 7000MB/s read',                            'BlazeDisk 2TB NVMe Gen4 SSD',     199.99,  (SELECT id FROM category WHERE name = 'PC Components'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 10, '16GB GDDR6X gaming graphics card, ray-tracing',                   'PhantomCore RTX 16GB GPU',        899.99,  (SELECT id FROM category WHERE name = 'PC Components'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 18, '8-core 16-thread desktop CPU with unlocked multiplier',           'Apex 8-Core Desktop CPU',         379.99,  (SELECT id FROM category WHERE name = 'PC Components'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 20, 'ATX DDR5 motherboard with Wi-Fi 6E and 3x M.2',                   'ForgeBoard ATX DDR5 Motherboard', 249.99,  (SELECT id FROM category WHERE name = 'PC Components'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 25, '850W 80 Plus Gold fully-modular PSU',                             'VoltCore 850W Gold PSU',          129.99,  (SELECT id FROM category WHERE name = 'PC Components'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 30, '240mm AIO liquid CPU cooler with ARGB pump',                      'IceLoop 240 AIO Liquid Cooler',   109.99,  (SELECT id FROM category WHERE name = 'PC Components'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 35, 'Dual-tower air CPU cooler with 2 quiet fans',                     'TwinPeak Air CPU Cooler',         79.99,   (SELECT id FROM category WHERE name = 'PC Components'), 'default-tenant', 'system');
+
+-- =========================================================================
+-- 13) Power
+-- =========================================================================
+INSERT INTO product (id, available_quantity, description, name, price, category_id, tenant_id, created_by) VALUES
+    (nextval('product_seq'), 60, '65W GaN USB-C fast charger, 3 ports',                             'ChargeCube 65W GaN Charger',      39.99,  (SELECT id FROM category WHERE name = 'Power'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 50, '20000 mAh 65W laptop-capable powerbank',                          'JuicePack 20K 65W Powerbank',     69.99,  (SELECT id FROM category WHERE name = 'Power'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 40, '3-in-1 wireless charging base for phone, watch, earbuds',         'TriCharge 3-in-1 Wireless Base',  49.99,  (SELECT id FROM category WHERE name = 'Power'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 15, '1500VA line-interactive UPS for home office',                     'GuardPower 1500VA UPS',           199.99, (SELECT id FROM category WHERE name = 'Power'), 'default-tenant', 'system');
+
+-- =========================================================================
+-- 14) Smart Tech / Gadgets
+-- =========================================================================
+INSERT INTO product (id, available_quantity, description, name, price, category_id, tenant_id, created_by) VALUES
+    (nextval('product_seq'), 30, 'AMOLED smartwatch with GPS and heart-rate sensor',                'Pulse Fit AMOLED Smartwatch',     189.99, (SELECT id FROM category WHERE name = 'Smart Tech'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 70, '15W Qi fast wireless charging pad',                               'Halo 15W Wireless Charger',       24.99,  (SELECT id FROM category WHERE name = 'Smart Tech'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 45, 'Smart RGB Wi-Fi light bulb, 16M colours',                         'LumenCast Smart Bulb',            14.99,  (SELECT id FROM category WHERE name = 'Smart Tech'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 35, 'Voice-assistant smart speaker with far-field mics',               'EchoPoint Smart Assistant',       59.99,  (SELECT id FROM category WHERE name = 'Smart Tech'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 50, 'Zigbee smart home door and window sensor, 2-pack',                'GuardSense Smart Door Sensor',    27.99,  (SELECT id FROM category WHERE name = 'Smart Tech'), 'default-tenant', 'system');
+
+-- =========================================================================
+-- 15) Portability
+-- =========================================================================
+INSERT INTO product (id, available_quantity, description, name, price, category_id, tenant_id, created_by) VALUES
+    (nextval('product_seq'), 40, 'Water-resistant 17-inch laptop backpack with USB port',           'TrekPack 17 Laptop Backpack',     59.99,  (SELECT id FROM category WHERE name = 'Portability'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 50, 'Slim 15-inch laptop shoulder bag with padded sleeve',             'SlimCarry 15 Laptop Bag',         39.99,  (SELECT id FROM category WHERE name = 'Portability'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 80, 'Hard shell protective case for 14-inch laptops',                  'ShellGuard 14 Laptop Case',       24.99,  (SELECT id FROM category WHERE name = 'Portability'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 60, 'Foldable aluminium tablet and phone stand',                       'FoldUp Portable Stand',           17.99,  (SELECT id FROM category WHERE name = 'Portability'), 'default-tenant', 'system');
+
+-- =========================================================================
+-- 16) Monitors / Displays
+-- =========================================================================
+INSERT INTO product (id, available_quantity, description, name, price, category_id, tenant_id, created_by) VALUES
+    (nextval('product_seq'), 20, '27-inch QHD 240Hz IPS gaming monitor, 1ms',                       'Apex 27 QHD 240Hz Gaming Monitor', 449.99, (SELECT id FROM category WHERE name = 'Monitors'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 15, '34-inch WQHD ultrawide 144Hz curved monitor',                     'Vista 34 Ultrawide 144Hz',         599.99, (SELECT id FROM category WHERE name = 'Monitors'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 18, '32-inch 4K UHD creator monitor, 98 percent DCI-P3',               'ArtPanel 32 4K Creator Monitor',   529.99, (SELECT id FROM category WHERE name = 'Monitors'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 60, 'Full-motion VESA dual-monitor desk mount',                        'DualArm VESA Desk Mount',          79.99,  (SELECT id FROM category WHERE name = 'Monitors'), 'default-tenant', 'system');
+
+-- =========================================================================
+-- 17) Printing
+-- =========================================================================
+INSERT INTO product (id, available_quantity, description, name, price, category_id, tenant_id, created_by) VALUES
+    (nextval('product_seq'), 20, 'Colour laser printer with duplex and Wi-Fi',                      'LaserPrint Colour Laser Printer', 289.99, (SELECT id FROM category WHERE name = 'Printing'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 120,'Tri-colour ink cartridge multipack',                              'PurePrint Tri-Colour Ink Pack',   49.99,  (SELECT id FROM category WHERE name = 'Printing'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 80, 'High-yield black toner cartridge, 3000 pages',                    'ToneCore Black Toner 3K',         79.99,  (SELECT id FROM category WHERE name = 'Printing'), 'default-tenant', 'system'),
+    (nextval('product_seq'), 200,'A4 premium matte photo paper, 50 sheets',                         'PhotoMatte A4 Premium Paper',     14.99,  (SELECT id FROM category WHERE name = 'Printing'), 'default-tenant', 'system');

--- a/product-service/src/test/resources/application.properties
+++ b/product-service/src/test/resources/application.properties
@@ -1,0 +1,3 @@
+spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration
+spring.config.import=
+spring.cloud.config.enabled=false

--- a/tenant-context/src/main/java/code/with/vanilson/tenantcontext/TenantContextAutoConfiguration.java
+++ b/tenant-context/src/main/java/code/with/vanilson/tenantcontext/TenantContextAutoConfiguration.java
@@ -55,13 +55,23 @@ public class TenantContextAutoConfiguration implements WebMvcConfigurer {
     }
 
     /**
-     * Hibernate filter configuration loaded ONLY when JPA is on the classpath.
-     * Isolated in a nested class to prevent NoClassDefFoundError in services
-     * that don't use JPA (e.g. cart-service with Redis).
+     * Hibernate filter configuration loaded ONLY when Hibernate ORM is on the classpath.
+     * <p>
+     * We key off {@code org.hibernate.Session} (shipped by hibernate-core) rather than
+     * {@code jakarta.persistence.EntityManagerFactory}. The latter is present in services
+     * that only pull {@code jakarta.persistence-api} (e.g. customer-service uses it for
+     * stray annotations but has no JPA starter), leading to activation without a real
+     * {@code EntityManager} bean. hibernate-core is only present where spring-boot-starter-data-jpa
+     * is declared, so this is a precise "JPA is actually wired" signal.
+     * <p>
+     * We do NOT use {@code @ConditionalOnBean(EntityManagerFactory.class)} here because
+     * condition evaluation on nested configuration classes runs during configuration parsing,
+     * before {@code HibernateJpaAutoConfiguration} registers the bean — causing the config
+     * to be skipped even in JPA services.
      */
     @Slf4j
     @Configuration
-    @ConditionalOnClass(name = "jakarta.persistence.EntityManager")
+    @ConditionalOnClass(name = "org.hibernate.Session")
     static class HibernateTenantFilterConfig {
 
         @Bean

--- a/tenant-context/src/main/java/code/with/vanilson/tenantcontext/security/JwtTokenValidator.java
+++ b/tenant-context/src/main/java/code/with/vanilson/tenantcontext/security/JwtTokenValidator.java
@@ -15,8 +15,15 @@ public class JwtTokenValidator {
 
     private final SecretKey signingKey;
 
-    public JwtTokenValidator(@Value("${application.security.jwt.secret-key}") String secretKeyBase64) {
-        this.signingKey = Keys.hmacShaKeyFor(Base64.getDecoder().decode(secretKeyBase64));
+    public JwtTokenValidator(@Value("${application.security.jwt.secret-key:}") String secretKeyBase64) {
+        if (secretKeyBase64 == null || secretKeyBase64.isBlank() || secretKeyBase64.startsWith("${")) {
+            throw new IllegalArgumentException("JWT secret key must be provided and must not be a placeholder. Check 'application.security.jwt.secret-key' property.");
+        }
+        try {
+            this.signingKey = Keys.hmacShaKeyFor(Base64.getDecoder().decode(secretKeyBase64));
+        } catch (IllegalArgumentException | SecurityException e) {
+            throw new IllegalArgumentException("Invalid JWT secret key format. Must be Base64-encoded and at least 256 bits.", e);
+        }
     }
 
     public JwtClaims validate(String token) {

--- a/tenant-service/src/test/resources/application.properties
+++ b/tenant-service/src/test/resources/application.properties
@@ -1,0 +1,3 @@
+spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration
+spring.config.import=
+spring.cloud.config.enabled=false


### PR DESCRIPTION
 What I got wrong before
                                                                                                                                               
  For the customer-service issue, I added @ConditionalOnBean(name = "entityManagerFactory") to the tenant-context auto-config. This has a 
  timing bug: @ConditionalOnBean on a nested @Configuration class evaluates during configuration parsing, before HibernateJpaAutoConfiguration
  registers entityManagerFactory. So the guard skipped even in JPA services → order-service lost TenantHibernateFilterActivator → startup      
  failed.

  The real fix (now applied)

  TenantContextAutoConfiguration$HibernateTenantFilterConfig now uses @ConditionalOnClass(name = "org.hibernate.Session"). Class-based,        
  classpath-time, no timing hazard.

  Verified matrix (via unzip -l ...jar):
  - hibernate-core present → auth, order, payment, product, tenant → filter activates ✓
  - hibernate-core absent → cart, customer, notification → filter skipped ✓

  Systemic audit — Redis timeouts

  While I was in there, I grepped every config for the same problem I fixed on cart-service. Found 3 more services with timeout: 2000ms (no    
  connect-timeout):
  - customer-service.yml — fixed
  - gateway-service.yml — fixed
  - product-service.yml — fixed

  All now use connect-timeout: 10s + timeout: 10s, same as cart.

  Files changed this round

  1. tenant-context/.../TenantContextAutoConfiguration.java — condition now org.hibernate.Session
  2. config-service/.../customer-service.yml — Redis timeouts
  3. config-service/.../gateway-service.yml — Redis timeouts
  4. config-service/.../product-service.yml — Redis timeouts

  To apply

  # Rebuild the one shared jar
  mvn -DskipTests -pl tenant-context install

  # Rebuild & redeploy services that consume tenant-context
  docker-compose build order-service customer-service payment-service product-service tenant-service authentication-service
  docker-compose restart config-service order-service customer-service payment-service product-service tenant-service authentication-service   
  gateway-api-service cart-service

  Why this kept recurring

  Two separate root-cause patterns were conflated:
  - JPA detection: the condition was checking a class (jakarta.persistence-api) that customer-service pulls transitively without actually using
   JPA. Any class-presence check that isn't strict about "real Hibernate" will misfire.
  - Redis startup timing: the 2s budget is inherited from some tutorial; in Docker with password AUTH on first connect it's not enough, but the
   symptom is hidden behind a confusing <unresolved> log line that looks like a DNS bug.