### PR TITLE
feat: Seller `/orders/seller` 500 Fix

### DIFF
--- a/order-service/src/main/java/code/with/vanilson/orderservice/orderLine/OrderLineRepository.java
+++ b/order-service/src/main/java/code/with/vanilson/orderservice/orderLine/OrderLineRepository.java
@@ -45,9 +45,16 @@ public interface OrderLineRepository extends JpaRepository<OrderLine, Integer> {
      *
      * @param sellerId the seller's userId
      * @return distinct parent orders, newest-first
+     *
+     * <p>The order entity ({@code o}) — not {@code ol.order} — is the SELECT target so the
+     * {@code ORDER BY o.orderId} column is part of the selected columns. Selecting
+     * {@code ol.order} made Hibernate emit {@code ORDER BY order_line.order_id} (the FK
+     * column), which is NOT in the {@code SELECT DISTINCT customer_order.*} list — PostgreSQL
+     * rejects that with "for SELECT DISTINCT, ORDER BY expressions must appear in select list".</p>
      */
-    @Query("SELECT DISTINCT ol.order FROM OrderLine ol WHERE ol.sellerId = :sellerId "
-            + "ORDER BY ol.order.orderId DESC")
+    @Query("SELECT DISTINCT o FROM Order o, OrderLine ol "
+            + "WHERE ol.order = o AND ol.sellerId = :sellerId "
+            + "ORDER BY o.orderId DESC")
     List<Order> findDistinctOrdersBySellerId(@Param("sellerId") String sellerId);
 
     /**


### PR DESCRIPTION
# Session Report — Seller `/orders/seller` 500 Fix

## Status: Backend 500 fixed & regression-tested ✅ — awaiting prod rebuild proof + runtime evidence for the "frozen icons" report

## Features Implemented
Resolved the production `500 Internal Server Error` on `GET /api/v1/orders/seller` that sellers hit immediately after login (Seller Dashboard + Order Management). Root cause was proven from the live container stack trace, not assumed.

## Step-by-Step Execution

1. **Located the failing endpoint** — traced `GET /orders/seller` through the stack: `OrderController.findSellerOrders` → `OrderService.findOrdersForSeller` → `OrderLineService.findOrdersForSeller` → `OrderLineRepository.findDistinctOrdersBySellerId`.

2. **Pulled the real production stack trace** (read-only `docker logs order-service`) instead of guessing:
   ```
   ERROR: for SELECT DISTINCT, ORDER BY expressions must appear in select list
   SQL: select distinct o1_0.* from customer_line ol1_0
        join customer_order o1_0 on o1_0.order_id=ol1_0.order_id
        where ol1_0.tenant_id=? and ol1_0.seller_id=? order by ol1_0.order_id desc
   ```

3. **Root cause** — JPQL `SELECT DISTINCT ol.order ... ORDER BY ol.order.orderId` made Hibernate emit `ORDER BY customer_line.order_id` (the FK column, read directly off the join column), which is **not** in the `SELECT DISTINCT customer_order.*` list. PostgreSQL rejects that → 500 on every call.

4. **Fix** — made the `Order` entity the SELECT target so the ORDER BY column is selected ([OrderLineRepository.java:49](order-service/src/main/java/code/with/vanilson/orderservice/orderLine/OrderLineRepository.java)):
   ```java
   SELECT DISTINCT o FROM Order o, OrderLine ol
   WHERE ol.order = o AND ol.sellerId = :sellerId
   ORDER BY o.orderId DESC
   ```
   Method signature unchanged → mocked tests unaffected.

5. **Verified no regression** — `mvn test -pl order-service` → **92/92 pass, BUILD SUCCESS** (incl. `OrderControllerSecurityTest$SellerOrders`).

6. **Investigated the "frozen icons" report** across the frontend (SellerDashboard, SellerLayout, Navbar, Sidebar, routes, ErrorBoundary, QueryClient, axios interceptor) — found the dashboard **swallows** the 500 (`retry:false`, `throwOnError:false`, `?? 0`), so the 500 does not crash/freeze it in code. Theme toggle and avatar have working handlers; only the seller cart icon is a dead button (`onCartOpen` undefined in `SellerLayout`, pre-existing). Did **not** guess-patch working UI — requested runtime console evidence instead.

## Mapping to SKILL Phases (`systematic-debugging`)
- **Phase 1 — Root Cause:** Read the exact Postgres error from the live container; traced data flow controller→repository; identified the precise SQL the JPQL compiled to.
- **Phase 2 — Pattern Analysis:** Compared the working `findAll`/`findMyOrders` (same mapper, no DISTINCT+ORDER-BY-on-FK) against the broken seller query to isolate the single difference.
- **Phase 3 — Hypothesis & Test:** One change — restructure the query so the ORDER BY column is in the DISTINCT select list. No other edits bundled.
- **Phase 4 — Implementation & Verification:** Applied the single fix; ran the full module suite (92/92). Explicitly flagged that mocked tests prove *no regression*, not SQL validity — real proof requires the Postgres rebuild.

## Files Created / Modified
| File | Change |
|---|---|
| [OrderLineRepository.java](order-service/src/main/java/code/with/vanilson/orderservice/orderLine/OrderLineRepository.java) | Rewrote `findDistinctOrdersBySellerId` JPQL to SELECT the `Order` entity (theta-join) so `ORDER BY o.orderId` is a selected column; added explanatory Javadoc |
| `memory/project_seller_orders_500_distinct_orderby.md` | New memory — root cause + fix, marked pending prod proof |
| `memory/MEMORY.md` | Added index pointer |

No frontend source files changed (no proven defect to fix without runtime evidence).

## Current State
- **Working tree:** `OrderLineRepository.java` modified (uncommitted — no git actions per your standing rule).
- **order-service tests:** ✅ 92/92, BUILD SUCCESS.
- **500 fix:** code-complete, **not yet proven against real Postgres** (mocked tests can't catch SQL grammar).
- **Frozen-icons report:** investigated; no code-level freeze found on the dashboard; awaiting your runtime console output.

## Next Steps
1. **You rebuild + restart `order-service`** (Docker is yours to run). I'll then verify `/orders/seller` returns 200 via container logs — that also restores Total Revenue + the Orders page.
2. **Send the browser DevTools Console output** when clicking the theme toggle / avatar on `/seller` — confirms whether the "freeze" is a real JS crash or just the page looking dead while everything was `0` and the orders call 500'd.
3. *(Pending your call)* The seller cart icon does nothing by design (`onCartOpen` not wired in `SellerLayout`) — tell me if sellers should have a cart, otherwise I leave it.

