### PR TITLE
feat: Gateway Circuit Breaker 

### DIFF
--- a/config-service/src/main/resources/configurations/cart-service.yml
+++ b/config-service/src/main/resources/configurations/cart-service.yml
@@ -17,9 +17,10 @@ spring:
       timeout: 10s
       lettuce:
         pool:
-          max-active: 16
-          max-idle: 8
-          min-idle: 2
+          max-active: 32
+          max-idle: 16
+          min-idle: 4
+          max-wait: 2s
 
   cache:
     type: redis
@@ -39,6 +40,9 @@ springdoc:
     path: /swagger-ui.html
 
 management:
+  health:
+    redis:
+      enabled: true
   endpoints:
     web:
       exposure:

--- a/config-service/src/main/resources/configurations/gateway-service.yml
+++ b/config-service/src/main/resources/configurations/gateway-service.yml
@@ -103,12 +103,12 @@ spring:
                 key-resolver: "#{@tenantKeyResolver}"
             - name: Retry
               args:
-                retries: 1
+                retries: 2
                 statuses: BAD_GATEWAY,SERVICE_UNAVAILABLE
-                methods: GET
+                methods: GET,POST,PATCH
                 backoff:
-                  firstBackoff: 50ms
-                  maxBackoff: 200ms
+                  firstBackoff: 100ms
+                  maxBackoff: 500ms
                   factor: 2
 
         # -------------------------------------------------------
@@ -244,8 +244,8 @@ resilience4j:
         failure-rate-threshold: 60
         wait-duration-in-open-state: 15s
         permitted-number-of-calls-in-half-open-state: 5
-        slow-call-rate-threshold: 90
-        slow-call-duration-threshold: 1s   # Redis should be < 1ms; 1s = Redis down
+        slow-call-rate-threshold: 80
+        slow-call-duration-threshold: 3s
       order-cb:
         sliding-window-size: 10
         failure-rate-threshold: 50

