### PR TITLE
feat: fixed bugs 2

### DIFF
--- a/cart-service/src/main/java/code/with/vanilson/cartservice/application/CartService.java
+++ b/cart-service/src/main/java/code/with/vanilson/cartservice/application/CartService.java
@@ -52,8 +52,23 @@ public class CartService {
     // READ
     // -------------------------------------------------------
 
+    /**
+     * Returns the customer's cart, or an empty (un-persisted) cart when none exists yet.
+     * <p>
+     * "The current user's cart" is a resource that conceptually always exists — a customer
+     * who has never added an item simply has an empty one. Returning 200 + empty cart instead
+     * of 404 stops the UI from showing a scary "cart.not.found" error on pages that probe the
+     * cart (e.g. right after login/registration) and removes the matching WARN log noise.
+     * The empty cart is NOT saved to Redis here — we only create a row when an item is added.
+     */
     public CartResponse getCart(String customerId) {
-        Cart cart = findOrThrow(buildCartId(customerId), customerId);
+        String cartId = buildCartId(customerId);
+        Cart cart = cartRepository.findById(cartId).orElseGet(() -> Cart.builder()
+                .cartId(cartId)
+                .customerId(customerId)
+                .tenantId(TenantContext.requireCurrentTenantId())
+                .items(new ArrayList<>())
+                .build());
         log.info(msg("cart.log.fetched", cart.getCartId(), cart.getItemCount()));
         return cartMapper.toResponse(cart);
     }

--- a/cart-service/src/test/java/code/with/vanilson/cartservice/CartServiceTest.java
+++ b/cart-service/src/test/java/code/with/vanilson/cartservice/CartServiceTest.java
@@ -126,13 +126,18 @@ class CartServiceTest {
             assertThat(result.itemCount()).isEqualTo(1);
         }
 
-        @Test @DisplayName("should throw CartNotFoundException when cart does not exist")
-        void shouldThrowWhenCartNotFound() {
+        @Test @DisplayName("should return an empty cart (200, not 404) when none exists yet")
+        void shouldReturnEmptyCartWhenNotFound() {
             when(cartRepository.findById(CART_ID)).thenReturn(Optional.empty());
+            CartResponse emptyResponse = buildResponse(CART_ID, CUSTOMER_ID, 0);
+            when(cartMapper.toResponse(any(Cart.class))).thenReturn(emptyResponse);
 
-            assertThatThrownBy(() -> cartService.getCart(CUSTOMER_ID))
-                    .isInstanceOf(CartNotFoundException.class)
-                    .hasMessageContaining("cart.not.found");
+            CartResponse result = cartService.getCart(CUSTOMER_ID);
+
+            assertThat(result).isNotNull();
+            assertThat(result.itemCount()).isEqualTo(0);
+            // Probing an empty cart must not persist anything to Redis.
+            verify(cartRepository, never()).save(any());
         }
     }
 

--- a/cart-service/src/test/java/code/with/vanilson/cartservice/presentation/CartControllerTest.java
+++ b/cart-service/src/test/java/code/with/vanilson/cartservice/presentation/CartControllerTest.java
@@ -3,7 +3,6 @@ package code.with.vanilson.cartservice.presentation;
 import code.with.vanilson.cartservice.application.AddCartItemRequest;
 import code.with.vanilson.cartservice.application.CartResponse;
 import code.with.vanilson.cartservice.application.CartService;
-import code.with.vanilson.cartservice.exception.CartNotFoundException;
 import code.with.vanilson.cartservice.exception.CartValidationException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
@@ -82,13 +81,16 @@ class CartControllerTest {
         }
 
         @Test
-        @DisplayName("should return 404 when cart not found")
-        void shouldReturn404() throws Exception {
-            when(cartService.getCart("unknown")).thenThrow(new CartNotFoundException("Not found", "cart.not.found"));
+        @DisplayName("should return 200 with an empty cart when none exists yet (not 404)")
+        void shouldReturn200EmptyWhenNoCartYet() throws Exception {
+            CartResponse empty = new CartResponse("cart:unknown", "unknown", List.of(),
+                    BigDecimal.ZERO, 0, null, null);
+            when(cartService.getCart("unknown")).thenReturn(empty);
 
             mockMvc.perform(get("/api/v1/carts/{customerId}", "unknown")
                             .header(TENANT_HEADER, TENANT_ID))
-                    .andExpect(status().isNotFound());
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.itemCount", is(0)));
         }
     }
 

--- a/config-service/Dockerfile
+++ b/config-service/Dockerfile
@@ -12,7 +12,10 @@ COPY . .
 
 # Build only the config-service module
 ENV MAVEN_OPTS="-Dhttps.protocols=TLSv1.2,TLSv1.3"
-RUN mvn -B clean package -DskipTests=true -pl config-service -am
+RUN mvn -B clean package -DskipTests=true -pl config-service -am \
+      -Dmaven.wagon.http.retryHandler.count=5 \
+      -Dmaven.wagon.http.retryHandler.requestSentEnabled=true \
+      -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
 
 # ===================================================================
 # Stage 2: Runtime Stage

--- a/config-service/src/main/resources/configurations/gateway-service.yml
+++ b/config-service/src/main/resources/configurations/gateway-service.yml
@@ -166,14 +166,23 @@ spring:
               args:
                 name: order-cb
                 fallbackUri: forward:/fallback/orders
+            # Retry transparently on transient connection blips (stale/cold keep-alive
+            # sockets surface as PrematureCloseException, a subclass of IOException) as
+            # well as on 503/502/504 statuses, BEFORE the circuit breaker counts a
+            # failure. This is what stops the "503 on the first GET after login".
+            # GET only — safe to replay.
             - name: Retry
               args:
-                retries: 1
-                statuses: BAD_GATEWAY,SERVICE_UNAVAILABLE
+                retries: 3
+                statuses: BAD_GATEWAY,SERVICE_UNAVAILABLE,GATEWAY_TIMEOUT
                 methods: GET
+                exceptions:
+                  - java.io.IOException
+                  - java.util.concurrent.TimeoutException
+                  - org.springframework.cloud.gateway.support.TimeoutException
                 backoff:
-                  firstBackoff: 200ms
-                  maxBackoff: 1000ms
+                  firstBackoff: 50ms
+                  maxBackoff: 500ms
                   factor: 2
 
         # -------------------------------------------------------
@@ -190,6 +199,21 @@ spring:
               args:
                 name: order-cb
                 fallbackUri: forward:/fallback/orders
+            # order-lines had NO retry — a single connection blip went straight to the
+            # 503 fallback, so the invoice/line-items view failed intermittently.
+            - name: Retry
+              args:
+                retries: 3
+                statuses: BAD_GATEWAY,SERVICE_UNAVAILABLE,GATEWAY_TIMEOUT
+                methods: GET
+                exceptions:
+                  - java.io.IOException
+                  - java.util.concurrent.TimeoutException
+                  - org.springframework.cloud.gateway.support.TimeoutException
+                backoff:
+                  firstBackoff: 50ms
+                  maxBackoff: 500ms
+                  factor: 2
 
         # -------------------------------------------------------
         # PRODUCT SERVICE
@@ -205,13 +229,20 @@ spring:
               args:
                 name: product-cb
                 fallbackUri: forward:/fallback/products
+            # Product list must be reliably available right after login — retry transient
+            # connection blips (PrematureCloseException ⊂ IOException) and 503/502/504,
+            # GET only, before the breaker falls back.
             - name: Retry
               args:
-                retries: 2
-                statuses: BAD_GATEWAY,SERVICE_UNAVAILABLE
+                retries: 3
+                statuses: BAD_GATEWAY,SERVICE_UNAVAILABLE,GATEWAY_TIMEOUT
                 methods: GET
+                exceptions:
+                  - java.io.IOException
+                  - java.util.concurrent.TimeoutException
+                  - org.springframework.cloud.gateway.support.TimeoutException
                 backoff:
-                  firstBackoff: 100ms
+                  firstBackoff: 50ms
                   maxBackoff: 500ms
                   factor: 2
 
@@ -289,21 +320,24 @@ resilience4j:
         slow-call-rate-threshold: 80
         slow-call-duration-threshold: 5s
       order-cb:
-        sliding-window-size: 10
-        minimum-number-of-calls: 5
-        failure-rate-threshold: 60
-        wait-duration-in-open-state: 10s
-        permitted-number-of-calls-in-half-open-state: 5
-        slow-call-rate-threshold: 80
-        slow-call-duration-threshold: 5s
-      product-cb:
         sliding-window-size: 20
+        # Needs more failures before tripping — one cold/slow first call must not open it.
         minimum-number-of-calls: 10
-        failure-rate-threshold: 70
-        wait-duration-in-open-state: 10s
+        failure-rate-threshold: 60
+        # Recover quickly: half-open after 5s so a brief blip doesn't 503 every call for 10s.
+        wait-duration-in-open-state: 5s
         permitted-number-of-calls-in-half-open-state: 5
-        slow-call-rate-threshold: 80
-        slow-call-duration-threshold: 5s
+        slow-call-rate-threshold: 90
+        # These services genuinely take ~4s on the first hit — do NOT count that as a failure.
+        slow-call-duration-threshold: 15s
+      product-cb:
+        sliding-window-size: 30
+        minimum-number-of-calls: 15
+        failure-rate-threshold: 70
+        wait-duration-in-open-state: 5s
+        permitted-number-of-calls-in-half-open-state: 5
+        slow-call-rate-threshold: 90
+        slow-call-duration-threshold: 15s
       payment-cb:
         sliding-window-size: 10
         failure-rate-threshold: 30

--- a/frontend/src/api/orders.api.ts
+++ b/frontend/src/api/orders.api.ts
@@ -8,8 +8,18 @@ import type {
 } from './types';
 
 export const ordersApi = {
-  create: (data: OrderRequest) =>
-    apiClient.post<OrderCreateResponse>('/orders', data).then((r) => r.data),
+  // idempotencyKey: a stable per-checkout UUID. The gateway can return a false 503
+  // on a write that actually succeeded (stale keep-alive connection); sending the
+  // same key on a resubmit lets order-service return the existing order instead of
+  // creating a duplicate.
+  create: (data: OrderRequest, idempotencyKey?: string) =>
+    apiClient
+      .post<OrderCreateResponse>(
+        '/orders',
+        data,
+        idempotencyKey ? { headers: { 'Idempotency-Key': idempotencyKey } } : undefined,
+      )
+      .then((r) => r.data),
 
   getStatus: (correlationId: string) =>
     apiClient

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -14,7 +14,19 @@ import './index.css';
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      retry: 1,
+      // Transient gateway blips (503 fallback, 502/504, or a dropped connection that
+      // surfaces as status 0) should self-heal before the user ever sees an error —
+      // the backends can be slow to warm up on the first call after login. Retry those
+      // up to 4 times with a short backoff; everything else (404/403/401/400) retries
+      // at most once, as before.
+      retry: (failureCount, error) => {
+        const status = (error as { status?: number } | null)?.status;
+        if (status === 503 || status === 502 || status === 504 || status === 0) {
+          return failureCount < 4;
+        }
+        return failureCount < 1;
+      },
+      retryDelay: (attempt) => Math.min(300 * 2 ** attempt, 2000),
       refetchOnWindowFocus: false,
     },
   },

