### PR TITLE
feat: Product service RBAC + ownership fields2

### DIFF
--- a/frontend/src/api/orders.api.ts
+++ b/frontend/src/api/orders.api.ts
@@ -26,8 +26,13 @@ export const ordersApi = {
       .get<OrderStatusResponse>(`/orders/status/${correlationId}`)
       .then((r) => r.data),
 
+  // ADMIN-only: every order across the platform.
   getAll: (signal?: AbortSignal) =>
     apiClient.get<OrderResponse[]>('/orders', { signal }).then((r) => r.data),
+
+  // SELLER: only orders placed for the seller's own products (scoped by seller_id).
+  getSeller: (signal?: AbortSignal) =>
+    apiClient.get<OrderResponse[]>('/orders/seller', { signal }).then((r) => r.data),
 
   getById: (orderId: number, signal?: AbortSignal) =>
     apiClient.get<OrderResponse>(`/orders/${orderId}`, { signal }).then((r) => r.data),

--- a/frontend/src/api/products.api.ts
+++ b/frontend/src/api/products.api.ts
@@ -23,6 +23,13 @@ export const productsApi = {
       .get<PageResponse<ProductResponse>>('/products', { params: { page, size }, signal })
       .then((r) => r.data),
 
+  // Seller's own products only (scoped by created_by on the backend). Newest-first.
+  // Used by the seller management screens; the public catalogue uses getAll/search.
+  getMine: (page = 0, size = 20, signal?: AbortSignal) =>
+    apiClient
+      .get<PageResponse<ProductResponse>>('/products/mine', { params: { page, size }, signal })
+      .then((r) => r.data),
+
   getById: (id: number) =>
     apiClient.get<ProductResponse>(`/products/${id}`).then((r) => r.data),
 

--- a/frontend/src/pages/public/AuthFlow.test.tsx
+++ b/frontend/src/pages/public/AuthFlow.test.tsx
@@ -52,11 +52,14 @@ describe('RegisterPage — both roles must sign in after registering', () => {
     await user.type(screen.getByLabelText(/first name/i), 'Ada');
     await user.type(screen.getByLabelText(/last name/i), 'Lovelace');
     await user.type(screen.getByLabelText(/email/i), 'ada@example.com');
-    await user.type(screen.getByLabelText(/password/i), 'password123');
+    await user.type(screen.getByLabelText(/password/i, { selector: 'input' }), 'password123');
     await user.click(screen.getByRole('button', { name: /create account/i }));
 
-    await waitFor(() => expect(path).toBe('/login'));
-    // And the login form is empty (no prefill from registration)
+    // findByText waits for LoginPage's subtitle to appear in the DOM — this is
+    // unique to LoginPage and only true after the route commit, avoiding the race
+    // between LocationProbe's render-phase path update and the actual DOM transition.
+    await screen.findByText('Sign in to your account', {}, { timeout: 5000 });
+    // Now LoginPage is definitively mounted — email must be empty (no auto-fill).
     const email = screen.getByLabelText(/email/i) as HTMLInputElement;
     expect(email.value).toBe('');
   });
@@ -70,7 +73,7 @@ describe('RegisterPage — both roles must sign in after registering', () => {
     await user.type(screen.getByLabelText(/first name/i), 'Sam');
     await user.type(screen.getByLabelText(/last name/i), 'Seller');
     await user.type(screen.getByLabelText(/email/i), 'sam@shop.example');
-    await user.type(screen.getByLabelText(/password/i), 'password123');
+    await user.type(screen.getByLabelText(/password/i, { selector: 'input' }), 'password123');
     await user.click(screen.getByRole('button', { name: /create account/i }));
 
     await waitFor(() => expect(path).toBe('/login'));

--- a/frontend/src/pages/public/AuthFlow.test.tsx
+++ b/frontend/src/pages/public/AuthFlow.test.tsx
@@ -46,8 +46,7 @@ describe('LoginPage — email is always empty', () => {
 describe('RegisterPage — both roles must sign in after registering', () => {
   it('USER registration navigates to /login (no auto-login)', async () => {
     const user = userEvent.setup();
-    let path = '';
-    renderAt(['/register'], (p) => { path = p; });
+    renderAt(['/register']);
 
     await user.type(screen.getByLabelText(/first name/i), 'Ada');
     await user.type(screen.getByLabelText(/last name/i), 'Lovelace');

--- a/frontend/src/pages/public/AuthFlow.test.tsx
+++ b/frontend/src/pages/public/AuthFlow.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ThemeProvider } from '@mui/material';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createAppTheme } from '@theme/mui-theme';
+import LoginPage from './LoginPage';
+import RegisterPage from './RegisterPage';
+
+const theme = createAppTheme('dark');
+
+function LocationProbe({ onChange }: { onChange: (path: string) => void }) {
+  const loc = useLocation();
+  onChange(loc.pathname);
+  return null;
+}
+
+function renderAt(initialEntries: Array<string | { pathname: string; state?: unknown }>, onLocation?: (p: string) => void) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider theme={theme}>
+        <MemoryRouter initialEntries={initialEntries}>
+          {onLocation && <LocationProbe onChange={onLocation} />}
+          <Routes>
+            <Route path="/login" element={<LoginPage />} />
+            <Route path="/register" element={<RegisterPage />} />
+            <Route path="/seller" element={<div>seller-dashboard</div>} />
+            <Route path="/account" element={<div>account-dashboard</div>} />
+          </Routes>
+        </MemoryRouter>
+      </ThemeProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe('LoginPage — email is always empty', () => {
+  it('renders an empty email field even when navigation state carries an email', () => {
+    renderAt([{ pathname: '/login', state: { email: 'leftover@example.com' } }]);
+    const email = screen.getByLabelText(/email/i) as HTMLInputElement;
+    expect(email.value).toBe('');
+  });
+});
+
+describe('RegisterPage — both roles must sign in after registering', () => {
+  it('USER registration navigates to /login (no auto-login)', async () => {
+    const user = userEvent.setup();
+    let path = '';
+    renderAt(['/register'], (p) => { path = p; });
+
+    await user.type(screen.getByLabelText(/first name/i), 'Ada');
+    await user.type(screen.getByLabelText(/last name/i), 'Lovelace');
+    await user.type(screen.getByLabelText(/email/i), 'ada@example.com');
+    await user.type(screen.getByLabelText(/password/i), 'password123');
+    await user.click(screen.getByRole('button', { name: /create account/i }));
+
+    await waitFor(() => expect(path).toBe('/login'));
+    // And the login form is empty (no prefill from registration)
+    const email = screen.getByLabelText(/email/i) as HTMLInputElement;
+    expect(email.value).toBe('');
+  });
+
+  it('SELLER registration also navigates to /login (no auto-login)', async () => {
+    const user = userEvent.setup();
+    let path = '';
+    renderAt(['/register'], (p) => { path = p; });
+
+    await user.click(screen.getByRole('button', { name: /i want to sell/i }));
+    await user.type(screen.getByLabelText(/first name/i), 'Sam');
+    await user.type(screen.getByLabelText(/last name/i), 'Seller');
+    await user.type(screen.getByLabelText(/email/i), 'sam@shop.example');
+    await user.type(screen.getByLabelText(/password/i), 'password123');
+    await user.click(screen.getByRole('button', { name: /create account/i }));
+
+    await waitFor(() => expect(path).toBe('/login'));
+    expect(screen.queryByText('seller-dashboard')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/public/LoginPage.tsx
+++ b/frontend/src/pages/public/LoginPage.tsx
@@ -31,9 +31,8 @@ type FormValues = z.infer<typeof schema>;
 export default function LoginPage() {
   const navigate = useNavigate();
   const location = useLocation();
-  const navState = location.state as { from?: string; email?: string } | null;
+  const navState = location.state as { from?: string } | null;
   const from = navState?.from ?? ROUTES.ACCOUNT;
-  const prefilledEmail = navState?.email ?? '';
   const setAuth = useAuthStore((s) => s.setAuth);
   const addToast = useUIStore((s) => s.addToast);
   const [showPassword, setShowPassword] = useState(false);
@@ -45,7 +44,7 @@ export default function LoginPage() {
     formState: { errors, isSubmitting },
   } = useForm<FormValues>({
     resolver: zodResolver(schema),
-    defaultValues: { email: prefilledEmail, password: '' },
+    defaultValues: { email: '', password: '' },
   });
 
   const onSubmit = async (values: FormValues) => {

--- a/frontend/src/pages/public/RegisterPage.tsx
+++ b/frontend/src/pages/public/RegisterPage.tsx
@@ -19,7 +19,6 @@ import {
 } from '@mui/material';
 import { Visibility, VisibilityOff } from '@mui/icons-material';
 import { authApi } from '@api/auth.api';
-import { useAuthStore } from '@stores/auth.store';
 import { useUIStore } from '@stores/ui.store';
 import { ROUTES } from '@utils/constants';
 import { normalizeError } from '@api/client';
@@ -36,7 +35,6 @@ type FormValues = z.infer<typeof schema>;
 
 export default function RegisterPage() {
   const navigate = useNavigate();
-  const setAuth = useAuthStore((s) => s.setAuth);
   const addToast = useUIStore((s) => s.addToast);
   const [showPassword, setShowPassword] = useState(false);
   const [serverError, setServerError] = useState<string | null>(null);
@@ -55,28 +53,13 @@ export default function RegisterPage() {
   const onSubmit = async (values: FormValues) => {
     setServerError(null);
     try {
-      const response = await authApi.register(values);
-      if (values.role === 'SELLER') {
-        setAuth({
-          accessToken: response.accessToken,
-          refreshToken: response.refreshToken,
-          userId: response.userId,
-          email: response.email,
-          role: response.role,
-          tenantId: response.tenantId,
-        });
-        addToast({
-          message: 'Welcome! Set up your store to start selling.',
-          variant: 'success',
-        });
-        navigate(ROUTES.SELLER, { replace: true });
-      } else {
-        addToast({
-          message: 'Account created — please sign in to continue',
-          variant: 'success',
-        });
-        navigate(ROUTES.LOGIN, { replace: true, state: { email: values.email } });
-      }
+      await authApi.register(values);
+      const message =
+        values.role === 'SELLER'
+          ? 'Seller account created — please sign in to access your store'
+          : 'Account created — please sign in to continue';
+      addToast({ message, variant: 'success' });
+      navigate(ROUTES.LOGIN, { replace: true });
     } catch (err) {
       const normalized = normalizeError(err);
       if (normalized.fieldErrors) {

--- a/frontend/src/pages/seller/InventoryPage.tsx
+++ b/frontend/src/pages/seller/InventoryPage.tsx
@@ -17,8 +17,8 @@ function StockBadge({ qty }: { qty: number }) {
 export default function InventoryPage() {
   const navigate = useNavigate();
   const { data, isLoading } = useQuery({
-    queryKey: [QUERY_KEYS.PRODUCTS, 0, 100],
-    queryFn: () => productsApi.getAll(0, 100),
+    queryKey: [QUERY_KEYS.MY_PRODUCTS, 0, 100],
+    queryFn: () => productsApi.getMine(0, 100),
     staleTime: 2 * 60 * 1000,
   });
 

--- a/frontend/src/pages/seller/OrderManagement.tsx
+++ b/frontend/src/pages/seller/OrderManagement.tsx
@@ -12,8 +12,8 @@ import type { OrderResponse } from '@api/types';
 export default function OrderManagement() {
   const navigate = useNavigate();
   const { data: orders, isLoading } = useQuery({
-    queryKey: [QUERY_KEYS.ORDERS],
-    queryFn: ({ signal }) => ordersApi.getAll(signal),
+    queryKey: [QUERY_KEYS.SELLER_ORDERS],
+    queryFn: ({ signal }) => ordersApi.getSeller(signal),
     staleTime: 30 * 1000,
   });
 

--- a/frontend/src/pages/seller/ProductForm.tsx
+++ b/frontend/src/pages/seller/ProductForm.tsx
@@ -82,6 +82,7 @@ export default function ProductForm() {
   const { mutateAsync: createProduct } = useMutation({
     mutationFn: (req: ProductRequest) => productsApi.create(req),
     onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.MY_PRODUCTS] });
       queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.PRODUCTS] });
       addToast({ message: 'Product created', variant: 'success' });
       navigate(ROUTES.SELLER_PRODUCTS);
@@ -92,6 +93,7 @@ export default function ProductForm() {
   const { mutateAsync: updateProduct } = useMutation({
     mutationFn: (req: ProductRequest) => productsApi.update(Number(id), req),
     onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.MY_PRODUCTS] });
       queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.PRODUCTS] });
       queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.PRODUCT, id] });
       addToast({ message: 'Product updated', variant: 'success' });

--- a/frontend/src/pages/seller/ProductManagement.tsx
+++ b/frontend/src/pages/seller/ProductManagement.tsx
@@ -20,14 +20,15 @@ export default function ProductManagement() {
   const [deleteTarget, setDeleteTarget] = useState<ProductResponse | null>(null);
 
   const { data, isLoading } = useQuery({
-    queryKey: [QUERY_KEYS.PRODUCTS, page, 20],
-    queryFn: () => productsApi.getAll(page, 20),
+    queryKey: [QUERY_KEYS.MY_PRODUCTS, page, 20],
+    queryFn: () => productsApi.getMine(page, 20),
     staleTime: 2 * 60 * 1000,
   });
 
   const { mutate: deleteProduct, isPending: deleting } = useMutation({
     mutationFn: (id: number) => productsApi.delete(id),
     onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.MY_PRODUCTS] });
       queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.PRODUCTS] });
       addToast({ message: 'Product deleted', variant: 'success' });
       setDeleteTarget(null);

--- a/frontend/src/pages/seller/SellerDashboard.tsx
+++ b/frontend/src/pages/seller/SellerDashboard.tsx
@@ -20,15 +20,15 @@ function StatCard({ label, value, sub }: { label: string; value: string; sub?: s
 
 export default function SellerDashboard() {
   const { data: products, isLoading: productsLoading } = useQuery({
-    queryKey: [QUERY_KEYS.PRODUCTS, 0, 100],
-    queryFn: ({ signal }) => productsApi.getAll(0, 100, signal),
+    queryKey: [QUERY_KEYS.MY_PRODUCTS, 0, 100],
+    queryFn: ({ signal }) => productsApi.getMine(0, 100, signal),
     staleTime: 2 * 60 * 1000,
     retry: false,
     throwOnError: false,
   });
   const { data: orders, isLoading: ordersLoading } = useQuery({
-    queryKey: [QUERY_KEYS.ORDERS],
-    queryFn: ({ signal }) => ordersApi.getAll(signal),
+    queryKey: [QUERY_KEYS.SELLER_ORDERS],
+    queryFn: ({ signal }) => ordersApi.getSeller(signal),
     staleTime: 30 * 1000,
     retry: false,
     throwOnError: false,

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -25,10 +25,12 @@ export const ROUTES = {
 
 export const QUERY_KEYS = {
   PRODUCTS: 'products',
+  MY_PRODUCTS: 'my-products',
   PRODUCT: 'product',
   CATEGORIES: 'categories',
   CART: 'cart',
   ORDERS: 'orders',
+  SELLER_ORDERS: 'seller-orders',
   ORDER: 'order',
   ORDER_STATUS: 'order-status',
   ORDER_LINES: 'order-lines',

--- a/order-service/src/main/java/code/with/vanilson/orderservice/OrderController.java
+++ b/order-service/src/main/java/code/with/vanilson/orderservice/OrderController.java
@@ -90,11 +90,23 @@ public class OrderController {
         return ResponseEntity.ok(orderService.getOrderStatus(correlationId));
     }
 
-    @Operation(summary = "List orders within the caller's tenant (ADMIN or SELLER)")
-    @PreAuthorize("hasAnyRole('ADMIN','SELLER')")
+    @Operation(summary = "List ALL orders across the platform (ADMIN only)",
+            description = "Returns every order regardless of seller. Sellers must use GET /orders/seller, " +
+                    "which scopes to orders placed for their own products — competing sellers never see " +
+                    "each other's orders.")
+    @PreAuthorize("hasRole('ADMIN')")
     @GetMapping
     public ResponseEntity<List<OrderResponse>> findAll() {
         return ResponseEntity.ok(orderService.findAllOrders());
+    }
+
+    @Operation(summary = "List orders placed for the authenticated seller's products",
+            description = "Returns only orders that contain at least one product owned by the caller (SELLER). " +
+                    "Ownership is the seller_id stamped on each order line at creation.")
+    @PreAuthorize("hasAnyRole('ADMIN','SELLER')")
+    @GetMapping("/seller")
+    public ResponseEntity<List<OrderResponse>> findSellerOrders() {
+        return ResponseEntity.ok(orderService.findOrdersForSeller());
     }
 
     @Operation(summary = "List orders for the authenticated user")

--- a/order-service/src/main/java/code/with/vanilson/orderservice/OrderController.java
+++ b/order-service/src/main/java/code/with/vanilson/orderservice/OrderController.java
@@ -90,8 +90,8 @@ public class OrderController {
         return ResponseEntity.ok(orderService.getOrderStatus(correlationId));
     }
 
-    @Operation(summary = "List all orders (admin only)")
-    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "List orders within the caller's tenant (ADMIN or SELLER)")
+    @PreAuthorize("hasAnyRole('ADMIN','SELLER')")
     @GetMapping
     public ResponseEntity<List<OrderResponse>> findAll() {
         return ResponseEntity.ok(orderService.findAllOrders());

--- a/order-service/src/main/java/code/with/vanilson/orderservice/OrderService.java
+++ b/order-service/src/main/java/code/with/vanilson/orderservice/OrderService.java
@@ -259,6 +259,26 @@ public class OrderService {
         return orders;
     }
 
+    /**
+     * Returns the orders that contain at least one of the authenticated seller's
+     * products. Marketplace isolation: a seller sees only orders placed for their own
+     * products (keyed off the {@code seller_id} stamped on each line at creation), never
+     * other sellers' orders. Backs {@code GET /api/v1/orders/seller}.
+     */
+    public List<OrderResponse> findOrdersForSeller() {
+        SecurityPrincipal principal = currentPrincipal();
+        if (principal == null) {
+            return List.of();
+        }
+        String sellerId = String.valueOf(principal.userId());
+        List<OrderResponse> orders = orderLineService.findOrdersForSeller(sellerId)
+                .stream()
+                .map(orderMapper::fromOrder)
+                .collect(Collectors.toList());
+        log.info("[OrderService] Seller orders for sellerId=[{}]: count=[{}]", sellerId, orders.size());
+        return orders;
+    }
+
     public List<OrderResponse> findMyOrders() {
         filterActivator.activateFilter();
         SecurityPrincipal principal = currentPrincipal();
@@ -282,7 +302,9 @@ public class OrderService {
 
         SecurityPrincipal principal = currentPrincipal();
         if (principal != null && !"ADMIN".equals(principal.role())
-                && !order.getCustomerId().equals(String.valueOf(principal.userId()))) {
+                && !order.getCustomerId().equals(String.valueOf(principal.userId()))
+                && !(principal.isSeller()
+                     && orderLineService.sellerOwnsLineInOrder(id, String.valueOf(principal.userId())))) {
             throw new OrderForbiddenException(
                     msg("order.access.denied"), "order.access.denied");
         }

--- a/order-service/src/main/java/code/with/vanilson/orderservice/orderLine/OrderLine.java
+++ b/order-service/src/main/java/code/with/vanilson/orderservice/orderLine/OrderLine.java
@@ -58,4 +58,13 @@ public class OrderLine {
     private Integer productId;
 
     private double quantity;
+
+    /**
+     * Marketplace ownership: the userId of the SELLER who owns this line's product
+     * (= product.createdBy), stamped at order creation. Lets a seller see exactly the
+     * orders placed for their own products. Nullable — pre-existing lines and any line
+     * whose product lookup failed at creation stay null and simply don't surface.
+     */
+    @Column(name = "seller_id")
+    private String sellerId;
 }

--- a/order-service/src/main/java/code/with/vanilson/orderservice/orderLine/OrderLineRepository.java
+++ b/order-service/src/main/java/code/with/vanilson/orderservice/orderLine/OrderLineRepository.java
@@ -1,5 +1,6 @@
 package code.with.vanilson.orderservice.orderLine;
 
+import code.with.vanilson.orderservice.Order;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -36,4 +37,25 @@ public interface OrderLineRepository extends JpaRepository<OrderLine, Integer> {
      */
     @Query("SELECT ol FROM OrderLine ol WHERE ol.order.orderId = :orderId")
     List<OrderLine> findAllOrderById(@Param("orderId") Integer orderId);
+
+    /**
+     * Returns the distinct orders that contain at least one line owned by the given
+     * seller (line.sellerId = product.createdBy). Backs the seller order list — each
+     * seller sees only the orders placed for their own products.
+     *
+     * @param sellerId the seller's userId
+     * @return distinct parent orders, newest-first
+     */
+    @Query("SELECT DISTINCT ol.order FROM OrderLine ol WHERE ol.sellerId = :sellerId "
+            + "ORDER BY ol.order.orderId DESC")
+    List<Order> findDistinctOrdersBySellerId(@Param("sellerId") String sellerId);
+
+    /**
+     * @return true if the given seller owns at least one line in the given order —
+     *         used to authorise a seller viewing an order's detail / lines.
+     */
+    @Query("SELECT (COUNT(ol) > 0) FROM OrderLine ol "
+            + "WHERE ol.order.orderId = :orderId AND ol.sellerId = :sellerId")
+    boolean existsByOrderIdAndSellerId(@Param("orderId") Integer orderId,
+                                       @Param("sellerId") String sellerId);
 }

--- a/order-service/src/main/java/code/with/vanilson/orderservice/orderLine/OrderLineService.java
+++ b/order-service/src/main/java/code/with/vanilson/orderservice/orderLine/OrderLineService.java
@@ -4,6 +4,7 @@ import code.with.vanilson.orderservice.Order;
 import code.with.vanilson.orderservice.OrderRepository;
 import code.with.vanilson.orderservice.exception.OrderForbiddenException;
 import code.with.vanilson.orderservice.exception.OrderNotFoundException;
+import code.with.vanilson.orderservice.product.ProductClient;
 import code.with.vanilson.tenantcontext.TenantContext;
 import code.with.vanilson.tenantcontext.TenantHibernateFilterActivator;
 import code.with.vanilson.tenantcontext.security.SecurityPrincipal;
@@ -39,6 +40,7 @@ public class OrderLineService {
     private final OrderRepository orderRepository;
     private final TenantHibernateFilterActivator filterActivator;
     private final MessageSource messageSource;
+    private final ProductClient productClient;
 
     /**
      * Persists a single order line.
@@ -50,10 +52,51 @@ public class OrderLineService {
     public Integer saveOrderLine(OrderLineRequest request) {
         OrderLine orderLine = mapper.toOrderLine(request);
         orderLine.setTenantId(TenantContext.requireCurrentTenantId());
+        orderLine.setSellerId(resolveSellerId(request.productId()));
         Integer savedId = repository.save(orderLine).getId();
-        log.debug("[OrderLineService] Saved order line: id=[{}] orderId=[{}] productId=[{}] qty=[{}]",
-                savedId, request.orderId(), request.productId(), request.quantity());
+        log.debug("[OrderLineService] Saved order line: id=[{}] orderId=[{}] productId=[{}] qty=[{}] sellerId=[{}]",
+                savedId, request.orderId(), request.productId(), request.quantity(), orderLine.getSellerId());
         return savedId;
+    }
+
+    /**
+     * Resolves the owning seller (product.createdBy) for a product, used to stamp the
+     * order line at creation. Defensive: a null productId or any product-service failure
+     * yields {@code null} (logged) rather than blocking checkout — the line is still
+     * persisted; it just won't surface to a seller until backfilled.
+     */
+    private String resolveSellerId(Integer productId) {
+        if (productId == null) {
+            return null;
+        }
+        try {
+            return productClient.getProductById(productId)
+                    .map(p -> p.createdBy())
+                    .orElse(null);
+        } catch (Exception ex) {
+            log.warn("[OrderLineService] Could not resolve seller for productId=[{}] — order line stored without "
+                    + "sellerId: {}", productId, ex.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Returns the distinct orders that contain at least one line owned by the given
+     * seller. Backs {@code GET /api/v1/orders/seller}.
+     *
+     * @param sellerId the seller's userId
+     * @return orders placed for the seller's products (most-recent-first by DB order)
+     */
+    public List<Order> findOrdersForSeller(String sellerId) {
+        filterActivator.activateFilter();
+        return repository.findDistinctOrdersBySellerId(sellerId);
+    }
+
+    /**
+     * @return true if the given seller owns at least one line in the given order.
+     */
+    public boolean sellerOwnsLineInOrder(Integer orderId, String sellerId) {
+        return repository.existsByOrderIdAndSellerId(orderId, sellerId);
     }
 
     /**
@@ -74,7 +117,9 @@ public class OrderLineService {
 
         SecurityPrincipal principal = currentPrincipal();
         if (principal != null && !"ADMIN".equals(principal.role())
-                && !order.getCustomerId().equals(String.valueOf(principal.userId()))) {
+                && !order.getCustomerId().equals(String.valueOf(principal.userId()))
+                && !(principal.isSeller()
+                     && repository.existsByOrderIdAndSellerId(orderId, String.valueOf(principal.userId())))) {
             throw new OrderForbiddenException(
                     msg("order.access.denied"), "order.access.denied");
         }

--- a/order-service/src/main/java/code/with/vanilson/orderservice/product/ProductClient.java
+++ b/order-service/src/main/java/code/with/vanilson/orderservice/product/ProductClient.java
@@ -1,0 +1,34 @@
+package code.with.vanilson.orderservice.product;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.Optional;
+
+/**
+ * ProductClient
+ * <p>
+ * Feign client owned by order-service. Resolves a product's owning seller
+ * ({@code createdBy}) so each order line can be stamped with its seller_id at
+ * creation — this is what lets a seller see exactly the orders placed for their
+ * own products.
+ * <p>
+ * Targets product-service's public {@code GET /api/v1/products/{id}} via
+ * {@code application.config.product-url}. The {@link code.with.vanilson.tenantcontext.TenantFeignInterceptor}
+ * forwards the caller's Authorization + X-Tenant-Id automatically. Failures are
+ * handled defensively at the call site (see OrderLineService) so a transient
+ * product-service hiccup never blocks checkout.
+ *
+ * @author vamuhong
+ * @version 1.0
+ */
+@FeignClient(
+        name = "product-service",
+        url = "${application.config.product-url}"
+)
+public interface ProductClient {
+
+    @GetMapping("/{product-id}")
+    Optional<ProductOwnerResponse> getProductById(@PathVariable("product-id") Integer productId);
+}

--- a/order-service/src/main/java/code/with/vanilson/orderservice/product/ProductOwnerResponse.java
+++ b/order-service/src/main/java/code/with/vanilson/orderservice/product/ProductOwnerResponse.java
@@ -1,0 +1,22 @@
+package code.with.vanilson.orderservice.product;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * ProductOwnerResponse
+ * <p>
+ * Minimal local DTO owned by order-service. Captures only the fields of
+ * product-service's {@code ProductResponse} that order-service needs to stamp
+ * ownership on an order line: the product id and its {@code createdBy} (the
+ * owning seller's userId). Unknown JSON properties are ignored so the full
+ * product payload deserialises without coupling to product-service's DTO.
+ *
+ * @author vamuhong
+ * @version 1.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ProductOwnerResponse(
+        Integer id,
+        String createdBy
+) {
+}

--- a/order-service/src/main/resources/db/migration/V1_10__add_seller_id_to_order_line.sql
+++ b/order-service/src/main/resources/db/migration/V1_10__add_seller_id_to_order_line.sql
@@ -1,0 +1,17 @@
+-- V1_10__add_seller_id_to_order_line.sql
+-- Marketplace: stamp the owning seller (product.created_by) on every order line so a
+-- seller can see exactly the orders placed for THEIR products — competing sellers are
+-- isolated by ownership, not by the shared "default" tenant.
+-- Nullable: pre-existing lines (and any line whose product lookup fails at creation)
+-- stay NULL and simply won't surface to a seller.
+
+BEGIN;
+
+ALTER TABLE customer_line
+    ADD COLUMN IF NOT EXISTS seller_id VARCHAR(255);
+
+-- Index for the seller order query (WHERE seller_id = ?)
+CREATE INDEX IF NOT EXISTS idx_order_line_seller_id
+    ON customer_line (seller_id);
+
+COMMIT;

--- a/order-service/src/test/java/code/with/vanilson/orderservice/OrderControllerSecurityTest.java
+++ b/order-service/src/test/java/code/with/vanilson/orderservice/OrderControllerSecurityTest.java
@@ -129,11 +129,11 @@ class OrderControllerSecurityTest {
     }
 
     // -------------------------------------------------------
-    // GET /orders — list all (ADMIN only)
+    // GET /orders — list orders within tenant (ADMIN or SELLER)
     // -------------------------------------------------------
 
     @Nested
-    @DisplayName("GET /orders — list all (ADMIN only)")
+    @DisplayName("GET /orders — list orders within tenant (ADMIN or SELLER)")
     class ListOrders {
 
         @Test
@@ -161,6 +161,18 @@ class OrderControllerSecurityTest {
             mockMvc.perform(get(BASE)
                             .header(TENANT_HDR, TENANT_VAL)
                             .with(authentication(authAs(1L, "ADMIN"))))
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        @DisplayName("200 when SELLER lists their tenant's orders")
+        void seller_lists_tenant_orders() throws Exception {
+            when(orderService.findAllOrders()).thenReturn(List.of(
+                    new OrderResponse(1, "REF-001", BigDecimal.valueOf(100), "CREDIT_CARD", "42", "REQUESTED")));
+
+            mockMvc.perform(get(BASE)
+                            .header(TENANT_HDR, TENANT_VAL)
+                            .with(authentication(authAs(7L, "SELLER"))))
                     .andExpect(status().isOk());
         }
     }

--- a/order-service/src/test/java/code/with/vanilson/orderservice/OrderControllerSecurityTest.java
+++ b/order-service/src/test/java/code/with/vanilson/orderservice/OrderControllerSecurityTest.java
@@ -129,11 +129,11 @@ class OrderControllerSecurityTest {
     }
 
     // -------------------------------------------------------
-    // GET /orders — list orders within tenant (ADMIN or SELLER)
+    // GET /orders — list ALL orders across the platform (ADMIN only)
     // -------------------------------------------------------
 
     @Nested
-    @DisplayName("GET /orders — list orders within tenant (ADMIN or SELLER)")
+    @DisplayName("GET /orders — list ALL orders (ADMIN only)")
     class ListOrders {
 
         @Test
@@ -165,14 +165,59 @@ class OrderControllerSecurityTest {
         }
 
         @Test
-        @DisplayName("200 when SELLER lists their tenant's orders")
-        void seller_lists_tenant_orders() throws Exception {
-            when(orderService.findAllOrders()).thenReturn(List.of(
-                    new OrderResponse(1, "REF-001", BigDecimal.valueOf(100), "CREDIT_CARD", "42", "REQUESTED")));
-
+        @DisplayName("403 when SELLER tries to list ALL orders — must use /orders/seller")
+        void seller_cannot_list_all_orders() throws Exception {
             mockMvc.perform(get(BASE)
                             .header(TENANT_HDR, TENANT_VAL)
                             .with(authentication(authAs(7L, "SELLER"))))
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    // -------------------------------------------------------
+    // GET /orders/seller — orders for the seller's own products (SELLER or ADMIN)
+    // -------------------------------------------------------
+
+    @Nested
+    @DisplayName("GET /orders/seller — seller's own product orders (SELLER or ADMIN)")
+    class SellerOrders {
+
+        @Test
+        @DisplayName("401 when unauthenticated")
+        void unauthenticated_gets_401() throws Exception {
+            mockMvc.perform(get(BASE + "/seller").header(TENANT_HDR, TENANT_VAL))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("403 when USER tries to list seller orders")
+        void user_cannot_list_seller_orders() throws Exception {
+            mockMvc.perform(get(BASE + "/seller")
+                            .header(TENANT_HDR, TENANT_VAL)
+                            .with(authentication(authAs(42L, "USER"))))
+                    .andExpect(status().isForbidden());
+        }
+
+        @Test
+        @DisplayName("200 when SELLER lists orders for their own products")
+        void seller_lists_their_product_orders() throws Exception {
+            when(orderService.findOrdersForSeller()).thenReturn(List.of(
+                    new OrderResponse(1, "REF-001", BigDecimal.valueOf(100), "CREDIT_CARD", "42", "REQUESTED")));
+
+            mockMvc.perform(get(BASE + "/seller")
+                            .header(TENANT_HDR, TENANT_VAL)
+                            .with(authentication(authAs(7L, "SELLER"))))
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        @DisplayName("200 when ADMIN lists seller orders")
+        void admin_can_list_seller_orders() throws Exception {
+            when(orderService.findOrdersForSeller()).thenReturn(List.of());
+
+            mockMvc.perform(get(BASE + "/seller")
+                            .header(TENANT_HDR, TENANT_VAL)
+                            .with(authentication(authAs(1L, "ADMIN"))))
                     .andExpect(status().isOk());
         }
     }

--- a/order-service/src/test/java/code/with/vanilson/orderservice/orderLine/OrderLineServiceTest.java
+++ b/order-service/src/test/java/code/with/vanilson/orderservice/orderLine/OrderLineServiceTest.java
@@ -4,6 +4,7 @@ import code.with.vanilson.orderservice.Order;
 import code.with.vanilson.orderservice.OrderRepository;
 import code.with.vanilson.orderservice.exception.OrderForbiddenException;
 import code.with.vanilson.orderservice.exception.OrderNotFoundException;
+import code.with.vanilson.orderservice.product.ProductClient;
 import code.with.vanilson.tenantcontext.TenantContext;
 import code.with.vanilson.tenantcontext.TenantHibernateFilterActivator;
 import code.with.vanilson.tenantcontext.security.SecurityPrincipal;
@@ -56,6 +57,7 @@ class OrderLineServiceTest {
     @Mock private OrderRepository      orderRepository;
     @Mock private TenantHibernateFilterActivator filterActivator;
     @Mock private MessageSource        messageSource;
+    @Mock private ProductClient        productClient;
 
     @InjectMocks
     private OrderLineService orderLineService;

--- a/product-service/src/main/java/code/with/vanilson/productservice/ProductController.java
+++ b/product-service/src/main/java/code/with/vanilson/productservice/ProductController.java
@@ -64,6 +64,19 @@ public class ProductController {
         return ResponseEntity.ok(productService.getAllProducts(pageable));
     }
 
+    @Operation(summary = "List the authenticated seller's own products (paginated)",
+               description = "Returns only products created by the caller (SELLER) — competing sellers " +
+                       "never see each other's catalogue. Newest-first by default. ADMIN sees their own too; " +
+                       "use GET /products for the full cross-seller catalogue.")
+    @ApiResponse(responseCode = "200", description = "Seller's own products retrieved successfully")
+    @GetMapping("/mine")
+    @PreAuthorize("hasAnyRole('SELLER','ADMIN')")
+    public ResponseEntity<Page<ProductResponse>> getMyProducts(
+            @PageableDefault(size = 20, sort = "id", direction = Sort.Direction.DESC)
+            @Parameter(hidden = true) Pageable pageable) {
+        return ResponseEntity.ok(productService.getMyProducts(pageable));
+    }
+
     @Operation(summary = "Get product by ID")
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "Product found"),

--- a/product-service/src/main/java/code/with/vanilson/productservice/ProductRepository.java
+++ b/product-service/src/main/java/code/with/vanilson/productservice/ProductRepository.java
@@ -1,6 +1,8 @@
 package code.with.vanilson.productservice;
 
 import jakarta.persistence.LockModeType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Lock;
@@ -49,4 +51,20 @@ public interface ProductRepository extends JpaRepository<Product, Integer>, JpaS
     @QueryHints(@QueryHint(name = "jakarta.persistence.lock.timeout", value = "3000"))
     @Query("SELECT p FROM Product p WHERE p.id IN :ids ORDER BY p.id ASC")
     List<Product> findAllByIdInOrderById(@Param("ids") List<Integer> ids);
+
+    /**
+     * Returns only the products created by the given user (the seller's own catalogue).
+     * <p>
+     * Backs {@code GET /api/v1/products/mine}: in this marketplace, competing sellers
+     * must not see each other's products. Ownership is keyed off {@code created_by}
+     * (the seller's userId, stamped at creation) — not {@code tenant_id}, which the
+     * read path does not currently filter on. The public catalogue ({@code /products},
+     * {@code /products/search}) intentionally stays cross-seller so customers browse
+     * every store.
+     *
+     * @param createdBy the seller's userId (as stored in {@code created_by})
+     * @param pageable  pagination and sort parameters
+     * @return page of the seller's own products
+     */
+    Page<Product> findByCreatedBy(String createdBy, Pageable pageable);
 }

--- a/product-service/src/main/java/code/with/vanilson/productservice/ProductService.java
+++ b/product-service/src/main/java/code/with/vanilson/productservice/ProductService.java
@@ -90,6 +90,31 @@ public class ProductService {
     }
 
     /**
+     * Returns a paginated list of the authenticated seller's own products.
+     * <p>
+     * Marketplace rule: competing sellers must not see each other's products, so this
+     * scopes by {@code created_by = principal.userId} (ownership) — the field stamped at
+     * creation in {@link #createProduct(Product)}. This is the read-side counterpart to
+     * the write-side ownership checks already enforced in {@link #updateProduct} and
+     * {@link #deleteProduct}. NOT cached on the shared {@code product-list} key, which is
+     * page-only and would leak one seller's products to another.
+     *
+     * @param pageable pagination and sort parameters (defaults to newest-first)
+     * @return Page of the caller's own ProductResponse DTOs (empty if unauthenticated)
+     */
+    public Page<ProductResponse> getMyProducts(Pageable pageable) {
+        SecurityPrincipal principal = currentPrincipal();
+        if (principal == null) {
+            return Page.empty(pageable);
+        }
+        String createdBy = String.valueOf(principal.userId());
+        Page<ProductResponse> page = productRepository.findByCreatedBy(createdBy, pageable)
+                .map(productMapper::fromProduct);
+        log.info(resolve("product.log.mine.found", page.getTotalElements(), createdBy));
+        return page;
+    }
+
+    /**
      * Returns a single product by ID.
      * Cached individually in Redis under 'products::{id}'.
      *

--- a/product-service/src/main/java/code/with/vanilson/productservice/config/ProductSecurityConfig.java
+++ b/product-service/src/main/java/code/with/vanilson/productservice/config/ProductSecurityConfig.java
@@ -37,6 +37,9 @@ public class ProductSecurityConfig {
                     "/v3/api-docs/**",
                     "/api-docs/**"
                 ).permitAll()
+                // Seller's own catalogue must be authenticated — matched BEFORE the public
+                // GET /** rule below (first match wins). Role is enforced via @PreAuthorize.
+                .requestMatchers(HttpMethod.GET, "/api/v1/products/mine").authenticated()
                 .requestMatchers(HttpMethod.GET, "/api/v1/products", "/api/v1/products/**").permitAll()
                 .anyRequest().authenticated()
             )

--- a/product-service/src/main/resources/messages.properties
+++ b/product-service/src/main/resources/messages.properties
@@ -38,6 +38,7 @@ product.validation.failed=Invalid data in product request.
 
 # --- Logs ---
 product.log.all.found=Product listing: total=[{0}]
+product.log.mine.found=Seller product listing: total=[{0}] createdBy=[{1}]
 product.log.found.by.id=Product found: id=[{0}] name=[{1}]
 product.log.created=Product created: id=[{0}] name=[{1}]
 product.log.updated=Product updated: id=[{0}] name=[{1}]

--- a/product-service/src/test/java/code/with/vanilson/productservice/ProductControllerSecurityTest.java
+++ b/product-service/src/test/java/code/with/vanilson/productservice/ProductControllerSecurityTest.java
@@ -102,6 +102,52 @@ class ProductControllerSecurityTest {
     }
 
     // -------------------------------------------------------
+    // GET /mine — seller's own catalogue (SELLER or ADMIN only)
+    // -------------------------------------------------------
+
+    @Nested
+    @DisplayName("GET /mine — SELLER or ADMIN only")
+    class MyProducts {
+
+        @Test
+        @DisplayName("401 Unauthorized when no authentication")
+        void unauthenticated_gets_401() throws Exception {
+            mockMvc.perform(get(BASE + "/mine").header(TENANT_HDR, TENANT_VAL))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @WithMockUser(roles = "USER")
+        @DisplayName("403 Forbidden for USER role")
+        void user_cannot_list_mine() throws Exception {
+            mockMvc.perform(get(BASE + "/mine").header(TENANT_HDR, TENANT_VAL))
+                    .andExpect(status().isForbidden());
+        }
+
+        @Test
+        @WithMockUser(roles = "SELLER")
+        @DisplayName("200 OK for SELLER — returns the seller's own products")
+        void seller_can_list_mine() throws Exception {
+            when(productService.getMyProducts(any()))
+                    .thenReturn(org.springframework.data.domain.Page.empty());
+
+            mockMvc.perform(get(BASE + "/mine").header(TENANT_HDR, TENANT_VAL))
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        @WithMockUser(roles = "ADMIN")
+        @DisplayName("200 OK for ADMIN role")
+        void admin_can_list_mine() throws Exception {
+            when(productService.getMyProducts(any()))
+                    .thenReturn(org.springframework.data.domain.Page.empty());
+
+            mockMvc.perform(get(BASE + "/mine").header(TENANT_HDR, TENANT_VAL))
+                    .andExpect(status().isOk());
+        }
+    }
+
+    // -------------------------------------------------------
     // POST /create
     // -------------------------------------------------------
 


### PR DESCRIPTION
## Resumo final

### Problema 1 — SELLER no dashboard recebia 403 ✅
**Causa raiz:** [OrderController.java:94](order-service/src/main/java/code/with/vanilson/orderservice/OrderController.java:94) só aceitava `ADMIN`. O `AccessDeniedException` caía no handler genérico [OrderGlobalExceptionHandler.java:50](order-service/src/main/java/code/with/vanilson/orderservice/exception/OrderGlobalExceptionHandler.java:50) e re-usava a mesma chave i18n `order.access.denied` que está escrita para o caso singular do `findById` — daí a mensagem confusa "this order... owner or ADMIN".

**Fix:** `@PreAuthorize("hasAnyRole('ADMIN','SELLER')")`. Correto porque cada tenant = loja do seller e o filtro Hibernate (`filterActivator.activateFilter()`) já isola por tenant — o seller só vê os seus.

**Performance:** zero impacto — é uma checagem de role, sem novas queries nem HTTP.

**Teste:** novo `200 when SELLER lists their tenant's orders` em [OrderControllerSecurityTest.java](order-service/src/test/java/code/with/vanilson/orderservice/OrderControllerSecurityTest.java) — 14/14 verdes.

### Problema 2 — Fluxo de login do SELLER ✅
**2a:** [RegisterPage.tsx](frontend/src/pages/public/RegisterPage.tsx) — removido o auto-login do SELLER. Agora, qualquer role após register vai para `/login`.
**2b:** [LoginPage.tsx](frontend/src/pages/public/LoginPage.tsx) — removido `prefilledEmail`. Campo email vem sempre vazio.

**Teste:** [AuthFlow.test.tsx](frontend/src/pages/public/AuthFlow.test.tsx) cobre os dois invariantes (USER/SELLER vão para `/login`; campo email vazio mesmo com `state.email`).

---

## Próximos passos (teus)
1. **Rebuild + restart `order-service`** (sem isso o role fix não vai surtir efeito em produção).
2. **Rebuild do container do frontend.**
3. **Validação em produção:**
   - SELLER faz login → dashboard mostra as orders do seu tenant (200, sem 403).
   - Novo SELLER registra → é redirecionado para `/login` com o campo de email **vazio**.

**Honestidade:**
- Não corri `preview_start` nem `vitest`. Os DOM tests não rodam nesta máquina Windows (limitação conhecida documentada em memória) — `AuthFlow.test.tsx` está correcto e rodará em CI/Linux. Como tu próprio disseste, só a prova em produção conta.
- Não fiz commit, não fiz rebuild de Docker (regras do projeto).