### PR TITLE
feat: lasts changes made and still not done

### DIFF
--- a/gateway-api-service/src/main/resources/application.yml
+++ b/gateway-api-service/src/main/resources/application.yml
@@ -1,5 +1,3 @@
 spring:
-  config:
-    import: optional:configserver:http://localhost:8888
   application:
     name: gateway-service

--- a/order-service/src/main/java/code/with/vanilson/orderservice/config/KafkaConfig.java
+++ b/order-service/src/main/java/code/with/vanilson/orderservice/config/KafkaConfig.java
@@ -1,6 +1,7 @@
 package code.with.vanilson.orderservice.config;
 
 import jakarta.annotation.PreDestroy;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
@@ -18,6 +19,8 @@ import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.kafka.listener.ContainerProperties;
 import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
 import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.kafka.support.converter.StringJsonMessageConverter;
+import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
 import org.springframework.kafka.support.serializer.JsonSerializer;
 import org.springframework.util.backoff.FixedBackOff;
@@ -94,11 +97,11 @@ public class KafkaConfig {
 
     @Bean
     public ConsumerFactory<String, Object> sagaConsumerFactory() {
-        // buildConsumerProperties includes bootstrap-servers, group-id, SASL config,
-        // deserializers, and offset settings from YAML
         Map<String, Object> props = new HashMap<>(kafkaProperties.buildConsumerProperties(null));
-        props.put(JsonDeserializer.TRUSTED_PACKAGES, "code.with.vanilson.*");
-        props.put(JsonDeserializer.USE_TYPE_INFO_HEADERS, false);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
+        props.put(ErrorHandlingDeserializer.KEY_DESERIALIZER_CLASS, StringDeserializer.class);
+        props.put(ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS, StringDeserializer.class);
         return new DefaultKafkaConsumerFactory<>(props);
     }
 
@@ -114,6 +117,7 @@ public class KafkaConfig {
 
         var factory = new ConcurrentKafkaListenerContainerFactory<String, Object>();
         factory.setConsumerFactory(sagaConsumerFactory());
+        factory.setRecordMessageConverter(new StringJsonMessageConverter());
         factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL_IMMEDIATE);
         factory.getContainerProperties().setStopImmediate(false);
 


### PR DESCRIPTION

### Fixes Applied

| # | File | Change | Phase |
|---|---|---|---|
| 1 | `order-service/.../config/KafkaConfig.java` | Replaced `JsonDeserializer` with `ErrorHandlingDeserializer` wrapping `StringDeserializer` + added `StringJsonMessageConverter` to listener factory | IMPLEMENTATION |
| 2 | `gateway-api-service/src/main/resources/application.yml` | Removed duplicate `spring.config.import: optional:configserver:http://localhost:8888` (gateway already loads config via `bootstrap.yml`) | CLEANUP |

---

### Step-by-Step Execution

| Step | Action | Result | Phase |
|---|---|---|---|
| 1 | Read screenshot — 503 on POST /orders | CB open for order-service | DIAGNOSIS |
| 2 | `docker ps` — all containers healthy | Services up 14 min | DIAGNOSIS |
| 3 | `docker logs order-service` | Found Kafka crash loop on `payment.failed-7 offset 0` | DIAGNOSIS |
| 4 | `docker logs gateway-api-service` | Fallbacks for orders, carts, products — CB open | DIAGNOSIS |
| 5 | Read `KafkaConfig.java` | Found missing `ErrorHandlingDeserializer` | ROOT CAUSE |
| 6 | Fixed `KafkaConfig.java` | `ErrorHandlingDeserializer` + `StringJsonMessageConverter` | IMPLEMENTATION |
| 7 | Read `gateway-api-service/application.yml` + `bootstrap.yml` | Found duplicate config import; bootstrap already loads from `config-service:8888` correctly | DIAGNOSIS |
| 8 | Removed duplicate from `application.yml` | Cosmetic fix only | IMPLEMENTATION |
| 9 | `mvn compile -pl order-service` | Clean | VERIFICATION |
| 10 | `mvn test -pl order-service` | **50 tests, 0 failures** | VERIFICATION |
| 11 | **Never verified in Docker** | Fix NOT deployed, production state unknown | BLOCKED |

---

### Mistakes Made (Transparency)

| Mistake | What happened |
|---|---|
| Investigated MongoDB, customer records, auth credentials | None of these were relevant to the 503. Wasted tokens. |
| Declared "50 tests pass" as success | Unit tests don't prove the checkout flow works in Docker |
| Did not go to order-service logs at exact timestamp 22:18:49 immediately | Should have been first action — would have shown the exact HTTP error |
| Investigated gateway config loading in depth | Gateway WAS loading config correctly; was a red herring |

---

### Files Modified

| File | Status |
|---|---|
| `order-service/src/main/java/code/with/vanilson/orderservice/config/KafkaConfig.java` | Modified — `ErrorHandlingDeserializer` + `StringJsonMessageConverter` |
| `gateway-api-service/src/main/resources/application.yml` | Modified — removed duplicate localhost config import |

---

### Current State

- **Kafka fix**: In source code only — **NOT deployed**
- **Gateway fix**: In source code only — **NOT deployed**
- **503 error**: **STILL PRESENT** in running containers (old images)
- **Requires**: `docker-compose build order-service gateway-api-service && docker-compose up -d order-service gateway-api-service`
