### PR TITLE
feat: P3-fix-spurious-permission-errors -Full Implemented

### DIFF
--- a/frontend/src/api/client.interceptor.test.ts
+++ b/frontend/src/api/client.interceptor.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { server } from '@test/mocks/server';
+import { http, HttpResponse } from 'msw';
+import apiClient from './client';
+
+// vi.hoisted ensures these are available inside vi.mock factory closures
+const { authStoreState, mockAddToast } = vi.hoisted(() => ({
+  authStoreState: { accessToken: null as string | null, tenantId: null as string | null },
+  mockAddToast: vi.fn().mockReturnValue('toast-id'),
+}));
+
+vi.mock('../stores/auth.store', () => ({
+  useAuthStore: { getState: () => authStoreState },
+}));
+
+vi.mock('../stores/ui.store', () => ({
+  useUIStore: { getState: () => ({ addToast: mockAddToast }) },
+}));
+
+describe('403 interceptor — BUG-008/BUG-009 spurious permission errors', () => {
+  beforeEach(() => {
+    mockAddToast.mockClear();
+    authStoreState.accessToken = null;
+    authStoreState.tenantId = null;
+  });
+
+  it('should NOT show a toast when the request has no Authorization token (timing race)', async () => {
+    authStoreState.accessToken = null;
+    server.use(http.get('/api/v1/orders', () => new HttpResponse(null, { status: 403 })));
+
+    await expect(apiClient.get('/orders')).rejects.toBeDefined();
+
+    expect(mockAddToast).not.toHaveBeenCalled();
+  });
+
+  it('should NOT show a toast for /admin 403s — RoleRoute handles navigation permission checks', async () => {
+    authStoreState.accessToken = 'test-token';
+    server.use(http.get('/api/v1/admin/users', () => new HttpResponse(null, { status: 403 })));
+
+    await expect(apiClient.get('/admin/users')).rejects.toBeDefined();
+
+    expect(mockAddToast).not.toHaveBeenCalled();
+  });
+
+  it('should NOT show a toast for /seller 403s — RoleRoute handles navigation permission checks', async () => {
+    authStoreState.accessToken = 'test-token';
+    server.use(http.get('/api/v1/seller/products', () => new HttpResponse(null, { status: 403 })));
+
+    await expect(apiClient.get('/seller/products')).rejects.toBeDefined();
+
+    expect(mockAddToast).not.toHaveBeenCalled();
+  });
+
+  it('should show a toast with PERMISSION_TOAST_ID for real 403s (authenticated, non-nav endpoint)', async () => {
+    authStoreState.accessToken = 'test-token';
+    server.use(http.get('/api/v1/orders', () => new HttpResponse(null, { status: 403 })));
+
+    await expect(apiClient.get('/orders')).rejects.toBeDefined();
+
+    expect(mockAddToast).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'permission-denied', variant: 'error' })
+    );
+  });
+
+  it('should reject with status 403 for no-token 403 responses (no toast shown)', async () => {
+    authStoreState.accessToken = null;
+    server.use(http.get('/api/v1/orders', () => new HttpResponse(null, { status: 403 })));
+
+    const error = await apiClient.get('/orders').catch((e) => e);
+
+    expect(error).toMatchObject({ status: 403 });
+    expect(mockAddToast).not.toHaveBeenCalled();
+  });
+
+  it('should reject with status 403 for nav-check 403 responses (no toast shown)', async () => {
+    authStoreState.accessToken = 'test-token';
+    server.use(http.get('/api/v1/admin/users', () => new HttpResponse(null, { status: 403 })));
+
+    const error = await apiClient.get('/admin/users').catch((e) => e);
+
+    expect(error).toMatchObject({ status: 403 });
+    expect(mockAddToast).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -3,6 +3,8 @@ import type { AppError, ApiError } from './types';
 
 const PUBLIC_PATHS = ['/auth/login', '/auth/register', '/auth/refresh'];
 
+export const PERMISSION_TOAST_ID = 'permission-denied';
+
 // Singleton mutex to prevent concurrent refresh attempts
 let isRefreshing = false;
 let failedQueue: Array<{
@@ -18,14 +20,25 @@ function processQueue(error: unknown, token: string | null) {
   failedQueue = [];
 }
 
-// Lazy store accessor — avoids circular import at module init time
-function getAuthStore() {
-  // Import is deferred until call time; by then all modules are initialized
-  return import('../stores/auth.store').then((m) => m.useAuthStore);
+// Lazy store accessors — avoid circular import at module init time.
+// Cached after first import so concurrent requests share the same reference.
+let cachedAuthStore: typeof import('../stores/auth.store').useAuthStore | null = null;
+let cachedUIStore: typeof import('../stores/ui.store').useUIStore | null = null;
+
+async function getAuthStore() {
+  if (!cachedAuthStore) {
+    const m = await import('../stores/auth.store');
+    cachedAuthStore = m.useAuthStore;
+  }
+  return cachedAuthStore;
 }
 
-function getUIStore() {
-  return import('../stores/ui.store').then((m) => m.useUIStore);
+async function getUIStore() {
+  if (!cachedUIStore) {
+    const m = await import('../stores/ui.store');
+    cachedUIStore = m.useUIStore;
+  }
+  return cachedUIStore;
 }
 
 const apiClient = axios.create({
@@ -96,8 +109,24 @@ apiClient.interceptors.response.use(
     }
 
     if (error.response?.status === 403) {
+      console.log('[403]', originalRequest.url, originalRequest.headers?.['Authorization']);
+      const url = originalRequest.url ?? '';
+
+      // Don't toast for requests fired before auth was ready (timing issue, no real permission error)
+      const hasToken = originalRequest.headers?.['Authorization'];
+      if (!hasToken) {
+        return Promise.reject(normalizeError(error));
+      }
+
+      // Don't toast for navigation-triggered 403s — role route guards handle these
+      const isNavigationCheck = url.includes('/admin') || url.includes('/seller');
+      if (isNavigationCheck) {
+        return Promise.reject(normalizeError(error));
+      }
+
       const useUIStore = await getUIStore();
       useUIStore.getState().addToast({
+        id: PERMISSION_TOAST_ID,
         message: "You don't have permission to perform this action",
         variant: 'error',
       });

--- a/frontend/src/api/orders.api.ts
+++ b/frontend/src/api/orders.api.ts
@@ -16,11 +16,12 @@ export const ordersApi = {
       .get<OrderStatusResponse>(`/orders/status/${correlationId}`)
       .then((r) => r.data),
 
-  getAll: () => apiClient.get<OrderResponse[]>('/orders').then((r) => r.data),
+  getAll: (signal?: AbortSignal) =>
+    apiClient.get<OrderResponse[]>('/orders', { signal }).then((r) => r.data),
 
-  getById: (orderId: number) =>
-    apiClient.get<OrderResponse>(`/orders/${orderId}`).then((r) => r.data),
+  getById: (orderId: number, signal?: AbortSignal) =>
+    apiClient.get<OrderResponse>(`/orders/${orderId}`, { signal }).then((r) => r.data),
 
-  getLines: (orderId: number) =>
-    apiClient.get<OrderLineResponse[]>(`/order-lines/${orderId}`).then((r) => r.data),
+  getLines: (orderId: number, signal?: AbortSignal) =>
+    apiClient.get<OrderLineResponse[]>(`/order-lines/${orderId}`, { signal }).then((r) => r.data),
 };

--- a/frontend/src/api/products.api.ts
+++ b/frontend/src/api/products.api.ts
@@ -18,9 +18,9 @@ export interface SearchParams {
 }
 
 export const productsApi = {
-  getAll: (page = 0, size = 20) =>
+  getAll: (page = 0, size = 20, signal?: AbortSignal) =>
     apiClient
-      .get<PageResponse<ProductResponse>>('/products', { params: { page, size } })
+      .get<PageResponse<ProductResponse>>('/products', { params: { page, size }, signal })
       .then((r) => r.data),
 
   getById: (id: number) =>

--- a/frontend/src/api/users.api.ts
+++ b/frontend/src/api/users.api.ts
@@ -12,9 +12,9 @@ export interface AdminUser {
 }
 
 export const usersApi = {
-  list: (page = 0, size = 25) =>
+  list: (page = 0, size = 25, signal?: AbortSignal) =>
     apiClient
-      .get<PageResponse<AdminUser>>(`/auth/users`, { params: { page, size } })
+      .get<PageResponse<AdminUser>>(`/auth/users`, { params: { page, size }, signal })
       .then((r) => r.data),
 
   updateRole: (userId: number, role: Role) =>

--- a/frontend/src/pages/admin/UserManagement.tsx
+++ b/frontend/src/pages/admin/UserManagement.tsx
@@ -17,7 +17,7 @@ export default function UserManagement() {
 
   const { data, isLoading } = useQuery({
     queryKey: USERS_KEY,
-    queryFn: () => usersApi.list(0, 50),
+    queryFn: ({ signal }) => usersApi.list(0, 50, signal),
     staleTime: 60_000,
   });
 

--- a/frontend/src/pages/customer/DashboardPage.tsx
+++ b/frontend/src/pages/customer/DashboardPage.tsx
@@ -41,7 +41,7 @@ export default function DashboardPage() {
 
   const { data: orders, isLoading } = useQuery({
     queryKey: [QUERY_KEYS.ORDERS],
-    queryFn: ordersApi.getAll,
+    queryFn: ({ signal }) => ordersApi.getAll(signal),
     staleTime: 30 * 1000,
     retry: false,
     throwOnError: false,

--- a/frontend/src/pages/customer/OrderDetailPage.tsx
+++ b/frontend/src/pages/customer/OrderDetailPage.tsx
@@ -17,13 +17,13 @@ export default function OrderDetailPage() {
 
   const { data: order, isLoading, isError } = useQuery({
     queryKey: [QUERY_KEYS.ORDER, id],
-    queryFn: () => ordersApi.getById(Number(id)),
+    queryFn: ({ signal }) => ordersApi.getById(Number(id), signal),
     enabled: !!id,
   });
 
   const { data: lines } = useQuery({
     queryKey: [QUERY_KEYS.ORDER_LINES, id],
-    queryFn: () => ordersApi.getLines(Number(id)),
+    queryFn: ({ signal }) => ordersApi.getLines(Number(id), signal),
     enabled: !!id,
   });
 

--- a/frontend/src/pages/customer/OrdersPage.tsx
+++ b/frontend/src/pages/customer/OrdersPage.tsx
@@ -16,7 +16,7 @@ import {
 export default function OrdersPage() {
   const { data: orders, isLoading } = useQuery({
     queryKey: [QUERY_KEYS.ORDERS],
-    queryFn: ordersApi.getAll,
+    queryFn: ({ signal }) => ordersApi.getAll(signal),
     staleTime: 30 * 1000,
   });
 

--- a/frontend/src/pages/seller/OrderManagement.tsx
+++ b/frontend/src/pages/seller/OrderManagement.tsx
@@ -13,7 +13,7 @@ export default function OrderManagement() {
   const navigate = useNavigate();
   const { data: orders, isLoading } = useQuery({
     queryKey: [QUERY_KEYS.ORDERS],
-    queryFn: ordersApi.getAll,
+    queryFn: ({ signal }) => ordersApi.getAll(signal),
     staleTime: 30 * 1000,
   });
 

--- a/frontend/src/pages/seller/SellerDashboard.tsx
+++ b/frontend/src/pages/seller/SellerDashboard.tsx
@@ -21,14 +21,14 @@ function StatCard({ label, value, sub }: { label: string; value: string; sub?: s
 export default function SellerDashboard() {
   const { data: products, isLoading: productsLoading } = useQuery({
     queryKey: [QUERY_KEYS.PRODUCTS, 0, 100],
-    queryFn: () => productsApi.getAll(0, 100),
+    queryFn: ({ signal }) => productsApi.getAll(0, 100, signal),
     staleTime: 2 * 60 * 1000,
     retry: false,
     throwOnError: false,
   });
   const { data: orders, isLoading: ordersLoading } = useQuery({
     queryKey: [QUERY_KEYS.ORDERS],
-    queryFn: ordersApi.getAll,
+    queryFn: ({ signal }) => ordersApi.getAll(signal),
     staleTime: 30 * 1000,
     retry: false,
     throwOnError: false,

--- a/frontend/src/routes/RoleRoute.tsx
+++ b/frontend/src/routes/RoleRoute.tsx
@@ -1,6 +1,7 @@
 import { Navigate, Outlet } from 'react-router-dom';
 import { useAuthStore } from '@stores/auth.store';
 import { useUIStore } from '@stores/ui.store';
+import { PERMISSION_TOAST_ID } from '@api/client';
 import type { Role } from '@api/types';
 import { ROUTES } from '@utils/constants';
 
@@ -17,7 +18,7 @@ export default function RoleRoute({ allowedRoles }: RoleRouteProps) {
   }
 
   if (!role || !allowedRoles.includes(role)) {
-    addToast({ message: 'You do not have permission to access this page', variant: 'error' });
+    addToast({ id: PERMISSION_TOAST_ID, message: 'You do not have permission to access this page', variant: 'error' });
     return <Navigate to={ROUTES.HOME} replace />;
   }
 

--- a/frontend/src/stores/ui.store.test.ts
+++ b/frontend/src/stores/ui.store.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useUIStore } from './ui.store';
+
+describe('useUIStore — addToast deduplication (BUG-009)', () => {
+  beforeEach(() => {
+    useUIStore.setState({ toastQueue: [] });
+  });
+
+  it('should append a new toast with auto-generated ID when no ID is provided', () => {
+    const id1 = useUIStore.getState().addToast({ message: 'First', variant: 'success' });
+    const id2 = useUIStore.getState().addToast({ message: 'Second', variant: 'info' });
+
+    const { toastQueue } = useUIStore.getState();
+    expect(toastQueue).toHaveLength(2);
+    expect(toastQueue[0].id).toBe(id1);
+    expect(toastQueue[1].id).toBe(id2);
+    expect(id1).not.toBe(id2);
+  });
+
+  it('should append a toast when a unique fixed ID is provided', () => {
+    useUIStore.getState().addToast({ id: 'toast-unique', message: 'Hello', variant: 'success' });
+
+    const { toastQueue } = useUIStore.getState();
+    expect(toastQueue).toHaveLength(1);
+    expect(toastQueue[0].id).toBe('toast-unique');
+    expect(toastQueue[0].message).toBe('Hello');
+  });
+
+  it('should REPLACE existing toast when the same ID is reused — no duplicate stacking', () => {
+    useUIStore.getState().addToast({ id: 'permission-denied', message: 'First error', variant: 'error' });
+    useUIStore.getState().addToast({ id: 'permission-denied', message: 'Replaced error', variant: 'error' });
+
+    const { toastQueue } = useUIStore.getState();
+    expect(toastQueue).toHaveLength(1);
+    expect(toastQueue[0].id).toBe('permission-denied');
+    expect(toastQueue[0].message).toBe('Replaced error');
+  });
+
+  it('should replace only the matching toast and leave others untouched', () => {
+    useUIStore.getState().addToast({ message: 'Unrelated toast', variant: 'info' });
+    useUIStore.getState().addToast({ id: 'permission-denied', message: 'Permission error', variant: 'error' });
+    useUIStore.getState().addToast({ id: 'permission-denied', message: 'Updated permission error', variant: 'error' });
+
+    const { toastQueue } = useUIStore.getState();
+    expect(toastQueue).toHaveLength(2);
+
+    const permToast = toastQueue.find((t) => t.id === 'permission-denied');
+    expect(permToast?.message).toBe('Updated permission error');
+
+    const otherToast = toastQueue.find((t) => t.id !== 'permission-denied');
+    expect(otherToast?.message).toBe('Unrelated toast');
+  });
+
+  it('should return the provided ID when a fixed ID is passed', () => {
+    const returned = useUIStore.getState().addToast({ id: 'my-toast', message: 'Hello', variant: 'success' });
+    expect(returned).toBe('my-toast');
+  });
+
+  it('should remove a toast by ID', () => {
+    useUIStore.getState().addToast({ id: 'remove-me', message: 'I will be removed', variant: 'warning' });
+    useUIStore.getState().removeToast('remove-me');
+
+    expect(useUIStore.getState().toastQueue).toHaveLength(0);
+  });
+
+  it('should leave queue unchanged when removing a non-existent ID', () => {
+    useUIStore.getState().addToast({ message: 'Survivor', variant: 'success' });
+    useUIStore.getState().removeToast('does-not-exist');
+
+    expect(useUIStore.getState().toastQueue).toHaveLength(1);
+  });
+});

--- a/frontend/src/stores/ui.store.ts
+++ b/frontend/src/stores/ui.store.ts
@@ -20,7 +20,7 @@ interface UIState {
   toggleTheme: () => void;
   setSidebarOpen: (open: boolean) => void;
   toggleSidebar: () => void;
-  addToast: (toast: Omit<Toast, 'id'>) => string;
+  addToast: (toast: Omit<Toast, 'id'> & { id?: string }) => string;
   removeToast: (id: string) => void;
 }
 
@@ -39,8 +39,13 @@ export const useUIStore = create<UIState>()(
       toggleSidebar: () => set((s) => ({ sidebarOpen: !s.sidebarOpen })),
 
       addToast: (toast) => {
-        const id = `toast-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-        set((s) => ({ toastQueue: [...s.toastQueue, { ...toast, id }] }));
+        const id = toast.id ?? `toast-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+        set((s) => ({
+          // Replace existing toast with the same ID; otherwise append
+          toastQueue: s.toastQueue.some((t) => t.id === id)
+            ? s.toastQueue.map((t) => (t.id === id ? { ...toast, id } : t))
+            : [...s.toastQueue, { ...toast, id }],
+        }));
         return id;
       },
 


### PR DESCRIPTION

   Current Work:

     Immediately before this summary request, the work that was completed was the full execution of `P3-fix-spurious-permission-errors.md`. The final verification was:

     Tests: `Tests 36 passed (36), Test Files 6 passed (6)` — clean
     Build: `✓ built in 7.32s` — zero TypeScript errors

     The skill verification checklist was completed:
     - Step 1 ✅ `console.log('[403]', originalRequest.url, originalRequest.headers?.['Authorization'])` in client.ts:112
     - Step 2 ✅ `hasToken` guard (no-token skip) + `isNavigationCheck` guard (/admin, /seller skip) in client.ts
     - Step 3 ✅ `cachedAuthStore` + `cachedUIStore` module-level caching with async init in client.ts
     - Step 4 ✅ `PERMISSION_TOAST_ID = 'permission-denied'` exported + `addToast` deduplication in ui.store.ts
     - Step 5 ✅ `RoleRoute` imports and uses `PERMISSION_TOAST_ID` — both sources deduplicate via same ID
     - Step 6 ✅ `signal?: AbortSignal` added to orders.api and users.api; all relevant `useQuery` calls updated to `({ signal }) => api.method(signal)` pattern

    1. Optional Next Step:

     The user's most recent explicit instruction was to execute the `P3-fix-spurious-permission-errors.md` skill and then "stop and wait for my approval before continuing." That task is complete. The   
     assistant stated: "Await your approval before proceeding to the next skill."
     I'll fix the `productsApi` AbortSignal inconsistency now.

	Now fix `SellerDashboard.tsx` to pass the signal:

	Now let me verify both files are correct:

	Both files are fixed. Now let me do a final sweep to confirm all API functions across all relevant files consistently support AbortSignal:

	Every single `useQuery` call now properly passes `signal`. The fix is complete and consistent across all components.

	**Summary of changes:**
	- [`frontend/src/api/products.api.ts:21`](frontend/src/api/products.api.ts) — Added `signal?: AbortSignal` parameter to `getAll()` and forwarded it to Axios
	- [`frontend/src/pages/seller/SellerDashboard.tsx:24`](frontend/src/pages/seller/SellerDashboard.tsx) — Changed `queryFn: () =>` to `queryFn: ({ signal }) =>` and passes `signal` to `productsApi.getAll()`

	All 8 `useQuery` calls across all pages now consistently destructure and forward the React Query `signal` for request cancellation on navigation, exactly matching the Step 6 requirement.
     No next step should be taken without explicit user approval. The user has not named a next skill to execute. When approval is given, the user may indicate which skill to run next.