### PR TITLE
feat: recovered the github action

### DIFF
--- a/frontend/src/routes/layouts/AdminLayout.tsx
+++ b/frontend/src/routes/layouts/AdminLayout.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import { Outlet } from 'react-router-dom';
 import { Box, useMediaQuery, useTheme } from '@mui/material';
 import { MotionConfig } from 'framer-motion';
@@ -27,11 +26,6 @@ export default function AdminLayout() {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('lg'));
 
-  // Auto-close sidebar on mobile so the overlay drawer doesn't cover content
-  useEffect(() => {
-    if (isMobile) setSidebarOpen(false);
-  }, [isMobile, setSidebarOpen]);
-
   return (
     <MotionConfig reducedMotion="user">
       <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
@@ -40,7 +34,7 @@ export default function AdminLayout() {
           <Sidebar
             items={ADMIN_NAV}
             title="Admin"
-            open={sidebarOpen}
+            open={sidebarOpen && !isMobile}
             onClose={() => setSidebarOpen(false)}
           />
           <Box

--- a/frontend/src/routes/layouts/SellerLayout.tsx
+++ b/frontend/src/routes/layouts/SellerLayout.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import { Outlet } from 'react-router-dom';
 import { Box, useMediaQuery, useTheme } from '@mui/material';
 import { MotionConfig } from 'framer-motion';
@@ -27,11 +26,6 @@ export default function SellerLayout() {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('lg'));
 
-  // Auto-close sidebar on mobile so the overlay drawer doesn't cover content
-  useEffect(() => {
-    if (isMobile) setSidebarOpen(false);
-  }, [isMobile, setSidebarOpen]);
-
   return (
     <MotionConfig reducedMotion="user">
       <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
@@ -40,7 +34,7 @@ export default function SellerLayout() {
           <Sidebar
             items={SELLER_NAV}
             title="Seller Hub"
-            open={sidebarOpen}
+            open={sidebarOpen && !isMobile}
             onClose={() => setSidebarOpen(false)}
           />
           <Box


### PR DESCRIPTION
# Session Report — Seller/Admin Page Freeze (Auto-Opening Temporary Drawer)

## Status: Code-complete, build + boot gates green ✅ — awaiting live-stack rebuild proof

## Feature / Fix Implemented

**Killed the freeze on SELLER/ADMIN pages.** `/seller` rendered fully (stats 0/0/0, every network request 200 OK) yet was completely unclickable. Root cause traced to a MUI `Drawer variant="temporary"` (Modal+Backdrop) that auto-opened on first paint at viewport < `lg` (1200px) — exactly the user's case with DevTools open — then closed one render later via `useEffect`. That synchronous Modal open→close leaves the backdrop / body scroll-lock hanging, intercepting all clicks. Fixed declaratively so the temporary drawer never auto-opens.

## Step-by-Step Execution

1. **Invoked `systematic-debugging`** and re-read the user's mandatory memory rules (no assumption, prove before fixing, verify the fix hits the real path).
2. **Confirmed working tree clean / prior fixes committed** (`f27fb41`) — so the cart + BCrypt work from the previous session is in the codebase, not lost.
3. **Ruled out the prior cart-503 storm with evidence:** the screenshot's network tab shows **no `GET /carts/*`** — only `/orders/seller`, `/products/mine`, all 200. So this freeze is a *new*, separate cause.
4. **Traced the route tree:** `/seller` uses `SellerLayout` (not `PublicLayout`). Read `SellerLayout`, `SellerDashboard`, `Sidebar`, `Navbar`, `RoleRoute`, `ProtectedRoute`, `ui.store`, `auth.store`, `client.ts`, `Toast` — no infinite render loop on the seller-allowed path.
5. **Isolated the structural difference:** only `SellerLayout` + `AdminLayout` mount the `Sidebar` temporary Drawer with `sidebarOpen` defaulting `true`. `PublicLayout`/`CustomerLayout` have no such Sidebar → they don't freeze. Matches the symptom exactly.
6. **Attempted live reproduction** in the internal Vite preview (its own browser — *not* the user's Chrome/Firefox; explicitly avoided installing anything). Injected a dummy seller into `localStorage`, but the dummy token tripped the `401 → refresh-fail → clearAuth → /login` flow in `client.ts:103`, bouncing me to the Sign-in page (confirmed by screenshot). **Owned that I could not get live proof of the exact blocker.**
7. **Did NOT fix on a half-proven hypothesis at first** (per the rules) — surfaced the structural finding and a 1-line console diagnostic. On the user's demand for a solution, **owned that I touched this code** and implemented the root-cause fix.
8. **Implemented + verified:** changed both layouts to `open={sidebarOpen && !isMobile}`, removed the fragile `useEffect`. `npm run build` → `✓ built`, 0 TS errors. Dev server boots clean, 0 console errors.

## Mapping to SKILL Phases (`systematic-debugging`)

- **Phase 1 — Root Cause:** Read the all-200 frozen screenshot; traced the route to `SellerLayout`; read every component on the seller path; checked recent commits (working tree clean, fixes committed).
- **Phase 2 — Pattern Analysis:** Compared the freezing layouts (Seller/Admin — have the temporary Drawer) against the non-freezing ones (Public/Customer — no Sidebar). Identified the single structural difference + the `sidebarOpen` default-`true` + post-paint `useEffect` close.
- **Phase 3 — Hypothesis & Test:** Formed one hypothesis (temporary Drawer auto-open leaves a click-blocking backdrop). Attempted reproduction; **disproved my own ability to prove it live** when the dummy-token 401 flow logged me out — stated this honestly rather than claiming proof.
- **Phase 4 — Implementation & Verification:** Single root-cause fix on the exact path; build green; app boots clean. Explicitly flagged that live freeze-resolution is **not** yet proven (needs the user's frontend rebuild + real seller session).

## Files Created / Modified

| Area | File | Change |
|---|---|---|
| frontend | [SellerLayout.tsx](frontend/src/routes/layouts/SellerLayout.tsx) | `open={sidebarOpen && !isMobile}`; removed auto-close `useEffect` + unused `useEffect` import |
| frontend | [AdminLayout.tsx](frontend/src/routes/layouts/AdminLayout.tsx) | Same fix |
| memory | `project_seller_admin_drawer_freeze.md` (new), `MEMORY.md` (index line) | Recorded root cause, fix, and the unproven-live caveat |

## Current State

- **Working tree:** above frontend files modified, uncommitted (per no-git-actions rule).
- **Gates green:** `npm run build` → `✓ built` (tsc + vite, 0 TS errors); internal dev server mounts cleanly on `/login`, **0 console errors**.
- **Behavior now (in code):** the temporary mobile Drawer's `open && isMobile` is always `false` → the Modal never mounts open → the backdrop/scroll-lock freeze class cannot occur. Desktop (>lg) permanent sidebar unchanged.
- **NOT proven live:** could not reach `/seller` in preview (dummy token → 401 → forced logout). Live unfreeze depends on the user's rebuild.
- **Login latency:** confirmed **no YAML forces BCrypt to 12**, so the committed cost-10 default should apply after an auth-service rebuild. Parked (Rule 5: one problem at a time) pending a slow-request log line if it persists.

## Next Steps

1. **You rebuild the `frontend` container** and log in as SELLER → confirm `/seller` is clickable (no freeze), even with DevTools open.
2. **If still frozen** (cause was elsewhere): paste in the browser console on the frozen page —
   `document.elementFromPoint(innerWidth/2,innerHeight/2)` and query `.MuiBackdrop-root,[aria-hidden="true"],[inert]` — send the output; I'll fix the real blocker at once, now that the drawer is eliminated.
3. **Login latency:** if still slow after the auth-service rebuild, send the auth-service log line at a slow request timestamp.
4. **Follow-up UX (non-blocking):** mobile sellers now have no sidebar nav (it was already non-functional — no opener existed). Add a Navbar hamburger toggle to restore it properly later.

**Honesty note:** proof so far is `npm run build` green + clean dev-server boot + a code-level evidence chain isolating the freeze to the Seller/Admin temporary-Drawer auto-open. Live freeze-resolution is **not** yet proven — that needs your frontend rebuild and a real seller login.