--- a/frontend/src/components/product/ProductGrid.test.tsx
+++ b/frontend/src/components/product/ProductGrid.test.tsx
@@ -1,0 +1,153 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@test/test-utils';
+import { server } from '@test/mocks/server';
+import { http, HttpResponse } from 'msw';
+import { useUIStore } from '@stores/ui.store';
+import { useAuthStore } from '@stores/auth.store';
+import ProductGrid from './ProductGrid';
+import type { ProductResponse } from '@api/types';
+
+const PRODUCT: ProductResponse = {
+  id: 1,
+  name: 'Obsidian Pen',
+  description: 'A premium writing instrument',
+  availableQuantity: 50,
+  price: 29.99,
+  categoryId: 1,
+  categoryName: 'Stationery',
+  categoryDescription: 'Writing essentials',
+};
+
+const CART_RESPONSE = {
+  cartId: 'cart-001',
+  customerId: 'user-001',
+  items: [],
+  total: 0,
+  itemCount: 0,
+  createdAt: '',
+  updatedAt: '',
+};
+
+describe('ProductGrid — add to cart retry', () => {
+  beforeEach(() => {
+    useAuthStore.setState({
+      isAuthenticated: true,
+      userId: 'user-001',
+      accessToken: 'mock-access-token',
+      refreshToken: null,
+      email: 'test@example.com',
+      role: 'USER',
+      tenantId: null,
+    });
+    useUIStore.setState({ toastQueue: [] });
+  });
+
+  afterEach(() => {
+    useAuthStore.getState().clearAuth();
+  });
+
+  it('shows success toast after successful add', async () => {
+    render(<ProductGrid products={[PRODUCT]} />);
+    fireEvent.click(screen.getByText('Add to cart'));
+    await waitFor(
+      () => {
+        const toasts = useUIStore.getState().toastQueue;
+        expect(toasts.some((t) => t.message === 'Item added to cart' && t.variant === 'success')).toBe(true);
+      },
+      { timeout: 3000 }
+    );
+  });
+
+  it('shows retrying toast then success when first call returns 503', async () => {
+    let callCount = 0;
+    server.use(
+      http.post('/api/v1/carts/:customerId/items', () => {
+        callCount++;
+        if (callCount === 1) {
+          return HttpResponse.json(
+            { status: 503, message: 'Service unavailable — please try again later' },
+            { status: 503 }
+          );
+        }
+        return HttpResponse.json(CART_RESPONSE);
+      })
+    );
+
+    render(<ProductGrid products={[PRODUCT]} />);
+    fireEvent.click(screen.getByText('Add to cart'));
+
+    await waitFor(
+      () => {
+        const toasts = useUIStore.getState().toastQueue;
+        expect(toasts.some((t) => t.message.includes('retrying') && t.variant === 'warning')).toBe(true);
+      },
+      { timeout: 5000 }
+    );
+
+    await waitFor(
+      () => {
+        const toasts = useUIStore.getState().toastQueue;
+        expect(toasts.some((t) => t.message === 'Item added to cart' && t.variant === 'success')).toBe(true);
+      },
+      { timeout: 5000 }
+    );
+  });
+
+  it('shows 503-specific error when all attempts return 503', async () => {
+    server.use(
+      http.post('/api/v1/carts/:customerId/items', () =>
+        HttpResponse.json(
+          { status: 503, message: 'Service unavailable — please try again later' },
+          { status: 503 }
+        )
+      )
+    );
+
+    render(<ProductGrid products={[PRODUCT]} />);
+    fireEvent.click(screen.getByText('Add to cart'));
+
+    await waitFor(
+      () => {
+        const toasts = useUIStore.getState().toastQueue;
+        expect(
+          toasts.some(
+            (t) =>
+              t.message === 'Cart service is temporarily unavailable. Please try again.' &&
+              t.variant === 'error'
+          )
+        ).toBe(true);
+      },
+      { timeout: 8000 }
+    );
+  });
+
+  it('shows generic error for non-503 failures', async () => {
+    server.use(
+      http.post('/api/v1/carts/:customerId/items', () =>
+        HttpResponse.json({ message: 'Internal server error' }, { status: 500 })
+      )
+    );
+
+    render(<ProductGrid products={[PRODUCT]} />);
+    fireEvent.click(screen.getByText('Add to cart'));
+
+    await waitFor(
+      () => {
+        const toasts = useUIStore.getState().toastQueue;
+        expect(toasts.some((t) => t.message === 'Failed to add item to cart' && t.variant === 'error')).toBe(true);
+      },
+      { timeout: 3000 }
+    );
+  });
+
+  it('renders empty state when no products provided', () => {
+    render(<ProductGrid products={[]} />);
+    expect(screen.getByText('No products found')).toBeInTheDocument();
+  });
+
+  it('renders product cards for each product', () => {
+    render(<ProductGrid products={[PRODUCT, { ...PRODUCT, id: 2, name: 'Ember Notebook' }]} />);
+    expect(screen.getByText('Obsidian Pen')).toBeInTheDocument();
+    expect(screen.getByText('Ember Notebook')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/product/ProductGrid.tsx
+++ b/frontend/src/components/product/ProductGrid.tsx
@@ -30,13 +30,13 @@ export default function ProductGrid({ products }: ProductGridProps) {
         quantity: 1,
         availableQuantity: product.availableQuantity,
       }),
-    retry: (count, error) => count <= 1 && (error as AppError).status === 503,
+    retry: (count, error) => count <= 1 && (error as unknown as AppError).status === 503,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.CART, userId] });
       addToast({ message: 'Item added to cart', variant: 'success' });
     },
     onError: (error) => {
-      const is503 = (error as AppError).status === 503;
+      const is503 = (error as unknown as AppError).status === 503;
       addToast({
         message: is503
           ? 'Cart service is temporarily unavailable. Please try again.'

--- a/frontend/src/components/product/ProductGrid.tsx
+++ b/frontend/src/components/product/ProductGrid.tsx
@@ -1,5 +1,6 @@
+import { useEffect, useRef } from 'react';
 import { Box } from '@mui/material';
-import type { ProductResponse } from '@api/types';
+import type { ProductResponse, AppError } from '@api/types';
 import ProductCard from './ProductCard';
 import EmptyState from '@components/feedback/EmptyState';
 import { useAuthStore } from '@stores/auth.store';
@@ -17,7 +18,9 @@ export default function ProductGrid({ products }: ProductGridProps) {
   const addToast = useUIStore((s) => s.addToast);
   const queryClient = useQueryClient();
 
-  const { mutate: addToCart } = useMutation({
+  const prevFailureCount = useRef(0);
+
+  const { mutate: addToCart, isPending: isAddingToCart, failureCount } = useMutation({
     mutationFn: (product: ProductResponse) =>
       cartApi.addItem(userId!, {
         productId: product.id,
@@ -27,14 +30,28 @@ export default function ProductGrid({ products }: ProductGridProps) {
         quantity: 1,
         availableQuantity: product.availableQuantity,
       }),
+    retry: (count, error) => count <= 1 && (error as AppError).status === 503,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.CART, userId] });
       addToast({ message: 'Item added to cart', variant: 'success' });
     },
-    onError: () => {
-      addToast({ message: 'Failed to add item to cart', variant: 'error' });
+    onError: (error) => {
+      const is503 = (error as AppError).status === 503;
+      addToast({
+        message: is503
+          ? 'Cart service is temporarily unavailable. Please try again.'
+          : 'Failed to add item to cart',
+        variant: 'error',
+      });
     },
   });
+
+  useEffect(() => {
+    if (failureCount === 1 && isAddingToCart && prevFailureCount.current === 0) {
+      addToast({ message: 'Cart service is busy — retrying…', variant: 'warning' });
+    }
+    prevFailureCount.current = failureCount;
+  }, [failureCount, isAddingToCart, addToast]);
 
   const handleAddToCart = (product: ProductResponse) => {
     if (!isAuthenticated || !userId) return;

--- a/frontend/src/pages/public/ProductPage.tsx
+++ b/frontend/src/pages/public/ProductPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import {
   Box,
@@ -20,6 +20,7 @@ import { QUERY_KEYS, ROUTES } from '@utils/constants';
 import { useAuthStore } from '@stores/auth.store';
 import { useUIStore } from '@stores/ui.store';
 import { formatCurrency } from '@utils/format';
+import type { AppError } from '@api/types';
 
 export default function ProductPage() {
   const { id } = useParams<{ id: string }>();
@@ -35,7 +36,9 @@ export default function ProductPage() {
     staleTime: 5 * 60 * 1000,
   });
 
-  const { mutate: addToCart, isPending } = useMutation({
+  const prevFailureCount = useRef(0);
+
+  const { mutate: addToCart, isPending, failureCount } = useMutation({
     mutationFn: () =>
       cartApi.addItem(userId!, {
         productId: product!.id,
@@ -45,14 +48,28 @@ export default function ProductPage() {
         quantity,
         availableQuantity: product!.availableQuantity,
       }),
+    retry: (count, error) => count <= 1 && (error as AppError).status === 503,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.CART, userId] });
       addToast({ message: `${product?.name} added to cart`, variant: 'success' });
     },
-    onError: () => {
-      addToast({ message: 'Failed to add to cart', variant: 'error' });
+    onError: (error) => {
+      const is503 = (error as AppError).status === 503;
+      addToast({
+        message: is503
+          ? 'Cart service is temporarily unavailable. Please try again.'
+          : 'Failed to add to cart',
+        variant: 'error',
+      });
     },
   });
+
+  useEffect(() => {
+    if (failureCount === 1 && isPending && prevFailureCount.current === 0) {
+      addToast({ message: 'Cart service is busy — retrying…', variant: 'warning' });
+    }
+    prevFailureCount.current = failureCount;
+  }, [failureCount, isPending, addToast]);
 
   if (isLoading) {
     return (
@@ -184,7 +201,11 @@ export default function ProductPage() {
                   onClick={() => addToCart()}
                   sx={{ flex: 1 }}
                 >
-                  {!isAuthenticated ? 'Sign in to purchase' : 'Add to cart'}
+                  {!isAuthenticated
+                    ? 'Sign in to purchase'
+                    : isPending && failureCount > 0
+                    ? 'Retrying…'
+                    : 'Add to cart'}
                 </Button>
               </Box>
             )}

--- a/frontend/src/pages/public/ProductPage.tsx
+++ b/frontend/src/pages/public/ProductPage.tsx
@@ -48,13 +48,13 @@ export default function ProductPage() {
         quantity,
         availableQuantity: product!.availableQuantity,
       }),
-    retry: (count, error) => count <= 1 && (error as AppError).status === 503,
+    retry: (count, error) => count <= 1 && (error as unknown as AppError).status === 503,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.CART, userId] });
       addToast({ message: `${product?.name} added to cart`, variant: 'success' });
     },
     onError: (error) => {
-      const is503 = (error as AppError).status === 503;
+      const is503 = (error as unknown as AppError).status === 503;
       addToast({
         message: is503
           ? 'Cart service is temporarily unavailable. Please try again.'


### PR DESCRIPTION
### Step 2 — Gateway Circuit Breaker (`gateway-service.yml:242–248`)
All 6 values match exactly: `sliding-window-size: 20`, `failure-rate-threshold: 60`, `wait-duration-in-open-state: 15s`, `permitted-number-of-calls-in-half-open-state: 5`, `slow-call-duration-threshold: 3s`, `slow-call-rate-threshold: 80`. ✅

### Step 3 — Retry Filter for Cart Route (`gateway-service.yml:105–112`)
All 6 retry values match: `retries: 2`, `statuses: BAD_GATEWAY,SERVICE_UNAVAILABLE`, `methods: GET,POST,PATCH`, backoff `100ms/500ms/factor 2`. ✅

### Step 4 — Redis Connection Pool (`cart-service.yml:19–23`)
All 4 pool settings match: `max-active: 32`, `max-idle: 16`, `min-idle: 4`, `max-wait: 2s`. ✅

### Step 5 — Redis Health Indicator (`cart-service.yml:42–52`)
Both settings present: `management.health.redis.enabled: true` and `show-details: when-authorized`. ✅

### Step 6 — Frontend Retry Logic
- Implemented in [ProductGrid.tsx:33](frontend/src/components/product/ProductGrid.tsx) and [ProductPage.tsx:51](frontend/src/pages/public/ProductPage.tsx) — the correct location since `CartDrawer.tsx` holds no add-to-cart mutation
- `retry: (count, error) => count <= 1 && status === 503` gives exactly 1 retry (TanStack Query v5 starts `failureCount` at 1 after first failure)
- "Cart service is busy — retrying…" warning toast fires correctly on first 503
- Test file `ProductGrid.test.tsx` covers all 4 scenarios (success, 503→retry→success, 503→retry→503, non-503 error) ✅

**No missing, incomplete, or incorrect items found.**