### PR TITLE
feat: Applied the Redis serializer fix in CustomerServiceConfig.java …

### DIFF
--- a/config-service/src/main/resources/configurations/gateway-service.yml
+++ b/config-service/src/main/resources/configurations/gateway-service.yml
@@ -175,6 +175,30 @@ spring:
                   factor: 2
 
         # -------------------------------------------------------
+        # TENANT SERVICE — admin-only tenant management
+        # -------------------------------------------------------
+        - id: tenant-service
+          uri: lb://TENANT-SERVICE
+          predicates:
+            - Path=/api/v1/tenants/**
+          filters:
+            - AddResponseHeader=API-Version, v1
+            - AddResponseHeader=Sunset, TBD
+            - name: CircuitBreaker
+              args:
+                name: tenant-cb
+                fallbackUri: forward:/fallback/tenants
+            - name: Retry
+              args:
+                retries: 1
+                statuses: BAD_GATEWAY,SERVICE_UNAVAILABLE
+                methods: GET
+                backoff:
+                  firstBackoff: 200ms
+                  maxBackoff: 1000ms
+                  factor: 2
+
+        # -------------------------------------------------------
         # PAYMENT SERVICE — stricter rate limits (financial endpoint)
         # -------------------------------------------------------
         - id: payment-service
@@ -243,6 +267,13 @@ resilience4j:
         permitted-number-of-calls-in-half-open-state: 2
         slow-call-rate-threshold: 70
         slow-call-duration-threshold: 5s
+      tenant-cb:
+        sliding-window-size: 10
+        failure-rate-threshold: 50
+        wait-duration-in-open-state: 30s
+        permitted-number-of-calls-in-half-open-state: 3
+        slow-call-rate-threshold: 80
+        slow-call-duration-threshold: 3s
 
 # -------------------------------------------------------
 # Gateway custom properties

--- a/customer-service/src/main/java/code/with/vanilson/customerservice/CustomerService.java
+++ b/customer-service/src/main/java/code/with/vanilson/customerservice/CustomerService.java
@@ -59,7 +59,7 @@ public class CustomerService {
     /**
      * Returns all customers, cached for 10 minutes.
      */
-    @Cacheable(CACHE_CUSTOMER_LIST)
+    @Cacheable(value = CACHE_CUSTOMER_LIST, unless = "#result == null || #result.isEmpty()")
     public List<CustomerResponse> findAllCustomers() {
         List<CustomerResponse> customers = customerRepository.findAll()
                 .stream()

--- a/customer-service/src/main/java/code/with/vanilson/customerservice/config/CustomerServiceConfig.java
+++ b/customer-service/src/main/java/code/with/vanilson/customerservice/config/CustomerServiceConfig.java
@@ -1,9 +1,16 @@
 package code.with.vanilson.customerservice.config;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Contact;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.beans.factory.InitializingBean;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.MessageSource;
 import org.springframework.context.annotation.Bean;
@@ -12,6 +19,7 @@ import org.springframework.context.support.ResourceBundleMessageSource;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 
@@ -56,10 +64,31 @@ public class CustomerServiceConfig {
                 .disableCachingNullValues()
                 .serializeValuesWith(
                         RedisSerializationContext.SerializationPair.fromSerializer(
-                                new GenericJackson2JsonRedisSerializer()));
+                                buildRedisSerializer()));
         return RedisCacheManager.builder(factory)
                 .cacheDefaults(config)
                 .build();
+    }
+
+    private GenericJackson2JsonRedisSerializer buildRedisSerializer() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        mapper.activateDefaultTyping(
+                BasicPolymorphicTypeValidator.builder().allowIfBaseType(Object.class).build(),
+                ObjectMapper.DefaultTyping.NON_FINAL,
+                JsonTypeInfo.As.PROPERTY
+        );
+        return new GenericJackson2JsonRedisSerializer(mapper);
+    }
+
+    @Bean
+    public InitializingBean flushStaleCustomerCache(StringRedisTemplate redisTemplate) {
+        return () -> {
+            var keys = redisTemplate.keys("customer*");
+            if (keys != null && !keys.isEmpty()) redisTemplate.delete(keys);
+        };
     }
 
     @Bean

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -528,7 +528,7 @@ services:
       discovery-service:
         condition: service_healthy
     environment:
-      JAVA_TOOL_OPTIONS: "-Xms64m -Xmx256m -XX:MaxMetaspaceSize=96m -XX:+UseSerialGC"
+      JAVA_TOOL_OPTIONS: "-Xms128m -Xmx384m -XX:MaxMetaspaceSize=192m -XX:+UseG1GC"
       SPRING_CONFIG_IMPORT: optional:configserver:http://config-service:8888
       SPRING_CLOUD_CONFIG_USERNAME: config
       SPRING_CLOUD_CONFIG_PASSWORD: ${CONFIG_SERVER_PASSWORD:-config-secret-2024}

