### PR TITLE
feat:Seller Catalog Isolation (`createdBy`) Fix

### DIFF
--- a/product-service/src/main/java/code/with/vanilson/productservice/ProductService.java
+++ b/product-service/src/main/java/code/with/vanilson/productservice/ProductService.java
@@ -81,9 +81,13 @@ public class ProductService {
      * @param pageable pagination and sort parameters
      * @return Page of ProductResponse DTOs
      */
-    @Cacheable(value = CACHE_PRODUCT_LIST, key = "#pageable.pageNumber + '-' + #pageable.pageSize")
+    @Cacheable(value = CACHE_PRODUCT_LIST,
+            key = "#root.target.catalogScopeKey() + '-' + #pageable.pageNumber + '-' + #pageable.pageSize")
     public Page<ProductResponse> getAllProducts(Pageable pageable) {
-        Page<ProductResponse> page = productRepository.findAll(pageable)
+        String sellerScope = currentSellerScope();
+        Page<ProductResponse> page = (sellerScope != null
+                ? productRepository.findByCreatedBy(sellerScope, pageable)
+                : productRepository.findAll(pageable))
                 .map(productMapper::fromProduct);
         log.info(resolve("product.log.all.found", page.getTotalElements()));
         return page;
@@ -157,6 +161,13 @@ public class ProductService {
         Pageable pageable = PageRequest.of(page, size, Sort.by(direction, sortBy));
 
         Specification<Product> spec = Specification.where(null);
+
+        // Marketplace isolation: a SELLER may only browse/search their own products.
+        // Customers, guests and ADMIN search the full cross-seller catalogue.
+        String sellerScope = currentSellerScope();
+        if (sellerScope != null) {
+            spec = spec.and((root, cq, cb) -> cb.equal(root.get("createdBy"), sellerScope));
+        }
 
         if (query != null && !query.isBlank()) {
             String pattern = "%" + query.toLowerCase() + "%";
@@ -334,5 +345,34 @@ public class ProductService {
         var auth = SecurityContextHolder.getContext().getAuthentication();
         if (auth == null || !(auth.getPrincipal() instanceof SecurityPrincipal sp)) return null;
         return sp;
+    }
+
+    /**
+     * Catalogue scope for the current caller.
+     * <p>
+     * Marketplace rule: a SELLER must only ever see their own products — competing sellers
+     * never see each other's catalogue, and a seller can never reach another seller's product
+     * to view or tamper with its price. This is the read-side counterpart to the write-side
+     * ownership guards in {@link #updateProduct} / {@link #deleteProduct}. Customers, guests
+     * and ADMIN get the full cross-seller catalogue.
+     *
+     * @return the seller's userId (as stored in {@code created_by}) when the caller is a
+     *         SELLER, otherwise {@code null} (no scoping → full catalogue)
+     */
+    private String currentSellerScope() {
+        SecurityPrincipal p = currentPrincipal();
+        return (p != null && p.isSeller()) ? String.valueOf(p.userId()) : null;
+    }
+
+    /**
+     * Cache discriminator for {@link #getAllProducts}: keeps a seller's scoped catalogue page
+     * from colliding with the public (cross-seller) one under the shared {@code product-list}
+     * key. Public so it is reachable from the {@code @Cacheable} SpEL key expression.
+     *
+     * @return {@code "seller:<id>"} for a SELLER caller, otherwise {@code "all"}
+     */
+    public String catalogScopeKey() {
+        String scope = currentSellerScope();
+        return scope == null ? "all" : "seller:" + scope;
     }
 }

--- a/product-service/src/test/java/code/with/vanilson/productservice/ProductServiceOwnershipTest.java
+++ b/product-service/src/test/java/code/with/vanilson/productservice/ProductServiceOwnershipTest.java
@@ -17,6 +17,9 @@ import org.springframework.context.MessageSource;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 import code.with.vanilson.productservice.category.Category;
 
@@ -29,6 +32,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -45,7 +50,9 @@ class ProductServiceOwnershipTest {
 
     @BeforeEach
     void setUp() {
-        when(messageSource.getMessage(anyString(), any(), any(Locale.class)))
+        // Shared default: echo the message key. lenient() — a few tests (e.g. catalogScopeKey)
+        // exercise paths that resolve no messages, and strict stubbing would flag this as unused.
+        lenient().when(messageSource.getMessage(anyString(), any(), any(Locale.class)))
                 .thenAnswer(inv -> inv.getArgument(0));
     }
 
@@ -219,6 +226,74 @@ class ProductServiceOwnershipTest {
             productService.deleteProduct(3);
 
             verify(productRepository).deleteById(3);
+        }
+    }
+
+    // -------------------------------------------------------
+    // Catalogue scoping — a SELLER browses only their own products
+    // -------------------------------------------------------
+
+    @Nested
+    @DisplayName("catalogue scoping — SELLER sees only own products")
+    class CatalogScoping {
+
+        private final Pageable pageable = PageRequest.of(0, 20);
+
+        @Test
+        @DisplayName("getAllProducts: SELLER is scoped to their own products (findByCreatedBy)")
+        void seller_catalog_scoped_to_own() {
+            authAs(7L, "SELLER");
+            when(productRepository.findByCreatedBy("7", pageable)).thenReturn(Page.empty(pageable));
+
+            productService.getAllProducts(pageable);
+
+            verify(productRepository).findByCreatedBy("7", pageable);
+            verify(productRepository, never()).findAll(any(Pageable.class));
+        }
+
+        @Test
+        @DisplayName("getAllProducts: guest (no principal) sees the full catalogue (findAll)")
+        void guest_sees_full_catalog() {
+            when(productRepository.findAll(pageable)).thenReturn(Page.empty(pageable));
+
+            productService.getAllProducts(pageable);
+
+            verify(productRepository).findAll(pageable);
+            verify(productRepository, never()).findByCreatedBy(anyString(), any(Pageable.class));
+        }
+
+        @Test
+        @DisplayName("getAllProducts: customer (USER) sees the full catalogue")
+        void customer_sees_full_catalog() {
+            authAs(3L, "USER");
+            when(productRepository.findAll(pageable)).thenReturn(Page.empty(pageable));
+
+            productService.getAllProducts(pageable);
+
+            verify(productRepository).findAll(pageable);
+            verify(productRepository, never()).findByCreatedBy(anyString(), any(Pageable.class));
+        }
+
+        @Test
+        @DisplayName("getAllProducts: ADMIN sees the full catalogue")
+        void admin_sees_full_catalog() {
+            authAs(1L, "ADMIN");
+            when(productRepository.findAll(pageable)).thenReturn(Page.empty(pageable));
+
+            productService.getAllProducts(pageable);
+
+            verify(productRepository).findAll(pageable);
+            verify(productRepository, never()).findByCreatedBy(anyString(), any(Pageable.class));
+        }
+
+        @Test
+        @DisplayName("catalogScopeKey: 'seller:<id>' for SELLER, 'all' for everyone else")
+        void catalog_scope_key_discriminates_seller() {
+            authAs(7L, "SELLER");
+            assertThat(productService.catalogScopeKey()).isEqualTo("seller:7");
+
+            SecurityContextHolder.clearContext();
+            assertThat(productService.catalogScopeKey()).isEqualTo("all");
         }
     }
 }


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h1>Session Report — Seller Catalog Isolation (<code>createdBy</code>) Fix</h1>
<h2>Status: Backend fix complete &amp; regression-tested ✅ — awaiting prod rebuild proof</h2>
<h2>Feature Implemented</h2>
<p>Fixed the production defect where a logged-in <strong>SELLER saw all 110 products</strong> in <code>/catalog</code> instead of only their own. Made the public catalog <strong>owner-aware on the backend</strong>: a SELLER now sees only products they created (<code>createdBy = userId</code>); customers, guests, and ADMIN still see the full cross-seller catalogue. Root cause was proven from the code, not assumed.</p>
<h2>Step-by-Step Execution</h2>
<ol>
<li><strong>Invoked <code>systematic-debugging</code></strong> and traced the catalog data flow: <code>CatalogPage</code> → <code>productsApi.search()</code> → <code>GET /api/v1/products/search</code> → <code>ProductService.searchProducts()</code>.</li>
<li><strong>Proved root cause in code:</strong> <code>searchProducts()</code> (<a href="https://claude.ai/epitaxy/product-service/src/main/java/code/with/vanilson/productservice/ProductService.java">ProductService.java:153</a>) and <code>getAllProducts()</code> (<a href="https://claude.ai/epitaxy/product-service/src/main/java/code/with/vanilson/productservice/ProductService.java">:85</a>) <strong>never filtered by owner</strong>. The repository Javadoc even documented the catalog as <em>"intentionally cross-seller"</em> (<a href="https://claude.ai/epitaxy/product-service/src/main/java/code/with/vanilson/productservice/ProductRepository.java">ProductRepository.java:60-63</a>) — that was the wrong assumption from the prior session.</li>
<li><strong>Separated the two concerns:</strong> Verified the <strong>write-side was already protected</strong> — <code>updateProduct</code>/<code>deleteProduct</code> throw <code>ProductForbiddenException</code> when a non-ADMIN's <code>userId ≠ createdBy</code> (<a href="https://claude.ai/epitaxy/product-service/src/main/java/code/with/vanilson/productservice/ProductService.java">:216, :245</a>). So the price-tampering risk was already blocked; the real defect was visibility.</li>
<li><strong>Confirmed <code>SecurityPrincipal</code></strong> exposes <code>isSeller()</code> / <code>isAdmin()</code> (<a href="https://claude.ai/epitaxy/tenant-context/src/main/java/code/with/vanilson/tenantcontext/security/SecurityPrincipal.java">SecurityPrincipal.java:3-6</a>).</li>
<li><strong>Implemented the fix</strong> (single, owner-aware lever matching the existing <code>getMyProducts</code> pattern):
<ul>
<li><code>currentSellerScope()</code> → returns userId only when <code>principal.isSeller()</code>, else <code>null</code>.</li>
<li><code>getAllProducts()</code> branches to <code>findByCreatedBy(scope, …)</code> for a seller.</li>
<li><code>searchProducts()</code> adds a <code>createdBy</code> Specification clause for a seller.</li>
<li><code>catalogScopeKey()</code> (<code>"seller:&lt;id&gt;"</code> | <code>"all"</code>) added to the <code>@Cacheable</code> key so a seller's scoped page can't leak via the shared <code>product-list</code> cache.</li>
</ul>
</li>
<li><strong>Added 5 <code>CatalogScoping</code> unit tests</strong> (SELLER scoped; guest/USER/ADMIN see all; cache-key discriminator).</li>
<li><strong>Fixed strict-Mockito <code>UnnecessaryStubbing</code></strong> by making the shared <code>messageSource</code> default-stub <code>lenient()</code>.</li>
<li><strong>Ran full module suite</strong> → <strong>109/109 pass, BUILD SUCCESS</strong>.</li>
<li><strong>Updated memory</strong> <code>project_seller_isolation_createdby.md</code> with the 2026-06-21 user correction (catalog must be seller-scoped).</li>
</ol>
<h2>Mapping to SKILL Phases (<code>systematic-debugging</code>)</h2>
<ul>
<li><strong>Phase 1 — Root Cause:</strong> Read the catalog request path end-to-end; proved the two read methods never filter by owner (file:line evidence), not a guess.</li>
<li><strong>Phase 2 — Pattern Analysis:</strong> Compared the broken catalog reads against the working <code>getMyProducts</code>/<code>findByCreatedBy</code> ownership pattern to isolate the single missing lever.</li>
<li><strong>Phase 3 — Hypothesis &amp; Test:</strong> One hypothesis (catalog endpoints ignore <code>createdBy</code>), one minimal fix (role-conditional scoping), no bundled changes.</li>
<li><strong>Phase 4 — Implementation &amp; Verification:</strong> Added failing-then-passing tests, applied the single fix, ran 109/109. Explicitly flagged mocked tests prove logic, <strong>not</strong> real Postgres/JWT behavior.</li>
</ul>
<h2>Files Created / Modified</h2>

File | Change
-- | --
ProductService.java | currentSellerScope() + catalogScopeKey(); getAllProducts branches to findByCreatedBy for sellers; searchProducts adds createdBy spec; cache key now scope-aware
ProductServiceOwnershipTest.java | New CatalogScoping nested class (5 tests); messageSource stub made lenient()
memory/project_seller_isolation_createdby.md | Recorded 2026-06-21 correction: catalog must be seller-scoped (prior "intentionally global" note was wrong)
No frontend files changed — CatalogPage renders whatever the now-scoped backend returns. |  


<h2>Current State</h2>
<ul>
<li><strong>Working tree:</strong> <code>ProductService.java</code> + <code>ProductServiceOwnershipTest.java</code> modified (uncommitted — per your no-git-actions rule).</li>
<li><strong>product-service tests:</strong> ✅ 109/109, BUILD SUCCESS (incl. 5 new scoping tests).</li>
<li><strong>Fix:</strong> code-complete, <strong>not yet proven against real Postgres + real JWT</strong> (mocks bypass the cache proxy and DB).</li>
</ul>
<h2>Next Steps</h2>
<ol>
<li><strong>You rebuild + restart <code>product-service</code></strong> (Docker is yours).</li>
<li><strong>Log in as the seller and open <code>/catalog</code></strong> — expected: only the seller's 2 products (#5303, #5302, same as Seller Hub) and counter <code>2 products</code>, not 110.</li>
<li><strong>Confirm or send logs</strong> — then I close this as proven. The one runtime risk to watch: the <code>@Cacheable</code> SpEL key <code>#root.target.catalogScopeKey()</code> is only exercised through the Spring cache proxy (not in unit tests), so the rebuild is what validates the cache path doesn't throw.</li>
</ol>
<p>Honesty note: my proof so far is <strong>code-level root cause</strong> + <strong>109/109 mocked tests</strong> (logic + no regression). I have <strong>not</strong> proven it against live Postgres/JWT or the cache proxy — that needs your rebuild.</p></body></html><!--EndFragment-->
</body>
</html># Session Report — Seller Catalog Isolation (`createdBy`) Fix

## Status: Backend fix complete & regression-tested ✅ — awaiting prod rebuild proof

## Feature Implemented
Fixed the production defect where a logged-in **SELLER saw all 110 products** in `/catalog` instead of only their own. Made the public catalog **owner-aware on the backend**: a SELLER now sees only products they created (`createdBy = userId`); customers, guests, and ADMIN still see the full cross-seller catalogue. Root cause was proven from the code, not assumed.

## Step-by-Step Execution
1. **Invoked `systematic-debugging`** and traced the catalog data flow: `CatalogPage` → `productsApi.search()` → `GET /api/v1/products/search` → `ProductService.searchProducts()`.
2. **Proved root cause in code:** `searchProducts()` ([[ProductService.java:153](https://claude.ai/epitaxy/product-service/src/main/java/code/with/vanilson/productservice/ProductService.java)](product-service/src/main/java/code/with/vanilson/productservice/ProductService.java)) and `getAllProducts()` ([[:85](https://claude.ai/epitaxy/product-service/src/main/java/code/with/vanilson/productservice/ProductService.java)](product-service/src/main/java/code/with/vanilson/productservice/ProductService.java)) **never filtered by owner**. The repository Javadoc even documented the catalog as *"intentionally cross-seller"* ([[ProductRepository.java:60-63](https://claude.ai/epitaxy/product-service/src/main/java/code/with/vanilson/productservice/ProductRepository.java)](product-service/src/main/java/code/with/vanilson/productservice/ProductRepository.java)) — that was the wrong assumption from the prior session.
3. **Separated the two concerns:** Verified the **write-side was already protected** — `updateProduct`/`deleteProduct` throw `ProductForbiddenException` when a non-ADMIN's `userId ≠ createdBy` ([[:216, :245](https://claude.ai/epitaxy/product-service/src/main/java/code/with/vanilson/productservice/ProductService.java)](product-service/src/main/java/code/with/vanilson/productservice/ProductService.java)). So the price-tampering risk was already blocked; the real defect was visibility.
4. **Confirmed `SecurityPrincipal`** exposes `isSeller()` / `isAdmin()` ([[SecurityPrincipal.java:3-6](https://claude.ai/epitaxy/tenant-context/src/main/java/code/with/vanilson/tenantcontext/security/SecurityPrincipal.java)](tenant-context/src/main/java/code/with/vanilson/tenantcontext/security/SecurityPrincipal.java)).
5. **Implemented the fix** (single, owner-aware lever matching the existing `getMyProducts` pattern):
   - `currentSellerScope()` → returns userId only when `principal.isSeller()`, else `null`.
   - `getAllProducts()` branches to `findByCreatedBy(scope, …)` for a seller.
   - `searchProducts()` adds a `createdBy` Specification clause for a seller.
   - `catalogScopeKey()` (`"seller:<id>"` | `"all"`) added to the `@Cacheable` key so a seller's scoped page can't leak via the shared `product-list` cache.
6. **Added 5 `CatalogScoping` unit tests** (SELLER scoped; guest/USER/ADMIN see all; cache-key discriminator).
7. **Fixed strict-Mockito `UnnecessaryStubbing`** by making the shared `messageSource` default-stub `lenient()`.
8. **Ran full module suite** → **109/109 pass, BUILD SUCCESS**.
9. **Updated memory** `project_seller_isolation_createdby.md` with the 2026-06-21 user correction (catalog must be seller-scoped).

## Mapping to SKILL Phases (`systematic-debugging`)
- **Phase 1 — Root Cause:** Read the catalog request path end-to-end; proved the two read methods never filter by owner (file:line evidence), not a guess.
- **Phase 2 — Pattern Analysis:** Compared the broken catalog reads against the working `getMyProducts`/`findByCreatedBy` ownership pattern to isolate the single missing lever.
- **Phase 3 — Hypothesis & Test:** One hypothesis (catalog endpoints ignore `createdBy`), one minimal fix (role-conditional scoping), no bundled changes.
- **Phase 4 — Implementation & Verification:** Added failing-then-passing tests, applied the single fix, ran 109/109. Explicitly flagged mocked tests prove logic, **not** real Postgres/JWT behavior.

## Files Created / Modified
| File | Change |
|---|---|
| [[ProductService.java](https://claude.ai/epitaxy/product-service/src/main/java/code/with/vanilson/productservice/ProductService.java)](product-service/src/main/java/code/with/vanilson/productservice/ProductService.java) | `currentSellerScope()` + `catalogScopeKey()`; `getAllProducts` branches to `findByCreatedBy` for sellers; `searchProducts` adds `createdBy` spec; cache key now scope-aware |
| [[ProductServiceOwnershipTest.java](https://claude.ai/epitaxy/product-service/src/test/java/code/with/vanilson/productservice/ProductServiceOwnershipTest.java)](product-service/src/test/java/code/with/vanilson/productservice/ProductServiceOwnershipTest.java) | New `CatalogScoping` nested class (5 tests); `messageSource` stub made `lenient()` |
| `memory/project_seller_isolation_createdby.md` | Recorded 2026-06-21 correction: catalog must be seller-scoped (prior "intentionally global" note was wrong) |
No frontend files changed — `CatalogPage` renders whatever the now-scoped backend returns.

## Current State
- **Working tree:** `ProductService.java` + `ProductServiceOwnershipTest.java` modified (uncommitted — per your no-git-actions rule).
- **product-service tests:** ✅ 109/109, BUILD SUCCESS (incl. 5 new scoping tests).
- **Fix:** code-complete, **not yet proven against real Postgres + real JWT** (mocks bypass the cache proxy and DB).

## Next Steps
1. **You rebuild + restart `product-service`** (Docker is yours). 
2. **Log in as the seller and open `/catalog`** — expected: only the seller's 2 products (#5303, #5302, same as Seller Hub) and counter `2 products`, not 110.
3. **Confirm or send logs** — then I close this as proven. The one runtime risk to watch: the `@Cacheable` SpEL key `#root.target.catalogScopeKey()` is only exercised through the Spring cache proxy (not in unit tests), so the rebuild is what validates the cache path doesn't throw.

