### PR TITLE
feat: bugs fixed

### DIFF
--- a/authentication-service/Dockerfile
+++ b/authentication-service/Dockerfile
@@ -10,6 +10,7 @@ WORKDIR /build
 COPY . .
 
 # Build only the authentication-service module
+ENV MAVEN_OPTS="-Dhttps.protocols=TLSv1.2,TLSv1.3"
 RUN mvn -B clean package -DskipTests=true -pl authentication-service -am
 
 # ===================================================================

--- a/authentication-service/src/main/java/code/with/vanilson/authentication/config/SecurityConfig.java
+++ b/authentication-service/src/main/java/code/with/vanilson/authentication/config/SecurityConfig.java
@@ -66,7 +66,7 @@ public class SecurityConfig {
 
     // Explicit allowlist — a wildcard origin combined with allowCredentials(true)
     // would let any site make credentialed requests (CSRF-equivalent exposure).
-    @Value("${app.cors.allowed-origins:http://localhost:80,http://localhost:5173,http://localhost:3000,http://localhost:8222}")
+    @Value("${app.cors.allowed-origins:http://localhost:8080,http://localhost:5173,http://localhost:3000,http://localhost:8222}")
     private List<String> allowedOrigins;
 
     public SecurityConfig(JwtAuthFilter jwtAuthFilter,

--- a/cart-service/Dockerfile
+++ b/cart-service/Dockerfile
@@ -10,6 +10,7 @@ WORKDIR /build
 COPY . .
 
 # Build only the cart-service module
+ENV MAVEN_OPTS="-Dhttps.protocols=TLSv1.2,TLSv1.3"
 RUN mvn -B clean package -DskipTests=true -pl cart-service -am
 
 # ===================================================================

--- a/config-service/Dockerfile
+++ b/config-service/Dockerfile
@@ -11,6 +11,7 @@ WORKDIR /build
 COPY . .
 
 # Build only the config-service module
+ENV MAVEN_OPTS="-Dhttps.protocols=TLSv1.2,TLSv1.3"
 RUN mvn -B clean package -DskipTests=true -pl config-service -am
 
 # ===================================================================

--- a/config-service/src/main/resources/configurations/authentication-service.yml
+++ b/config-service/src/main/resources/configurations/authentication-service.yml
@@ -79,7 +79,7 @@ feign:
 # CORS — explicit origin allowlist (wildcard + credentials is a CSRF-equivalent hole)
 app:
   cors:
-    allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:80,http://localhost:5173,http://localhost:3000,http://localhost:8222}
+    allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:8080,http://localhost:5173,http://localhost:3000,http://localhost:8222}
 
 # JWT configuration — secret must match the Gateway's JWT secret exactly
 application:

--- a/config-service/src/main/resources/configurations/gateway-service.yml
+++ b/config-service/src/main/resources/configurations/gateway-service.yml
@@ -21,6 +21,30 @@ spring:
 
   cloud:
     gateway:
+      # ----------------------------------------------------------------
+      # HTTP client connection pool — root-cause fix for the intermittent
+      # 503s on the FIRST request after an idle period (product, cart AND
+      # order all fell over together right after login).
+      #
+      # Cause: the reactor-netty pool reused keep-alive connections that the
+      # backend Tomcat had already closed (default keepAliveTimeout = 60s),
+      # so the write hit a half-closed socket → "connection closed
+      # prematurely" (an IOException) → CircuitBreaker fallback → 503.
+      # The Retry filter only retries on 502/503 *status*, not on this
+      # connection exception, so the user saw the 503 on the first call and
+      # success only after a manual refresh.
+      #
+      # Evicting idle connections well below the server keep-alive window
+      # guarantees the gateway never writes to a stale socket.
+      # ----------------------------------------------------------------
+      httpclient:
+        connect-timeout: 5000          # ms — fail fast when a backend is genuinely unreachable
+        pool:
+          type: elastic
+          max-idle-time: 20s           # evict idle conns long before Tomcat's 60s keepAliveTimeout
+          max-life-time: 120s          # hard cap on total connection lifetime
+          eviction-interval: 30s       # proactively sweep idle connections from the pool
+
       discovery:
         locator:
           enabled: true

--- a/customer-service/Dockerfile
+++ b/customer-service/Dockerfile
@@ -11,6 +11,7 @@ WORKDIR /build
 COPY . .
 
 # Build only the customer-service module
+ENV MAVEN_OPTS="-Dhttps.protocols=TLSv1.2,TLSv1.3"
 RUN mvn -B clean package -DskipTests=true -pl customer-service -am
 
 # ===================================================================

--- a/discovery-service/Dockerfile
+++ b/discovery-service/Dockerfile
@@ -11,6 +11,7 @@ WORKDIR /build
 COPY . .
 
 # Build only the discovery-service module
+ENV MAVEN_OPTS="-Dhttps.protocols=TLSv1.2,TLSv1.3"
 RUN mvn -B clean package -DskipTests=true -pl discovery-service -am
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -511,6 +511,10 @@ services:
       VAULT_HOST: ${VAULT_HOST:-vault}
       VAULT_TOKEN: ${VAULT_TOKEN:-root-token}
       ZIPKIN_ENDPOINT: http://zipkin:9411/api/v2/spans
+      # Browser loads the SPA at http://localhost:8080 (nginx) and sends Origin:
+      # http://localhost:8080 on /api calls; 8080 MUST be allowed or auth endpoints
+      # return 403 "Invalid CORS request". (Frontend was remapped :80 -> :8080.)
+      CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-http://localhost:8080,http://localhost:5173,http://localhost:3000,http://localhost:8222}
       LOGGING_CONFIG: /app/logback-spring.xml
     volumes:
       - ./logback-spring.xml:/app/logback-spring.xml:ro

--- a/gateway-api-service/Dockerfile
+++ b/gateway-api-service/Dockerfile
@@ -11,6 +11,7 @@ WORKDIR /build
 COPY . .
 
 # Build only the gateway-api-service module
+ENV MAVEN_OPTS="-Dhttps.protocols=TLSv1.2,TLSv1.3"
 RUN mvn -B clean package -DskipTests=true -pl gateway-api-service -am
 
 # ===================================================================

--- a/notification-service/Dockerfile
+++ b/notification-service/Dockerfile
@@ -10,6 +10,7 @@ WORKDIR /build
 COPY . .
 
 # Build only the notification-service module
+ENV MAVEN_OPTS="-Dhttps.protocols=TLSv1.2,TLSv1.3"
 RUN mvn -B clean package -DskipTests=true -pl notification-service -am
 
 # ===================================================================

--- a/order-service/Dockerfile
+++ b/order-service/Dockerfile
@@ -10,6 +10,7 @@ WORKDIR /build
 COPY . .
 
 # Build only the order-service module
+ENV MAVEN_OPTS="-Dhttps.protocols=TLSv1.2,TLSv1.3"
 RUN mvn -B clean package -DskipTests=true -pl order-service -am
 
 # ===================================================================

--- a/order-service/src/main/java/code/with/vanilson/orderservice/OrderService.java
+++ b/order-service/src/main/java/code/with/vanilson/orderservice/OrderService.java
@@ -131,7 +131,8 @@ public class OrderService {
         log.info(msg("order.log.order.saved", order.getOrderId(), order.getReference()));
 
         // Step 3 — Persist OutboxEvent (same transaction — atomic!)
-        OrderRequestedEvent event = buildOrderRequestedEvent(request, customer, correlationId);
+        OrderRequestedEvent event = buildOrderRequestedEvent(
+                request, customer, correlationId, order.getReference(), order.getTenantId(), order.getOrderId());
         persistOutboxEvent(event, correlationId);
 
         log.info("[OrderService] Order persisted in REQUESTED state. correlationId=[{}] — saga will proceed via Kafka",
@@ -339,7 +340,10 @@ public class OrderService {
 
     private OrderRequestedEvent buildOrderRequestedEvent(OrderRequest request,
                                                           CustomerInfo customer,
-                                                          String correlationId) {
+                                                          String correlationId,
+                                                          String orderReference,
+                                                          String tenantId,
+                                                          Integer orderId) {
         List<ProductPurchaseRequest> products = request.products().stream()
                 .map(p -> new ProductPurchaseRequest(p.productId(), p.quantity()))
                 .collect(Collectors.toList());
@@ -354,7 +358,16 @@ public class OrderService {
                 products,
                 request.amount(),
                 request.paymentMethod(),
-                request.reference(),
+                // Use the PERSISTED order reference, not request.reference():
+                // the UI never sends a reference, so request.reference() is null.
+                // A null here propagates through inventory.reserved into the
+                // payment.order_reference NOT NULL column → payment always fails.
+                orderReference,
+                // tenantId + orderId carried through the saga so payment-service can
+                // satisfy its NOT NULL payment.tenant_id / payment.order_id columns —
+                // the Kafka consumer has no HTTP TenantContext and no order PK otherwise.
+                tenantId,
+                orderId,
                 Instant.now(),
                 1                                // schemaVersion
         );

--- a/order-service/src/main/java/code/with/vanilson/orderservice/kafka/OrderRequestedEvent.java
+++ b/order-service/src/main/java/code/with/vanilson/orderservice/kafka/OrderRequestedEvent.java
@@ -37,6 +37,11 @@ public record OrderRequestedEvent(
         BigDecimal                   totalAmount,
         PaymentMethod                paymentMethod,
         String                       orderReference,
+        // tenantId + orderId must travel the whole saga (order → inventory → payment).
+        // payment.tenant_id and payment.order_id are NOT NULL, but the async saga has
+        // no HTTP TenantContext and no order PK at the payment step unless we carry them.
+        String                       tenantId,
+        Integer                      orderId,
         Instant                      occurredAt,
         int                          schemaVersion    // always 1 for now
 ) {}

--- a/order-service/src/test/java/code/with/vanilson/orderservice/OrderServiceAsyncTest.java
+++ b/order-service/src/test/java/code/with/vanilson/orderservice/OrderServiceAsyncTest.java
@@ -281,6 +281,52 @@ class OrderServiceAsyncTest {
         }
 
         @Test
+        @DisplayName("published event payload must carry the persisted reference, never a null orderReference")
+        void outboxEventCarriesGeneratedReference() {
+            // Regression: the UI never sends a reference, so request.reference() is null.
+            // The event MUST carry the persisted order.getReference() (auto-generated ORD-...),
+            // otherwise a null orderReference propagates to payment.order_reference (NOT NULL)
+            // and every payment fails → order CANCELLED.
+            OrderRequest noRefRequest = new OrderRequest(
+                    null,
+                    null, // no reference sent by client
+                    BigDecimal.valueOf(199.99),
+                    PaymentMethod.CREDIT_CARD,
+                    "cust-001",
+                    List.of(new ProductPurchaseRequest(1, 1.0))
+            );
+
+            Order orderWithNullRef = Order.builder()
+                    .orderId(43)
+                    .reference(null)
+                    .totalAmount(BigDecimal.valueOf(199.99))
+                    .paymentMethod(PaymentMethod.CREDIT_CARD)
+                    .customerId("cust-001")
+                    .status(OrderStatus.REQUESTED)
+                    .tenantId("test-tenant-123")
+                    .build();
+
+            when(snapshotRepository.findById("cust-001")).thenReturn(Optional.empty());
+            when(customerClient.findCustomerById("cust-001")).thenReturn(Optional.of(validCustomer));
+            when(orderMapper.toOrder(any())).thenReturn(orderWithNullRef);
+            when(orderRepository.save(any())).thenReturn(orderWithNullRef);
+            when(outboxRepository.save(any())).thenReturn(new OutboxEvent());
+
+            orderService.createOrder(noRefRequest);
+
+            ArgumentCaptor<OutboxEvent> captor = ArgumentCaptor.forClass(OutboxEvent.class);
+            verify(outboxRepository).save(captor.capture());
+            String payload = captor.getValue().getPayload();
+
+            assertThat(payload)
+                    .as("event payload must carry the generated ORD- reference")
+                    .contains("\"orderReference\":\"ORD-");
+            assertThat(payload)
+                    .as("event payload must never carry a null orderReference")
+                    .doesNotContain("\"orderReference\":null");
+        }
+
+        @Test
         @DisplayName("should throw CustomerNotFoundException when customer not found — no DB writes")
         void shouldThrowAndNotWriteWhenCustomerMissing() {
             when(snapshotRepository.findById("cust-001")).thenReturn(Optional.empty());

--- a/payment-service/Dockerfile
+++ b/payment-service/Dockerfile
@@ -10,6 +10,7 @@ WORKDIR /build
 COPY . .
 
 # Build only the payment-service module
+ENV MAVEN_OPTS="-Dhttps.protocols=TLSv1.2,TLSv1.3"
 RUN mvn -B clean package -DskipTests=true -pl payment-service -am
 
 

--- a/payment-service/src/main/java/code/with/vanilson/paymentservice/application/PaymentService.java
+++ b/payment-service/src/main/java/code/with/vanilson/paymentservice/application/PaymentService.java
@@ -5,6 +5,7 @@ import code.with.vanilson.paymentservice.exception.PaymentNotFoundException;
 import code.with.vanilson.paymentservice.infrastructure.messaging.NotificationProducer;
 import code.with.vanilson.paymentservice.infrastructure.messaging.PaymentNotificationRequest;
 import code.with.vanilson.paymentservice.infrastructure.repository.PaymentRepository;
+import code.with.vanilson.tenantcontext.TenantContext;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.MessageSource;
 import org.springframework.context.i18n.LocaleContextHolder;
@@ -164,6 +165,10 @@ public class PaymentService {
     private Integer processNewPayment(PaymentRequest request, String idempotencyKey) {
         Payment payment = paymentMapper.toPayment(request);
         payment.setIdempotencyKey(idempotencyKey);
+        // payment.tenant_id is NOT NULL. The tenant is taken from TenantContext —
+        // seeded from the saga event by PaymentSagaConsumer, or by the gateway's
+        // tenant filter on the direct HTTP path. Mirrors order-service's approach.
+        payment.setTenantId(TenantContext.requireCurrentTenantId());
 
         Payment savedPayment = paymentRepository.save(payment);
 

--- a/payment-service/src/main/java/code/with/vanilson/paymentservice/infrastructure/kafka/InventoryReservedEvent.java
+++ b/payment-service/src/main/java/code/with/vanilson/paymentservice/infrastructure/kafka/InventoryReservedEvent.java
@@ -26,6 +26,11 @@ public record InventoryReservedEvent(
         List<ReservedItem> reservedItems,
         BigDecimal totalAmount,
         String  paymentMethod,
+        // Carried from order.requested through inventory.reserved: used to fill the
+        // NOT NULL payment.tenant_id / payment.order_id columns. Field names match
+        // product-service's InventoryReservedEvent serialisation.
+        String  tenantId,
+        Integer orderId,
         Instant occurredAt,
         int     schemaVersion
 ) {

--- a/payment-service/src/main/java/code/with/vanilson/paymentservice/infrastructure/kafka/PaymentSagaConsumer.java
+++ b/payment-service/src/main/java/code/with/vanilson/paymentservice/infrastructure/kafka/PaymentSagaConsumer.java
@@ -4,6 +4,7 @@ import code.with.vanilson.paymentservice.application.PaymentRequest;
 import code.with.vanilson.paymentservice.application.PaymentService;
 import code.with.vanilson.paymentservice.domain.CustomerData;
 import code.with.vanilson.paymentservice.domain.PaymentMethod;
+import code.with.vanilson.tenantcontext.TenantContext;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -65,6 +66,10 @@ public class PaymentSagaConsumer {
         try {
             MDC.put("correlationId", event.correlationId());
             MDC.put("sagaStep", "payment");
+            // Kafka consumers have no HTTP TenantContext. Seed it from the event so
+            // PaymentService can stamp the NOT NULL payment.tenant_id on the new row
+            // (and so any tenant-filtered reads stay scoped to the right tenant).
+            TenantContext.setCurrentTenantId(event.tenantId());
 
             log.info("[PaymentSagaConsumer] inventory.reserved received: correlationId=[{}] amount=[{}] partition=[{}] offset=[{}]",
                     event.correlationId(), event.totalAmount(), partition, offset);
@@ -80,7 +85,7 @@ public class PaymentSagaConsumer {
                         null,
                         event.totalAmount(),
                         method,
-                        null,            // orderId not available here — set null, saga uses correlationId
+                        event.orderId(),   // carried through the saga — payment.order_id is NOT NULL
                         event.orderReference(),
                         customer
                 );
@@ -103,6 +108,7 @@ public class PaymentSagaConsumer {
             ack.acknowledge();
         } finally {
             MDC.clear();
+            TenantContext.clear();
         }
     }
 

--- a/payment-service/src/test/java/code/with/vanilson/paymentservice/PaymentServiceTest.java
+++ b/payment-service/src/test/java/code/with/vanilson/paymentservice/PaymentServiceTest.java
@@ -11,6 +11,8 @@ import code.with.vanilson.paymentservice.exception.PaymentNotFoundException;
 import code.with.vanilson.paymentservice.infrastructure.messaging.NotificationProducer;
 import code.with.vanilson.paymentservice.infrastructure.messaging.PaymentNotificationRequest;
 import code.with.vanilson.paymentservice.infrastructure.repository.PaymentRepository;
+import code.with.vanilson.tenantcontext.TenantContext;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -74,6 +76,9 @@ class PaymentServiceTest {
 
     @BeforeEach
     void setUp() {
+        // Saga consumer / gateway filter seeds this; PaymentService stamps payment.tenant_id from it.
+        TenantContext.setCurrentTenantId("tenant-test-001");
+
         CustomerData customer = new CustomerData("c-001", "Ana", "Silva", "ana@example.com");
 
         validRequest = new PaymentRequest(
@@ -102,6 +107,11 @@ class PaymentServiceTest {
         // MessageSource: return key itself so we can check calls without exact message strings
         when(messageSource.getMessage(anyString(), any(), any(Locale.class)))
                 .thenAnswer(inv -> inv.getArgument(0));
+    }
+
+    @AfterEach
+    void tearDown() {
+        TenantContext.clear();
     }
 
     // -------------------------------------------------------
@@ -149,6 +159,10 @@ class PaymentServiceTest {
             assertThat(captor.getValue().getIdempotencyKey())
                     .as("Idempotency key must be set to 'payment:<orderReference>'")
                     .isEqualTo("payment:ORD-2024-001");
+
+            assertThat(captor.getValue().getTenantId())
+                    .as("tenant_id is NOT NULL — must be stamped from TenantContext before save")
+                    .isEqualTo("tenant-test-001");
         }
 
         @Test

--- a/payment-service/src/test/java/code/with/vanilson/paymentservice/bdd/PaymentStepDefinitions.java
+++ b/payment-service/src/test/java/code/with/vanilson/paymentservice/bdd/PaymentStepDefinitions.java
@@ -9,6 +9,8 @@ import code.with.vanilson.paymentservice.domain.Payment;
 import code.with.vanilson.paymentservice.domain.PaymentMethod;
 import code.with.vanilson.paymentservice.infrastructure.messaging.NotificationProducer;
 import code.with.vanilson.paymentservice.infrastructure.repository.PaymentRepository;
+import code.with.vanilson.tenantcontext.TenantContext;
+import io.cucumber.java.After;
 import io.cucumber.java.Before;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
@@ -53,9 +55,17 @@ public class PaymentStepDefinitions {
         lenient().when(messageSource.getMessage(anyString(), any(), any(Locale.class)))
                 .thenAnswer(inv -> inv.getArgument(0));
 
+        // Saga consumer / gateway filter seeds the tenant; PaymentService stamps payment.tenant_id from it.
+        TenantContext.setCurrentTenantId("tenant-test-001");
+
         caughtException = null;
         duplicateScenario = false;
         savedPaymentId = null;
+    }
+
+    @After
+    public void tearDown() {
+        TenantContext.clear();
     }
 
     @Given("a valid payment request for order {string} with amount {double}")

--- a/product-service/Dockerfile
+++ b/product-service/Dockerfile
@@ -10,6 +10,7 @@ WORKDIR /build
 COPY . .
 
 # Build only the product-service module
+ENV MAVEN_OPTS="-Dhttps.protocols=TLSv1.2,TLSv1.3"
 RUN mvn -B clean package -DskipTests=true -pl product-service -am
 
 # ===================================================================

--- a/product-service/src/main/java/code/with/vanilson/productservice/kafka/InventoryReservationConsumer.java
+++ b/product-service/src/main/java/code/with/vanilson/productservice/kafka/InventoryReservationConsumer.java
@@ -159,6 +159,9 @@ public class InventoryReservationConsumer {
                 reserved,
                 order.totalAmount(),
                 order.paymentMethod(),
+                // pass tenantId + orderId through so payment-service can persist
+                order.tenantId(),
+                order.orderId(),
                 Instant.now(),
                 1
         );

--- a/product-service/src/main/java/code/with/vanilson/productservice/kafka/InventoryReservedEvent.java
+++ b/product-service/src/main/java/code/with/vanilson/productservice/kafka/InventoryReservedEvent.java
@@ -23,6 +23,10 @@ public record InventoryReservedEvent(
         List<ReservedItem> reservedItems,
         java.math.BigDecimal totalAmount,
         String  paymentMethod,
+        // Propagated from order.requested → consumed by payment-service to fill its
+        // NOT NULL payment.tenant_id / payment.order_id columns in the async saga.
+        String  tenantId,
+        Integer orderId,
         Instant occurredAt,
         int     schemaVersion
 ) {

--- a/product-service/src/main/java/code/with/vanilson/productservice/kafka/OrderRequestedEvent.java
+++ b/product-service/src/main/java/code/with/vanilson/productservice/kafka/OrderRequestedEvent.java
@@ -26,6 +26,11 @@ public record OrderRequestedEvent(
         BigDecimal                   totalAmount,
         String                       paymentMethod,
         String                       orderReference,
+        // Carried through to inventory.reserved so payment-service can satisfy its
+        // NOT NULL payment.tenant_id / payment.order_id columns (field names must
+        // match order-service's OrderRequestedEvent serialisation).
+        String                       tenantId,
+        Integer                      orderId,
         Instant                      occurredAt,
         int                          schemaVersion
 ) {

--- a/product-service/src/test/java/code/with/vanilson/productservice/kafka/InventoryReservationConsumerTest.java
+++ b/product-service/src/test/java/code/with/vanilson/productservice/kafka/InventoryReservationConsumerTest.java
@@ -108,6 +108,8 @@ class InventoryReservationConsumerTest {
                 BigDecimal.valueOf(3600.00),
                 "CREDIT_CARD",
                 ORDER_REFERENCE,
+                "tenant-test-001",
+                42,
                 Instant.now(),
                 1
         );
@@ -194,7 +196,7 @@ class InventoryReservationConsumerTest {
                     "Ana", "Silva",
                     List.of(new OrderRequestedEvent.ProductPurchaseItem(1, 20.0)),
                     BigDecimal.valueOf(24000.00), "CREDIT_CARD",
-                    ORDER_REFERENCE, Instant.now(), 1
+                    ORDER_REFERENCE, "tenant-test-001", 42, Instant.now(), 1
             );
             when(productRepository.findAllByIdInOrderById(List.of(1)))
                     .thenReturn(List.of(laptop));
@@ -212,7 +214,7 @@ class InventoryReservationConsumerTest {
                     "Ana", "Silva",
                     List.of(new OrderRequestedEvent.ProductPurchaseItem(1, 999.0)),
                     BigDecimal.ZERO, "CREDIT_CARD",
-                    ORDER_REFERENCE, Instant.now(), 1
+                    ORDER_REFERENCE, "tenant-test-001", 42, Instant.now(), 1
             );
             when(productRepository.findAllByIdInOrderById(List.of(1)))
                     .thenReturn(List.of(laptop));
@@ -231,7 +233,7 @@ class InventoryReservationConsumerTest {
                     "Ana", "Silva",
                     List.of(new OrderRequestedEvent.ProductPurchaseItem(1, 50.0)),
                     BigDecimal.ZERO, "CREDIT_CARD",
-                    ORDER_REFERENCE, Instant.now(), 1
+                    ORDER_REFERENCE, "tenant-test-001", 42, Instant.now(), 1
             );
             when(productRepository.findAllByIdInOrderById(List.of(1)))
                     .thenReturn(List.of(laptop));
@@ -250,7 +252,7 @@ class InventoryReservationConsumerTest {
                     "Ana", "Silva",
                     List.of(new OrderRequestedEvent.ProductPurchaseItem(1, 20.0)),
                     BigDecimal.valueOf(24000.00), "CREDIT_CARD",
-                    ORDER_REFERENCE, Instant.now(), 1
+                    ORDER_REFERENCE, "tenant-test-001", 42, Instant.now(), 1
             );
             when(productRepository.findAllByIdInOrderById(List.of(1)))
                     .thenReturn(List.of(laptop));
@@ -275,7 +277,7 @@ class InventoryReservationConsumerTest {
                     "Ana", "Silva",
                     List.of(new OrderRequestedEvent.ProductPurchaseItem(1, 999.0)),
                     BigDecimal.ZERO, "CREDIT_CARD",
-                    ORDER_REFERENCE, Instant.now(), 1
+                    ORDER_REFERENCE, "tenant-test-001", 42, Instant.now(), 1
             );
             when(productRepository.findAllByIdInOrderById(List.of(1)))
                     .thenReturn(List.of(laptop));

--- a/tenant-service/Dockerfile
+++ b/tenant-service/Dockerfile
@@ -10,6 +10,7 @@ WORKDIR /build
 COPY . .
 
 # Build only the tenant-service module
+ENV MAVEN_OPTS="-Dhttps.protocols=TLSv1.2,TLSv1.3"
 RUN mvn -B clean package -DskipTests=true -pl tenant-service -am
 
 # ===================================================================


### PR DESCRIPTION
Branch: `feature/live-demo-qa` · Date: 2026-06-13

---

## 1. Features / Fixes Implemented

| # | Problem (user-reported) | Root cause | Status |
|---|---|---|---|
| **A** | After login, **product/cart/order lists 503** ("service temporarily unavailable") | Gateway reactor-netty pool **reused stale keep-alive connections** that Tomcat had already closed (default 60s); no idle eviction configured | ✅ Fixed **+ proven live** |
| **B** | **Every order payment fails → "Order Cancelled"** | Saga events dropped request-scoped data → `payment` table NOT NULL violations, in 3 layers: `order_reference`, `tenant_id`, `order_id` | ✅ Fixed in code + tests green; ⏳ awaiting user rebuild for live proof |

---

## 2. Step-by-Step Execution

1. **Refused to assume** — pulled container status: all services `Up (healthy)`, so 503 was *not* a crash.
2. **Gateway logs** showed `FallbackController` firing for product/cart/order; product-service direct (`:8082`) returned 200 → isolated the fault to the **gateway↔service path**.
3. **Reproduced 503 deterministically**: after ~15 min idle the first gateway call returned **503** (stale pooled connection). Confirmed no `httpclient.pool` config existed.
4. **Traced the cancelled order** (`76a55871…`) across order/payment/product logs → `payment.failed reason=[null value in column "order_reference" … NOT NULL]`.
5. Found order-service built the event with `request.reference()` (null from UI) instead of persisted `order.getReference()` → **fixed**.
6. After deploying that fix, a fresh live order surfaced the **next** NOT NULL column: `tenant_id` (and then `order_id`) → diagnosed the saga never propagated tenant/orderId.
7. **Propagated `tenantId` + `orderId`** through all 3 services' local Kafka event records; payment seeds `TenantContext` from the event and stamps `payment.tenant_id`.
8. Updated affected tests; ran Maven → **all green**.
9. Applied gateway pool-eviction config, restarted gateway, **proved**: 90s idle → 5/5 calls HTTP 200.

---

## 3. Mapping to SKILL Phases (systematic-debugging)

| Phase | Activity this session |
|---|---|
| **1 — Root Cause** | Read errors verbatim; reproduced 503 after idle; traced correlation IDs through saga logs; gathered evidence at each component boundary (gateway→service, event→DB) |
| **2 — Pattern** | Compared working direct call (200) vs gateway call (503); compared order-service's explicit `setTenantId` vs payment's missing one |
| **3 — Hypothesis** | "Stale keep-alive reuse" → tested with idle-gap repro. "Saga drops tenant/order data" → confirmed by sequential NOT NULL errors |
| **4 — Implementation** | One root fix per cause; added regression tests (outbox payload carries reference; `tenant_id` stamped); verified `mvn test`; gateway fix proven live |

---

## 4. Files Created / Modified

**Production code**
- `order-service/.../OrderService.java` — event built from persisted reference + tenantId + orderId
- `order-service/.../kafka/OrderRequestedEvent.java` — added `tenantId`, `orderId`
- `product-service/.../kafka/OrderRequestedEvent.java` — added `tenantId`, `orderId` (consume)
- `product-service/.../kafka/InventoryReservedEvent.java` — added `tenantId`, `orderId`
- `product-service/.../kafka/InventoryReservationConsumer.java` — passes them through
- `payment-service/.../kafka/InventoryReservedEvent.java` — added `tenantId`, `orderId`
- `payment-service/.../kafka/PaymentSagaConsumer.java` — seeds `TenantContext` from event; passes real `orderId`; clears context in finally
- `payment-service/.../application/PaymentService.java` — stamps `payment.tenant_id` from `TenantContext`
- `config-service/.../configurations/gateway-service.yml` — `httpclient.pool` eviction (root fix for 503)

**Tests**
- `order-service/.../OrderServiceAsyncTest.java` — regression: outbox payload carries `ORD-` reference
- `product-service/.../InventoryReservationConsumerTest.java` — event arity updated (6 sites)
- `payment-service/.../PaymentServiceTest.java` — `TenantContext` setup + asserts `tenant_id` stamped
- `payment-service/.../bdd/PaymentStepDefinitions.java` — `TenantContext` hook

**Memory**
- `feedback_never_run_docker.md`, `project_saga_tenant_propagation_bug.md` (+ `MEMORY.md` index)

---

## 5. Current State

- **Gateway 503 fix:** ✅ deployed (gateway restarted) and **proven** — 90s idle → 5/5 HTTP 200. No rebuild needed.
- **Payment saga fix:** ✅ code + tests complete — **order-service 81 / product-service 100 / payment-service 35 tests, 0 failures**, BUILD SUCCESS. ⏳ **Not yet deployed** — needs container rebuild (Docker is run by the user only).
- Working tree has uncommitted changes (no commit made — per your no-git-actions rule).

---