--- a/frontend/src/pages/customer/DashboardPage.tsx
+++ b/frontend/src/pages/customer/DashboardPage.tsx
@@ -43,6 +43,8 @@ export default function DashboardPage() {
     queryKey: [QUERY_KEYS.ORDERS],
     queryFn: ordersApi.getAll,
     staleTime: 30 * 1000,
+    retry: false,
+    throwOnError: false,
   });
 
   const totalSpent = orders?.reduce((s, o) => s + o.amount, 0) ?? 0;

--- a/frontend/src/pages/public/LoginPage.tsx
+++ b/frontend/src/pages/public/LoginPage.tsx
@@ -61,7 +61,12 @@ export default function LoginPage() {
         tenantId: res.tenantId,
       });
       addToast({ message: `Welcome back, ${res.email}`, variant: 'success' });
-      navigate(from, { replace: true });
+      const defaultDest =
+        res.role === 'ADMIN' ? ROUTES.ADMIN :
+        res.role === 'SELLER' ? ROUTES.SELLER :
+        ROUTES.ACCOUNT;
+      const dest = navState?.from ?? defaultDest;
+      navigate(dest, { replace: true });
     } catch (err) {
       const normalized = normalizeError(err);
       setServerError(

--- a/frontend/src/pages/public/LoginPage.tsx
+++ b/frontend/src/pages/public/LoginPage.tsx
@@ -65,7 +65,7 @@ export default function LoginPage() {
         res.role === 'ADMIN' ? ROUTES.ADMIN :
         res.role === 'SELLER' ? ROUTES.SELLER :
         ROUTES.ACCOUNT;
-      const dest = navState?.from ?? defaultDest;
+      const dest = from !== ROUTES.ACCOUNT ? from : defaultDest;
       navigate(dest, { replace: true });
     } catch (err) {
       const normalized = normalizeError(err);

--- a/frontend/src/pages/seller/SellerDashboard.tsx
+++ b/frontend/src/pages/seller/SellerDashboard.tsx
@@ -23,11 +23,15 @@ export default function SellerDashboard() {
     queryKey: [QUERY_KEYS.PRODUCTS, 0, 100],
     queryFn: () => productsApi.getAll(0, 100),
     staleTime: 2 * 60 * 1000,
+    retry: false,
+    throwOnError: false,
   });
   const { data: orders, isLoading: ordersLoading } = useQuery({
     queryKey: [QUERY_KEYS.ORDERS],
     queryFn: ordersApi.getAll,
     staleTime: 30 * 1000,
+    retry: false,
+    throwOnError: false,
   });
 
   const isLoading = productsLoading || ordersLoading;

--- a/payment-service/src/main/java/code/with/vanilson/paymentservice/domain/PaymentMethod.java
+++ b/payment-service/src/main/java/code/with/vanilson/paymentservice/domain/PaymentMethod.java
@@ -14,6 +14,7 @@ package code.with.vanilson.paymentservice.domain;
 public enum PaymentMethod {
     PAYPAL,
     CREDIT_CARD,
+    DEBIT_CARD,
     VISA,
     MASTER_CARD,
     BITCOIN


### PR DESCRIPTION
Purpose
Diagnose and fix a Redis serialization bug causing 500 errors in customer-service, then get the service healthy and running in Docker.

Current state
Done:

Applied the Redis serializer fix in CustomerServiceConfig.java — replaced bare GenericJackson2JsonRedisSerializer with a custom ObjectMapper that activates NON_FINAL polymorphic typing (@class property), matching the pattern already used in product-service.
mvn build completed successfully (run by user per workflow rule).
Docker image rebuilt and container restarted.
In flight / blocked:

customer-service container is unhealthy — the Spring Boot application context never finishes initializing after the new image is deployed.
Last log entry: MongoDB cluster connected (15:35:23). Port 8090 refuses connections. "Started CustomerApplication" never appears.
Primary suspect: flushStaleCustomerCache InitializingBean in CustomerServiceConfig.java calls redisTemplate.keys("customer*") synchronously during context startup, which may be blocking on a Redis connection.
Other uncommitted changes (not yet addressed):

docker-compose.yml, gateway-service.yml, DashboardPage.tsx, LoginPage.tsx, SellerDashboard.tsx, PaymentMethod.java
Outcome
The serialization fix is in place but the service is not yet reachable. The startup hang is blocking verification.

Next step: Ask the user to run docker logs customer-service --follow live, and confirm whether the log freezes after MongoDB connection (indicating flushStaleCustomerCache is the hang point). If confirmed, wrap the flush body in a try-catch or migrate it to an ApplicationReadyEvent listener so it runs after context initialization completes rather than during it.