--- a/frontend/src/pages/customer/CheckoutPage.tsx
+++ b/frontend/src/pages/customer/CheckoutPage.tsx
@@ -20,7 +20,7 @@ import {
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
-import { useQuery, useMutation } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { motion, AnimatePresence } from 'framer-motion';
 import { cartApi } from '@api/cart.api';
 import { ordersApi } from '@api/orders.api';
@@ -53,8 +53,11 @@ const PAYMENT_METHODS: { value: PaymentMethod; label: string }[] = [
 
 const STEPS = ['Delivery address', 'Payment method', 'Confirm order'];
 
+const IDEMPOTENCY_KEY_STORAGE = 'checkout_idempotency_key';
+
 export default function CheckoutPage() {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const { userId } = useAuthStore();
   const addToast = useUIStore((s) => s.addToast);
   const [activeStep, setActiveStep] = useState(() => {
@@ -64,6 +67,19 @@ export default function CheckoutPage() {
   const [paymentMethod, setPaymentMethod] = useState<PaymentMethod>('CREDIT_CARD');
   const [correlationId, setCorrelationId] = useState<string | null>(null);
   const submittingRef = useRef(false);
+
+  // Stable per-checkout idempotency key. Persisted in sessionStorage so a resubmit
+  // after a (possibly false) 503 reuses the same key → order-service de-duplicates
+  // instead of creating a second order. Cleared once the order is accepted (202).
+  const idempotencyKeyRef = useRef<string>(
+    (() => {
+      const existing = sessionStorage.getItem(IDEMPOTENCY_KEY_STORAGE);
+      if (existing) return existing;
+      const key = crypto.randomUUID();
+      sessionStorage.setItem(IDEMPOTENCY_KEY_STORAGE, key);
+      return key;
+    })(),
+  );
 
   const { data: cart, isLoading: cartLoading } = useQuery({
     queryKey: [QUERY_KEYS.CART, userId],
@@ -89,19 +105,24 @@ export default function CheckoutPage() {
 
   const { mutate: placeOrder, isPending: placingOrder, error: orderError } = useMutation({
     mutationFn: () =>
-      ordersApi.create({
-        amount: cart!.total,
-        paymentMethod,
-        customerId: userId!,
-        products: cart!.items.map((i) => ({
-          productId: i.productId,
-          quantity: i.quantity,
-        })),
-      }),
+      ordersApi.create(
+        {
+          amount: cart!.total,
+          paymentMethod,
+          customerId: userId!,
+          products: cart!.items.map((i) => ({
+            productId: i.productId,
+            quantity: i.quantity,
+          })),
+        },
+        idempotencyKeyRef.current,
+      ),
     onSuccess: (res) => {
       submittingRef.current = false;
       sessionStorage.removeItem('checkout_step');
       sessionStorage.removeItem('checkout_address');
+      // Order accepted — the next checkout must use a fresh idempotency key.
+      sessionStorage.removeItem(IDEMPOTENCY_KEY_STORAGE);
       setCorrelationId(res.correlationId);
       setActiveStep(3);
     },
@@ -118,7 +139,11 @@ export default function CheckoutPage() {
 
   const handleTimelineComplete = (status: OrderStatus) => {
     if (status === 'CONFIRMED') {
-      cartApi.clear(userId!);
+      // Clear server-side, then refresh the cached cart so the header badge and
+      // drawer empty immediately instead of only after the next navigation.
+      cartApi.clear(userId!).finally(() => {
+        queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.CART, userId] });
+      });
       addToast({ message: 'Order confirmed!', variant: 'success' });
     } else if (status === 'CANCELLED') {
       addToast({ message: 'Order was cancelled. Please try again.', variant: 'error' });

--- a/frontend/src/pages/customer/DashboardPage.tsx
+++ b/frontend/src/pages/customer/DashboardPage.tsx
@@ -43,7 +43,8 @@ export default function DashboardPage() {
     queryKey: [QUERY_KEYS.ORDERS],
     queryFn: ({ signal }) => ordersApi.getMyOrders(signal),
     staleTime: 30 * 1000,
-    retry: false,
+    // Inherit the global smart retry so a transient 503 right after login self-heals
+    // instead of showing "Failed to load your orders".
     throwOnError: false,
   });
 

--- a/frontend/src/pages/public/CatalogPage.tsx
+++ b/frontend/src/pages/public/CatalogPage.tsx
@@ -121,7 +121,7 @@ export default function CatalogPage() {
       }),
     staleTime: 2 * 60 * 1000,
     placeholderData: (prev) => prev,
-    retry: 1,
+    // Inherit the global smart retry — the product list must survive a transient 503.
   });
 
   const apiError = error as AppError | null;

--- a/order-service/src/main/java/code/with/vanilson/orderservice/OrderController.java
+++ b/order-service/src/main/java/code/with/vanilson/orderservice/OrderController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -61,8 +62,10 @@ public class OrderController {
     })
     @PreAuthorize("isAuthenticated()")
     @PostMapping
-    public ResponseEntity<Map<String, String>> createOrder(@RequestBody @Valid OrderRequest request) {
-        String correlationId = orderService.createOrder(request);
+    public ResponseEntity<Map<String, String>> createOrder(
+            @RequestBody @Valid OrderRequest request,
+            @RequestHeader(value = "Idempotency-Key", required = false) String idempotencyKey) {
+        String correlationId = orderService.createOrder(request, idempotencyKey);
         return ResponseEntity
                 .status(HttpStatus.ACCEPTED)
                 .body(Map.of(

--- a/order-service/src/main/java/code/with/vanilson/orderservice/OrderService.java
+++ b/order-service/src/main/java/code/with/vanilson/orderservice/OrderService.java
@@ -113,11 +113,50 @@ public class OrderService {
      */
     @Transactional
     public String createOrder(OrderRequest request) {
+        return createOrder(request, null);
+    }
+
+    /**
+     * Creates an order, with optional client-supplied idempotency.
+     * <p>
+     * The {@code idempotencyKey} (sent by the client as the {@code Idempotency-Key}
+     * header) makes order creation safe to retry. Without it, a <em>false</em> 503 at
+     * the gateway — caused by a stale keep-alive connection on a write that actually
+     * succeeded — let a user's resubmit create a <strong>second</strong> order
+     * (observed in live QA as a duplicated order). When a key is supplied we reuse it
+     * as the order's {@code correlationId} (already {@code unique}, so no new schema):
+     * if an order with that key already exists for this tenant, we return its
+     * correlationId unchanged instead of creating a duplicate. The DB unique constraint
+     * on {@code correlationId} is the final backstop against a concurrent double-submit.
+     *
+     * @param request        validated order request
+     * @param idempotencyKey client-generated key, stable across retries of one checkout; may be null
+     * @return correlationId for the client to poll status
+     */
+    @Transactional
+    public String createOrder(OrderRequest request, String idempotencyKey) {
         // Derive customerId from the authenticated JWT principal, not the request body.
         // The principal's userId (Long) is the string key used as the MongoDB customer _id.
         // This prevents spoofing where user A sends user B's customerId.
         String customerId = resolveCustomerId(request);
         log.info(msg("order.log.creating", customerId, request.products().size()));
+
+        boolean hasIdempotencyKey = idempotencyKey != null && !idempotencyKey.isBlank();
+        String correlationId = hasIdempotencyKey ? idempotencyKey : UUID.randomUUID().toString();
+
+        // Idempotent replay: if this key already produced an order for this tenant,
+        // return that order rather than creating a second one.
+        if (hasIdempotencyKey) {
+            filterActivator.activateFilter();
+            String tenantId = TenantContext.requireCurrentTenantId();
+            var existing = orderRepository.findByCorrelationIdAndTenantId(correlationId, tenantId);
+            if (existing.isPresent()) {
+                log.info("[OrderService] Idempotent replay — returning existing order: "
+                                + "correlationId=[{}] orderId=[{}]",
+                        correlationId, existing.get().getOrderId());
+                return correlationId;
+            }
+        }
 
         // Step 1 — Validate customer (snapshot-first, Feign fallback)
         CustomerInfo customer = resolveCustomer(customerId);
@@ -125,7 +164,6 @@ public class OrderService {
         log.info(msg("order.log.customer.found", customer.customerId()));
 
         // Step 2 — Persist order in REQUESTED state
-        String correlationId = UUID.randomUUID().toString();
         Order order = persistOrderWithLines(request, correlationId);
 
         log.info(msg("order.log.order.saved", order.getOrderId(), order.getReference()));

--- a/order-service/src/main/java/code/with/vanilson/orderservice/orderLine/OrderLineController.java
+++ b/order-service/src/main/java/code/with/vanilson/orderservice/orderLine/OrderLineController.java
@@ -29,11 +29,17 @@ public class OrderLineController {
 
     /**
      * Returns all order lines for a given order ID.
+     * <p>
+     * Any authenticated user may call this, but the service enforces that only the
+     * order's owner (or an ADMIN) actually receives the lines — non-owners get 403.
+     * This matches {@code GET /api/v1/orders/{id}} and the error message contract
+     * ("Only the owner or an ADMIN can view it"). Previously this was
+     * {@code hasRole('ADMIN')}, which 403'd every customer viewing their own order.
      *
      * @param orderId the parent order ID
      * @return list of order lines
      */
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("isAuthenticated()")
     @GetMapping("/{order-id}")
     public ResponseEntity<List<OrderLineResponse>> findByOrderId(
             @PathVariable("order-id") Integer orderId) {

--- a/order-service/src/main/java/code/with/vanilson/orderservice/orderLine/OrderLineService.java
+++ b/order-service/src/main/java/code/with/vanilson/orderservice/orderLine/OrderLineService.java
@@ -1,8 +1,17 @@
 package code.with.vanilson.orderservice.orderLine;
 
+import code.with.vanilson.orderservice.Order;
+import code.with.vanilson.orderservice.OrderRepository;
+import code.with.vanilson.orderservice.exception.OrderForbiddenException;
+import code.with.vanilson.orderservice.exception.OrderNotFoundException;
 import code.with.vanilson.tenantcontext.TenantContext;
+import code.with.vanilson.tenantcontext.TenantHibernateFilterActivator;
+import code.with.vanilson.tenantcontext.security.SecurityPrincipal;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.MessageSource;
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -12,6 +21,9 @@ import java.util.stream.Collectors;
  * OrderLineService — Application Layer (Phase 4 update)
  * <p>
  * Phase 4: sets tenantId from TenantContext on every new order line.
+ * <p>
+ * Authorization: {@link #findAllByOrderId(Integer)} enforces owner-or-ADMIN access,
+ * mirroring {@link code.with.vanilson.orderservice.OrderService#findById(Integer)}.
  * </p>
  *
  * @author vamuhong
@@ -24,6 +36,9 @@ public class OrderLineService {
 
     private final OrderLineRepository repository;
     private final OrderLineMapper mapper;
+    private final OrderRepository orderRepository;
+    private final TenantHibernateFilterActivator filterActivator;
+    private final MessageSource messageSource;
 
     /**
      * Persists a single order line.
@@ -42,15 +57,43 @@ public class OrderLineService {
     }
 
     /**
-     * Returns all order lines for a given order ID.
+     * Returns all order lines for a given order ID, after verifying the caller
+     * owns the parent order (or is an ADMIN).
      *
      * @param orderId the parent order ID
      * @return list of OrderLineResponse DTOs
+     * @throws OrderNotFoundException  if no order exists with the given id
+     * @throws OrderForbiddenException if the caller is neither the owner nor an ADMIN
      */
     public List<OrderLineResponse> findAllByOrderId(Integer orderId) {
+        filterActivator.activateFilter();
+
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new OrderNotFoundException(
+                        msg("order.not.found", orderId), "order.not.found"));
+
+        SecurityPrincipal principal = currentPrincipal();
+        if (principal != null && !"ADMIN".equals(principal.role())
+                && !order.getCustomerId().equals(String.valueOf(principal.userId()))) {
+            throw new OrderForbiddenException(
+                    msg("order.access.denied"), "order.access.denied");
+        }
+
         return repository.findAllOrderById(orderId)
                 .stream()
                 .map(mapper::toOrderLineResponse)
                 .collect(Collectors.toList());
+    }
+
+    private SecurityPrincipal currentPrincipal() {
+        var auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !(auth.getPrincipal() instanceof SecurityPrincipal sp)) {
+            return null;
+        }
+        return sp;
+    }
+
+    private String msg(String key, Object... args) {
+        return messageSource.getMessage(key, args, LocaleContextHolder.getLocale());
     }
 }

--- a/order-service/src/test/java/code/with/vanilson/orderservice/OrderControllerSecurityTest.java
+++ b/order-service/src/test/java/code/with/vanilson/orderservice/OrderControllerSecurityTest.java
@@ -104,7 +104,7 @@ class OrderControllerSecurityTest {
         @Test
         @DisplayName("202 when authenticated USER creates order")
         void authenticated_user_creates_order() throws Exception {
-            when(orderService.createOrder(any())).thenReturn("corr-id-123");
+            when(orderService.createOrder(any(), any())).thenReturn("corr-id-123");
 
             mockMvc.perform(post(BASE)
                             .header(TENANT_HDR, TENANT_VAL)
@@ -117,7 +117,7 @@ class OrderControllerSecurityTest {
         @Test
         @DisplayName("202 when ADMIN creates order")
         void admin_creates_order() throws Exception {
-            when(orderService.createOrder(any())).thenReturn("corr-id-456");
+            when(orderService.createOrder(any(), any())).thenReturn("corr-id-456");
 
             mockMvc.perform(post(BASE)
                             .header(TENANT_HDR, TENANT_VAL)

--- a/order-service/src/test/java/code/with/vanilson/orderservice/OrderControllerTest.java
+++ b/order-service/src/test/java/code/with/vanilson/orderservice/OrderControllerTest.java
@@ -103,7 +103,7 @@ class OrderControllerTest {
         @Test
         @DisplayName("should return 202 Accepted with correlationId when valid request")
         void shouldReturn202WithCorrelationId() throws Exception {
-            when(orderService.createOrder(any(OrderRequest.class))).thenReturn("corr-id-001");
+            when(orderService.createOrder(any(OrderRequest.class), any())).thenReturn("corr-id-001");
 
             mockMvc.perform(post("/api/v1/orders")
                             .header("X-Tenant-ID", "test-tenant-123")
@@ -125,7 +125,7 @@ class OrderControllerTest {
                     "cust-001",
                     List.of(new ProductPurchaseRequest(1, 1.0))
             );
-            when(orderService.createOrder(any(OrderRequest.class))).thenReturn("corr-id-auto");
+            when(orderService.createOrder(any(OrderRequest.class), any())).thenReturn("corr-id-auto");
 
             mockMvc.perform(post("/api/v1/orders")
                             .header("X-Tenant-ID", "test-tenant-123")
@@ -139,7 +139,7 @@ class OrderControllerTest {
         @Test
         @DisplayName("should return 503 when customer service is unavailable")
         void shouldReturn503WhenCustomerUnavailable() throws Exception {
-            when(orderService.createOrder(any(OrderRequest.class)))
+            when(orderService.createOrder(any(OrderRequest.class), any()))
                     .thenThrow(new CustomerServiceUnavailableException("Unavailable", "order.customer.not.found"));
 
             mockMvc.perform(post("/api/v1/orders")

--- a/order-service/src/test/java/code/with/vanilson/orderservice/OrderServiceAsyncTest.java
+++ b/order-service/src/test/java/code/with/vanilson/orderservice/OrderServiceAsyncTest.java
@@ -420,6 +420,71 @@ class OrderServiceAsyncTest {
     }
 
     // -------------------------------------------------------
+    // createOrder — idempotency (Idempotency-Key header)
+    // -------------------------------------------------------
+
+    @Nested
+    @DisplayName("createOrder — idempotency key prevents duplicate orders")
+    class CreateOrderIdempotency {
+
+        private static final String IDEM_KEY = "11111111-2222-3333-4444-555555555555";
+
+        @Test
+        @DisplayName("replay with a known key returns the existing order and creates nothing")
+        void replayReturnsExistingWithoutCreating() {
+            // An order already exists for this idempotency key (used as correlationId) + tenant.
+            when(orderRepository.findByCorrelationIdAndTenantId(IDEM_KEY, "test-tenant-123"))
+                    .thenReturn(Optional.of(savedOrder));
+
+            String correlationId = orderService.createOrder(validRequest, IDEM_KEY);
+
+            assertThat(correlationId).isEqualTo(IDEM_KEY);
+            // No new order, no customer resolution, no outbox event — pure replay.
+            verify(orderRepository, never()).save(any());
+            verify(orderMapper, never()).toOrder(any());
+            verify(outboxRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("first use of a key creates the order with that key as correlationId")
+        void firstUseCreatesWithKeyAsCorrelationId() {
+            when(orderRepository.findByCorrelationIdAndTenantId(IDEM_KEY, "test-tenant-123"))
+                    .thenReturn(Optional.empty());
+            when(snapshotRepository.findById("cust-001")).thenReturn(Optional.empty());
+            when(customerClient.findCustomerById("cust-001")).thenReturn(Optional.of(validCustomer));
+            when(orderRepository.existsByReference("REF-PHASE3-001")).thenReturn(false);
+            when(orderMapper.toOrder(any())).thenReturn(savedOrder);
+            when(orderRepository.save(any())).thenReturn(savedOrder);
+            when(outboxRepository.save(any())).thenReturn(new OutboxEvent());
+
+            String correlationId = orderService.createOrder(validRequest, IDEM_KEY);
+
+            assertThat(correlationId).isEqualTo(IDEM_KEY);
+            // The persisted order carried the idempotency key as its correlationId.
+            ArgumentCaptor<Order> captor = ArgumentCaptor.forClass(Order.class);
+            verify(orderRepository).save(captor.capture());
+            assertThat(captor.getValue().getCorrelationId()).isEqualTo(IDEM_KEY);
+        }
+
+        @Test
+        @DisplayName("null key falls back to a generated UUID correlationId")
+        void nullKeyGeneratesUuid() {
+            when(snapshotRepository.findById("cust-001")).thenReturn(Optional.empty());
+            when(customerClient.findCustomerById("cust-001")).thenReturn(Optional.of(validCustomer));
+            when(orderRepository.existsByReference("REF-PHASE3-001")).thenReturn(false);
+            when(orderMapper.toOrder(any())).thenReturn(savedOrder);
+            when(orderRepository.save(any())).thenReturn(savedOrder);
+            when(outboxRepository.save(any())).thenReturn(new OutboxEvent());
+
+            String correlationId = orderService.createOrder(validRequest, null);
+
+            assertThat(correlationId).matches("[0-9a-f\\-]{36}");
+            // No idempotency lookup performed when no key is supplied.
+            verify(orderRepository, never()).findByCorrelationIdAndTenantId(any(), any());
+        }
+    }
+
+    // -------------------------------------------------------
     // getOrderStatus — saga polling
     // -------------------------------------------------------
 

--- a/order-service/src/test/java/code/with/vanilson/orderservice/orderLine/OrderLineServiceTest.java
+++ b/order-service/src/test/java/code/with/vanilson/orderservice/orderLine/OrderLineServiceTest.java
@@ -1,7 +1,12 @@
 package code.with.vanilson.orderservice.orderLine;
 
 import code.with.vanilson.orderservice.Order;
+import code.with.vanilson.orderservice.OrderRepository;
+import code.with.vanilson.orderservice.exception.OrderForbiddenException;
+import code.with.vanilson.orderservice.exception.OrderNotFoundException;
 import code.with.vanilson.tenantcontext.TenantContext;
+import code.with.vanilson.tenantcontext.TenantHibernateFilterActivator;
+import code.with.vanilson.tenantcontext.security.SecurityPrincipal;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -12,11 +17,20 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.MessageSource;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -24,7 +38,9 @@ import static org.mockito.Mockito.when;
 /**
  * OrderLineServiceTest — Unit Tests
  * <p>
- * Covers saveOrderLine() and findAllByOrderId().
+ * Covers saveOrderLine() and findAllByOrderId(), including owner-or-ADMIN
+ * authorization. Regression for the live-demo bug where a customer viewing
+ * their own order received 403 (controller was {@code hasRole('ADMIN')}).
  * Framework: JUnit 5 + Mockito + AssertJ.
  * </p>
  *
@@ -37,9 +53,15 @@ class OrderLineServiceTest {
 
     @Mock private OrderLineRepository repository;
     @Mock private OrderLineMapper     mapper;
+    @Mock private OrderRepository      orderRepository;
+    @Mock private TenantHibernateFilterActivator filterActivator;
+    @Mock private MessageSource        messageSource;
 
     @InjectMocks
     private OrderLineService orderLineService;
+
+    private static final Integer ORDER_ID = 42;
+    private static final String  OWNER_ID = "7";
 
     private OrderLineRequest request;
     private OrderLine        orderLine;
@@ -49,11 +71,14 @@ class OrderLineServiceTest {
     void setUp() {
         TenantContext.setCurrentTenantId("test-tenant-123");
 
-        request = new OrderLineRequest(null, 42, 1, 2.0);
+        lenient().when(messageSource.getMessage(any(String.class), any(), any(Locale.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+
+        request = new OrderLineRequest(null, ORDER_ID, 1, 2.0);
 
         orderLine = OrderLine.builder()
                 .id(10)
-                .order(Order.builder().orderId(42).build())
+                .order(Order.builder().orderId(ORDER_ID).build())
                 .productId(1)
                 .quantity(2.0)
                 .build();
@@ -64,6 +89,19 @@ class OrderLineServiceTest {
     @AfterEach
     void cleanup() {
         TenantContext.clear();
+        SecurityContextHolder.clearContext();
+    }
+
+    private void authenticateAs(long userId, String role) {
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(
+                        new SecurityPrincipal("user@test.com", userId, "test-tenant-123", role),
+                        null,
+                        List.of(new SimpleGrantedAuthority("ROLE_" + role))));
+    }
+
+    private Order orderOwnedBy(String customerId) {
+        return Order.builder().orderId(ORDER_ID).customerId(customerId).build();
     }
 
     // -------------------------------------------------------
@@ -100,19 +138,21 @@ class OrderLineServiceTest {
     }
 
     // -------------------------------------------------------
-    // findAllByOrderId
+    // findAllByOrderId — owner-or-ADMIN authorization
     // -------------------------------------------------------
     @Nested
     @DisplayName("findAllByOrderId")
     class FindAllByOrderId {
 
         @Test
-        @DisplayName("should return mapped list of order line responses")
-        void shouldReturnMappedResponses() {
-            when(repository.findAllOrderById(42)).thenReturn(List.of(orderLine));
+        @DisplayName("owner: should return mapped list of order line responses")
+        void ownerGetsMappedResponses() {
+            authenticateAs(7L, "USER");
+            when(orderRepository.findById(ORDER_ID)).thenReturn(Optional.of(orderOwnedBy(OWNER_ID)));
+            when(repository.findAllOrderById(ORDER_ID)).thenReturn(List.of(orderLine));
             when(mapper.toOrderLineResponse(orderLine)).thenReturn(response);
 
-            List<OrderLineResponse> result = orderLineService.findAllByOrderId(42);
+            List<OrderLineResponse> result = orderLineService.findAllByOrderId(ORDER_ID);
 
             assertThat(result)
                     .isNotNull()
@@ -122,16 +162,51 @@ class OrderLineServiceTest {
                         assertThat(r.id()).isEqualTo(10);
                         assertThat(r.quantity()).isEqualTo(2.0);
                     });
+            verify(filterActivator).activateFilter();
         }
 
         @Test
-        @DisplayName("should return empty list when no order lines exist")
-        void shouldReturnEmptyList() {
-            when(repository.findAllOrderById(99)).thenReturn(List.of());
+        @DisplayName("owner: should return empty list when no order lines exist")
+        void ownerGetsEmptyList() {
+            authenticateAs(7L, "USER");
+            when(orderRepository.findById(ORDER_ID)).thenReturn(Optional.of(orderOwnedBy(OWNER_ID)));
+            when(repository.findAllOrderById(ORDER_ID)).thenReturn(List.of());
 
-            List<OrderLineResponse> result = orderLineService.findAllByOrderId(99);
+            List<OrderLineResponse> result = orderLineService.findAllByOrderId(ORDER_ID);
 
             assertThat(result).isNotNull().isEmpty();
+        }
+
+        @Test
+        @DisplayName("ADMIN: may read lines for an order they do not own")
+        void adminGetsLines() {
+            authenticateAs(999L, "ADMIN");
+            when(orderRepository.findById(ORDER_ID)).thenReturn(Optional.of(orderOwnedBy(OWNER_ID)));
+            when(repository.findAllOrderById(ORDER_ID)).thenReturn(List.of());
+
+            assertThat(orderLineService.findAllByOrderId(ORDER_ID)).isEmpty();
+        }
+
+        @Test
+        @DisplayName("non-owner: should throw OrderForbiddenException (403)")
+        void nonOwnerForbidden() {
+            authenticateAs(8L, "USER");
+            when(orderRepository.findById(ORDER_ID)).thenReturn(Optional.of(orderOwnedBy(OWNER_ID)));
+
+            assertThatThrownBy(() -> orderLineService.findAllByOrderId(ORDER_ID))
+                    .isInstanceOf(OrderForbiddenException.class);
+
+            verify(repository, never()).findAllOrderById(any());
+        }
+
+        @Test
+        @DisplayName("missing order: should throw OrderNotFoundException (404)")
+        void missingOrder() {
+            authenticateAs(7L, "USER");
+            when(orderRepository.findById(ORDER_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> orderLineService.findAllByOrderId(ORDER_ID))
+                    .isInstanceOf(OrderNotFoundException.class);
         }
     }
 }


### PR DESCRIPTION
# 📋 Session Report — Live-Demo QA Round 2: 503s, Order Duplication, 403 & Cart 404

**Branch:** `feature/live-demo-qa-1` · **Date:** 2026-06-13 · **Skill applied:** `superpowers:systematic-debugging`

---

## 1. Features / Fixes Implemented

| # | Problem (user-reported) | Root cause | Status |
|---|---|---|---|
| **A** | **Order duplicated** after a 503 (counted twice) — money loss | POST `/orders` non-idempotent: every call minted a fresh `correlationId`/`reference`. A *false* 503 (stale gateway↔backend socket on a write that succeeded) → user resubmits → 2nd order | ✅ Code + tests; ⏳ awaiting rebuild |
| **B** | **403** viewing own order invoice (`/order-lines/{id}`) | `OrderLineController` was `@PreAuthorize("hasRole('ADMIN')")` — blocked every owner, contradicting its own error message | ✅ Code + tests; ⏳ awaiting rebuild |
| **C** | **404** `cart.not.found` on every page incl. after login/register | `CartService.getCart` threw when no cart existed yet | ✅ Code + tests; ⏳ awaiting rebuild |
| **D** | Items stay in cart after payment (until navigation) | `cartApi.clear()` ran on CONFIRMED but didn't invalidate the React Query cache → stale badge | ✅ Frontend; ⏳ awaiting build |
| **E** | **503** product/order "all the time after login" | Gateway CircuitBreaker fallback on a single failed call; Retry only covered 503/502 *status*, not the connection exception; breakers intolerant of genuinely-slow (~4s) first calls | ✅ Robust config + frontend safety net; ⏳ **needs config-service rebuild + gateway restart to verify** |

---

## 2. Step-by-Step Execution

1. **Refused to assume** — clustered 6 symptoms by likely root cause; read the actual code paths before proposing any fix.
2. Read `OrderLineController` → confirmed `hasRole('ADMIN')` bug on sight (B).
3. Traced the duplication: ruled out auto-retry in **axios** (only retries 401), **gateway** (POST not retried on order route), and **React Query** (mutations default `retry:false`). Concluded: non-idempotent create + false-503 resubmit (A).
4. Confirmed `reference` + `correlationId` are both server-generated → reused the existing **unique `correlationId`** as the idempotency key (no DB migration).
5. Found order-service **never** calls cart-clear (grep) → cart clearing is frontend-driven via `handleTimelineComplete`; missing cache invalidation (D).
6. `CartService.getCart` → `findOrThrow` confirmed as the 404 source (C).
7. Diagnosed the 503: CircuitBreaker fallback on connection blips; Retry lacked `exceptions`; `slow-call-duration-threshold: 5s` too tight for ~4s first calls (E).
8. Implemented all fixes; updated affected tests; ran Maven (order + cart) and frontend `tsc`/build/vitest → **all green**.
9. Repaired the local Windows `rolldown` native binding (node_modules was linux-only) so the frontend build/tests could run.

---

## 3. Mapping to SKILL Phases (systematic-debugging)

| Phase | Activity this session |
|---|---|
| **1 — Root Cause** | Read errors verbatim; traced data flow backward (duplicate order → no idempotency key; 403 → annotation; 404 → getCart throw); gathered evidence at each boundary (axios → gateway → service) before any fix |
| **2 — Pattern** | Compared `OrderService.findById` (correct owner-or-ADMIN) vs `OrderLineController` (ADMIN-only); compared working `addItem` cart-creation vs `getCart` throw |
| **3 — Hypothesis** | "POST not idempotent → resubmit duplicates" → confirmed by ruling out every auto-retry path. "Retry doesn't cover connection exception" → matches the config comment + fallback timing |
| **4 — Implementation** | One root fix per cause + regression tests (idempotency replay, ownership 403, empty-cart 200); verified all suites green. **503 honestly flagged unproven** — needs deploy |

---

## 4. Files Created / Modified

**Production code**
- `order-service/.../orderLine/OrderLineController.java` — `isAuthenticated()` (was ADMIN-only)
- `order-service/.../orderLine/OrderLineService.java` — owner-or-ADMIN ownership check
- `order-service/.../OrderController.java` — `Idempotency-Key` header param
- `order-service/.../OrderService.java` — `createOrder(request, idempotencyKey)` overload + idempotent replay
- `cart-service/.../application/CartService.java` — `getCart` returns transient empty cart (200)
- `config-service/.../gateway-service.yml` — Retry on connection exceptions (product, order, **+order-lines added**); tolerant `product-cb`/`order-cb`
- `frontend/src/api/orders.api.ts` — sends `Idempotency-Key`
- `frontend/src/pages/customer/CheckoutPage.tsx` — per-checkout idempotency key + cart cache invalidation
- `frontend/src/main.tsx` — global smart retry on 503/502/504/network
- `frontend/src/pages/customer/DashboardPage.tsx` — removed `retry:false`
- `frontend/src/pages/public/CatalogPage.tsx` — removed `retry:1`

**Tests**
- `order-service/.../orderLine/OrderLineServiceTest.java` — rewritten: owner/ADMIN/forbidden/not-found (5) + save (2)
- `order-service/.../OrderServiceAsyncTest.java` — `CreateOrderIdempotency` nested (3)
- `order-service/.../OrderControllerTest.java` + `OrderControllerSecurityTest.java` — two-arg `createOrder` mocks
- `cart-service/.../CartServiceTest.java` + `presentation/CartControllerTest.java` — empty-cart-200 tests; removed unused import

**Memory**
- `project_qa_idempotency_authz_cart_bugs.md`, `reference_rolldown_win32_binding.md` (+ `MEMORY.md` index)

**Environment (local only)**
- `npm install --no-save @rolldown/binding-win32-x64-msvc@1.0.0-rc.15` — fixed Windows build (lockfile untouched)

---

## 5. Current State

- **All test suites green:** order-service **87/0**, cart-service **62/0**, frontend **36/0** + `tsc` clean + `npm run build` OK. Gateway YAML parses valid.
- **Nothing committed** (per your no-git rule). **Nothing deployed** — you run Docker.
- The errors you're still seeing have **old timestamps** (17:xx/18:xx) — from before these changes. None are live yet.
- The 503 fix is the **only** one I could not prove from here (no Docker) — it is the correct, layered configuration but requires deploy to confirm.

---

## 6. Next Steps (you run Docker)

1. **config-service** rebuild **+ restart `gateway-api-service`** → activates the 503 fix (gateway only re-reads config on restart). **This is the one that kills the 503.**
2. **order-service** rebuild → 403 fix + order idempotency.
3. **cart-service** rebuild → empty-cart-200.
4. **frontend** `npm run build` → 503 safety net + Idempotency-Key + cart clear.

After deploy: if a 503 still appears, send the log **with the new timestamp** — that gives me real evidence at the gateway to see why the retry didn't absorb it, instead of guessing.