### PR TITLE
feat: Frontend Navigation & Dashboard Overhaul

### DIFF
--- a/frontend/src/components/data-display/DashboardCharts.tsx
+++ b/frontend/src/components/data-display/DashboardCharts.tsx
@@ -1,0 +1,179 @@
+import { type ReactNode } from 'react';
+import { Box, Typography } from '@mui/material';
+import {
+  Area,
+  AreaChart,
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  Legend,
+  Pie,
+  PieChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import { formatCurrency } from '@utils/format';
+import { shortDay, type DayPoint, type Slice } from '@utils/analytics';
+
+/** Gold/copper theme palette (mirrors the obsidian theme accent ramp). */
+const CHART_PALETTE = ['#E8C48A', '#C47D5A', '#6B98B8', '#5CB87A', '#D4A544', '#C75450'];
+
+const TOOLTIP_STYLE = {
+  background: 'var(--surface-overlay)',
+  border: '1px solid var(--border-default)',
+  borderRadius: 4,
+  color: 'var(--text-primary)',
+  fontSize: 12,
+} as const;
+
+const AXIS_TICK = { fontSize: 11, fill: 'var(--text-secondary)' } as const;
+
+function ChartCard({
+  title,
+  subtitle,
+  children,
+}: {
+  title: string;
+  subtitle?: string;
+  children: ReactNode;
+}) {
+  return (
+    <Box sx={{ bgcolor: 'background.paper', border: '1px solid', borderColor: 'divider', borderRadius: 2, p: 3 }}>
+      <Typography variant="h6" sx={{ fontFamily: 'var(--font-serif)' }}>{title}</Typography>
+      {subtitle && (
+        <Typography variant="body2" color="text.secondary" sx={{ mt: 0.25 }}>{subtitle}</Typography>
+      )}
+      <Box sx={{ mt: 2.5 }}>{children}</Box>
+    </Box>
+  );
+}
+
+function EmptyState({ height = 280 }: { height?: number }) {
+  return (
+    <Box sx={{ height, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+      <Typography variant="body2" color="text.secondary">No data yet</Typography>
+    </Box>
+  );
+}
+
+/** Hero revenue/GMV-over-time area chart. */
+export function RevenueAreaCard({
+  title,
+  subtitle,
+  data,
+  height = 300,
+}: {
+  title: string;
+  subtitle?: string;
+  data: DayPoint[];
+  height?: number;
+}) {
+  return (
+    <ChartCard title={title} subtitle={subtitle}>
+      {data.length === 0 ? (
+        <EmptyState height={height} />
+      ) : (
+        <ResponsiveContainer width="100%" height={height}>
+          <AreaChart data={data} margin={{ top: 8, right: 8, left: 0, bottom: 0 }}>
+            <defs>
+              <linearGradient id="revFill" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor="var(--accent-primary)" stopOpacity={0.35} />
+                <stop offset="100%" stopColor="var(--accent-primary)" stopOpacity={0} />
+              </linearGradient>
+            </defs>
+            <CartesianGrid stroke="var(--border-default)" strokeDasharray="3 3" vertical={false} />
+            <XAxis dataKey="date" tickFormatter={shortDay} tick={AXIS_TICK} />
+            <YAxis tick={AXIS_TICK} tickFormatter={(v: number) => formatCurrency(v)} width={80} />
+            <Tooltip
+              contentStyle={TOOLTIP_STYLE}
+              formatter={(value) => [formatCurrency(Number(value ?? 0)), 'Revenue']}
+              labelFormatter={(label) => `Date: ${label}`}
+            />
+            <Area
+              type="monotone"
+              dataKey="revenue"
+              stroke="var(--accent-primary)"
+              strokeWidth={2}
+              fill="url(#revFill)"
+              dot={false}
+            />
+          </AreaChart>
+        </ResponsiveContainer>
+      )}
+    </ChartCard>
+  );
+}
+
+/** Categorical breakdown donut (order status, payment method, …). */
+export function BreakdownDonutCard({
+  title,
+  subtitle,
+  data,
+  height = 260,
+}: {
+  title: string;
+  subtitle?: string;
+  data: Slice[];
+  height?: number;
+}) {
+  return (
+    <ChartCard title={title} subtitle={subtitle}>
+      {data.length === 0 ? (
+        <EmptyState height={height} />
+      ) : (
+        <ResponsiveContainer width="100%" height={height}>
+          <PieChart>
+            <Pie data={data} dataKey="value" nameKey="name" innerRadius="55%" outerRadius="80%" paddingAngle={2}>
+              {data.map((_, i) => (
+                <Cell key={i} fill={CHART_PALETTE[i % CHART_PALETTE.length]} stroke="var(--surface-base)" />
+              ))}
+            </Pie>
+            <Tooltip contentStyle={TOOLTIP_STYLE} />
+            <Legend
+              wrapperStyle={{ fontSize: 12, color: 'var(--text-secondary)' }}
+              formatter={(value) => <span style={{ color: 'var(--text-secondary)' }}>{value}</span>}
+            />
+          </PieChart>
+        </ResponsiveContainer>
+      )}
+    </ChartCard>
+  );
+}
+
+/** Activity-volume bar chart (orders/payments per day). */
+export function ActivityBarCard({
+  title,
+  subtitle,
+  data,
+  height = 260,
+}: {
+  title: string;
+  subtitle?: string;
+  data: DayPoint[];
+  height?: number;
+}) {
+  return (
+    <ChartCard title={title} subtitle={subtitle}>
+      {data.length === 0 ? (
+        <EmptyState height={height} />
+      ) : (
+        <ResponsiveContainer width="100%" height={height}>
+          <BarChart data={data} margin={{ top: 8, right: 8, left: 0, bottom: 0 }}>
+            <CartesianGrid stroke="var(--border-default)" strokeDasharray="3 3" vertical={false} />
+            <XAxis dataKey="date" tickFormatter={shortDay} tick={AXIS_TICK} />
+            <YAxis allowDecimals={false} tick={AXIS_TICK} width={36} />
+            <Tooltip
+              contentStyle={TOOLTIP_STYLE}
+              formatter={(value) => [Number(value ?? 0), 'Orders']}
+              labelFormatter={(label) => `Date: ${label}`}
+            />
+            <Bar dataKey="count" fill="var(--accent-primary)" radius={[3, 3, 0, 0]} maxBarSize={32} />
+          </BarChart>
+        </ResponsiveContainer>
+      )}
+    </ChartCard>
+  );
+}

--- a/frontend/src/components/layout/MobileNav.tsx
+++ b/frontend/src/components/layout/MobileNav.tsx
@@ -16,7 +16,8 @@ interface MobileNavProps {
 
 export default function MobileNav({ onCartOpen, cartItemCount = 0 }: MobileNavProps) {
   const location = useLocation();
-  const { isAuthenticated } = useAuthStore();
+  const { isAuthenticated, role } = useAuthStore();
+  const showCart = role !== 'SELLER' && role !== 'ADMIN';
 
   // Index layout depends on whether the authenticated-only "Orders" action is shown:
   //   authed:     Home(0) Catalog(1) Cart(2) Orders(3) Account(4)
@@ -61,17 +62,19 @@ export default function MobileNav({ onCartOpen, cartItemCount = 0 }: MobileNavPr
           icon={<Explore />}
           sx={{ color: 'text.secondary', '&.Mui-selected': { color: 'primary.main' } }}
         />
-        <BottomNavigationAction
-          value={2}
-          label="Cart"
-          icon={
-            <Badge badgeContent={cartItemCount} color="primary">
-              <ShoppingBag />
-            </Badge>
-          }
-          onClick={onCartOpen}
-          sx={{ color: 'text.secondary' }}
-        />
+        {showCart && (
+          <BottomNavigationAction
+            value={2}
+            label="Cart"
+            icon={
+              <Badge badgeContent={cartItemCount} color="primary">
+                <ShoppingBag />
+              </Badge>
+            }
+            onClick={onCartOpen}
+            sx={{ color: 'text.secondary' }}
+          />
+        )}
         {isAuthenticated && (
           <BottomNavigationAction
             value={3}

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -25,6 +25,7 @@ import {
   LightMode,
   DarkMode,
   ReceiptLong,
+  Menu as MenuIcon,
 } from '@mui/icons-material';
 import { useAuthStore } from '@stores/auth.store';
 import { useUIStore } from '@stores/ui.store';
@@ -34,9 +35,11 @@ import RoleBadge from './RoleBadge';
 interface NavbarProps {
   onCartOpen?: () => void;
   cartItemCount?: number;
+  /** When provided (dashboard layouts on mobile), shows a hamburger that toggles the sidebar. */
+  onMenuClick?: () => void;
 }
 
-export default function Navbar({ onCartOpen, cartItemCount = 0 }: NavbarProps) {
+export default function Navbar({ onCartOpen, cartItemCount = 0, onMenuClick }: NavbarProps) {
   const navigate = useNavigate();
   const { isAuthenticated, role, email, clearAuth } = useAuthStore();
   const { themeMode, toggleTheme, addToast } = useUIStore();
@@ -66,6 +69,18 @@ export default function Navbar({ onCartOpen, cartItemCount = 0 }: NavbarProps) {
       }}
     >
       <Toolbar sx={{ gap: 2, px: { xs: 2, md: 4 } }}>
+        {/* Hamburger — only in dashboard layouts below md (toggles the sidebar) */}
+        {onMenuClick && (
+          <IconButton
+            edge="start"
+            onClick={onMenuClick}
+            sx={{ color: 'text.primary', display: { xs: 'inline-flex', md: 'none' } }}
+            aria-label="Open navigation menu"
+          >
+            <MenuIcon />
+          </IconButton>
+        )}
+
         {/* Logo */}
         <Typography
           component={Link}
@@ -116,18 +131,20 @@ export default function Navbar({ onCartOpen, cartItemCount = 0 }: NavbarProps) {
             </IconButton>
           </Tooltip>
 
-          {/* Cart */}
-          <Tooltip title="Cart">
-            <IconButton onClick={onCartOpen} sx={{ color: 'text.primary' }}>
-              <Badge
-                badgeContent={cartItemCount}
-                color="primary"
-                sx={{ '& .MuiBadge-badge': { fontFamily: 'var(--font-mono)', fontSize: '0.65rem' } }}
-              >
-                <ShoppingBag />
-              </Badge>
-            </IconButton>
-          </Tooltip>
+          {/* Cart — buyers (USER) and guests only. Sellers/admins do not buy. */}
+          {role !== 'SELLER' && role !== 'ADMIN' && (
+            <Tooltip title="Cart">
+              <IconButton onClick={onCartOpen} sx={{ color: 'text.primary' }}>
+                <Badge
+                  badgeContent={cartItemCount}
+                  color="primary"
+                  sx={{ '& .MuiBadge-badge': { fontFamily: 'var(--font-mono)', fontSize: '0.65rem' } }}
+                >
+                  <ShoppingBag />
+                </Badge>
+              </IconButton>
+            </Tooltip>
+          )}
 
           {/* User menu */}
           {isAuthenticated ? (

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -32,7 +32,7 @@ const DRAWER_WIDTH = 240;
 export default function Sidebar({ items, title, open, onClose }: SidebarProps) {
   const location = useLocation();
   const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down('lg'));
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
 
   const drawerContent = (
     <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
@@ -84,36 +84,33 @@ export default function Sidebar({ items, title, open, onClose }: SidebarProps) {
 
   return (
     <>
-      {/* Mobile: temporary overlay drawer */}
+      {/* Mobile (< md): temporary overlay drawer, toggled by the navbar hamburger */}
       <Drawer
         variant="temporary"
         open={open && isMobile}
         onClose={onClose}
         ModalProps={{ keepMounted: true }}
         sx={{
-          display: { xs: 'block', lg: 'none' },
+          display: { xs: 'block', md: 'none' },
           '& .MuiDrawer-paper': { width: DRAWER_WIDTH, bgcolor: 'background.paper' },
         }}
       >
         {drawerContent}
       </Drawer>
 
-      {/* Desktop: permanent drawer */}
+      {/* Desktop (md+): permanent drawer — always visible */}
       <Drawer
         variant="permanent"
-        open={open}
         sx={{
-          display: { xs: 'none', lg: 'block' },
-          width: open ? DRAWER_WIDTH : 0,
+          display: { xs: 'none', md: 'block' },
+          width: DRAWER_WIDTH,
           flexShrink: 0,
-          transition: 'width 200ms ease',
           '& .MuiDrawer-paper': {
             width: DRAWER_WIDTH,
             bgcolor: 'background.paper',
             borderRight: '1px solid',
             borderColor: 'divider',
             overflowX: 'hidden',
-            transition: 'width 200ms ease',
             position: 'relative',
             height: '100%',
           },

--- a/frontend/src/pages/admin/AdminDashboard.tsx
+++ b/frontend/src/pages/admin/AdminDashboard.tsx
@@ -8,6 +8,8 @@ import { customersApi } from '@api/customers.api';
 import { QUERY_KEYS } from '@utils/constants';
 import { StatCardSkeleton } from '@components/feedback/LoadingSkeleton';
 import { formatCurrency } from '@utils/format';
+import { RevenueAreaCard, BreakdownDonutCard, ActivityBarCard } from '@components/data-display/DashboardCharts';
+import { revenueByDay, countByKey, averageOrderValue } from '@utils/analytics';
 import UserManagement from './UserManagement';
 
 function StatCard({ label, value, sub }: { label: string; value: string; sub?: string }) {
@@ -42,6 +44,9 @@ export default function AdminDashboard() {
   const isLoading = tenantsLoading || paymentsLoading || customersLoading;
   const totalRevenue = payments?.reduce((s, p) => s + p.amount, 0) ?? 0;
   const activeTenants = tenants?.filter((t) => t.status === 'ACTIVE').length ?? 0;
+  const aov = averageOrderValue(payments);
+  const gmvSeries = revenueByDay(payments);
+  const byMethod = countByKey(payments, (p) => p.paymentMethod);
 
   return (
     <Container maxWidth="lg" sx={{ py: 2 }}>
@@ -59,18 +64,37 @@ export default function AdminDashboard() {
         </Tabs>
 
         {tab === 0 && (
-          <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', sm: 'repeat(2, 1fr)', md: 'repeat(4, 1fr)' }, gap: 2.5, mb: 6 }}>
-            {isLoading ? (
-              [1, 2, 3, 4].map((i) => <StatCardSkeleton key={i} />)
-            ) : (
-              <>
-                <StatCard label="TOTAL TENANTS" value={String(tenants?.length ?? 0)} sub={`${activeTenants} active`} />
-                <StatCard label="TOTAL REVENUE" value={formatCurrency(totalRevenue)} />
-                <StatCard label="TOTAL CUSTOMERS" value={String(customers?.length ?? 0)} />
-                <StatCard label="TOTAL PAYMENTS" value={String(payments?.length ?? 0)} />
-              </>
+          <>
+            <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', sm: 'repeat(2, 1fr)', md: 'repeat(4, 1fr)' }, gap: 2.5, mb: 4 }}>
+              {isLoading ? (
+                [1, 2, 3, 4].map((i) => <StatCardSkeleton key={i} />)
+              ) : (
+                <>
+                  <StatCard label="TOTAL GMV" value={formatCurrency(totalRevenue)} sub={`${payments?.length ?? 0} payments`} />
+                  <StatCard label="AVG ORDER VALUE" value={formatCurrency(aov)} />
+                  <StatCard label="TOTAL CUSTOMERS" value={String(customers?.length ?? 0)} />
+                  <StatCard label="TENANTS" value={String(tenants?.length ?? 0)} sub={`${activeTenants} active`} />
+                </>
+              )}
+            </Box>
+
+            {!isLoading && (
+              <Box sx={{ mb: 4 }}>
+                <RevenueAreaCard
+                  title="Platform GMV over time"
+                  subtitle="Daily gross merchandise value across all sellers"
+                  data={gmvSeries}
+                />
+              </Box>
             )}
-          </Box>
+
+            {!isLoading && (
+              <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', md: 'repeat(2, 1fr)' }, gap: 2.5, mb: 4 }}>
+                <BreakdownDonutCard title="Revenue by payment method" subtitle="Share of payments by method" data={byMethod} />
+                <ActivityBarCard title="Payments per day" subtitle="Platform transaction volume" data={gmvSeries} />
+              </Box>
+            )}
+          </>
         )}
 
         {tab === 1 && <UserManagement />}

--- a/frontend/src/pages/seller/SellerDashboard.tsx
+++ b/frontend/src/pages/seller/SellerDashboard.tsx
@@ -7,6 +7,8 @@ import { ordersApi } from '@api/orders.api';
 import { QUERY_KEYS, ROUTES } from '@utils/constants';
 import { StatCardSkeleton } from '@components/feedback/LoadingSkeleton';
 import { formatCurrency } from '@utils/format';
+import { RevenueAreaCard, BreakdownDonutCard } from '@components/data-display/DashboardCharts';
+import { revenueByDay, countByKey, averageOrderValue } from '@utils/analytics';
 
 function StatCard({ label, value, sub }: { label: string; value: string; sub?: string }) {
   return (
@@ -36,7 +38,13 @@ export default function SellerDashboard() {
 
   const isLoading = productsLoading || ordersLoading;
   const totalRevenue = orders?.reduce((s, o) => s + o.amount, 0) ?? 0;
+  const orderCount = orders?.length ?? 0;
+  const aov = averageOrderValue(orders);
   const lowStock = products?.content.filter((p) => p.availableQuantity < 5).length ?? 0;
+
+  const revenueSeries = revenueByDay(orders);
+  const byStatus = countByKey(orders, (o) => o.status as string);
+  const byPaymentMethod = countByKey(orders, (o) => o.paymentMethod);
 
   return (
     <Container maxWidth="lg" sx={{ py: 2 }}>
@@ -51,17 +59,38 @@ export default function SellerDashboard() {
           </Button>
         </Box>
 
-        <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', sm: 'repeat(3, 1fr)' }, gap: 2.5, mb: 6 }}>
+        {/* KPI row */}
+        <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', sm: 'repeat(2, 1fr)', md: 'repeat(4, 1fr)' }, gap: 2.5, mb: 4 }}>
           {isLoading ? (
-            [1, 2, 3].map((i) => <StatCardSkeleton key={i} />)
+            [1, 2, 3, 4].map((i) => <StatCardSkeleton key={i} />)
           ) : (
             <>
+              <StatCard label="TOTAL REVENUE" value={formatCurrency(totalRevenue)} sub={`${orderCount} orders`} />
+              <StatCard label="AVG ORDER VALUE" value={formatCurrency(aov)} />
               <StatCard label="TOTAL PRODUCTS" value={String(products?.totalElements ?? 0)} />
-              <StatCard label="TOTAL REVENUE" value={formatCurrency(totalRevenue)} />
               <StatCard label="LOW STOCK" value={String(lowStock)} sub="Items below 5 units" />
             </>
           )}
         </Box>
+
+        {/* Hero: revenue over time */}
+        {!isLoading && (
+          <Box sx={{ mb: 4 }}>
+            <RevenueAreaCard
+              title="Revenue over time"
+              subtitle="Daily revenue from your paid orders"
+              data={revenueSeries}
+            />
+          </Box>
+        )}
+
+        {/* Breakdown row */}
+        {!isLoading && (
+          <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', md: 'repeat(2, 1fr)' }, gap: 2.5, mb: 4 }}>
+            <BreakdownDonutCard title="Orders by status" subtitle="Saga lifecycle of your orders" data={byStatus} />
+            <BreakdownDonutCard title="Payment methods" subtitle="How buyers paid" data={byPaymentMethod} />
+          </Box>
+        )}
       </motion.div>
     </Container>
   );

--- a/frontend/src/routes/layouts/AdminLayout.tsx
+++ b/frontend/src/routes/layouts/AdminLayout.tsx
@@ -22,19 +22,19 @@ const ADMIN_NAV = [
 ];
 
 export default function AdminLayout() {
-  const { sidebarOpen, setSidebarOpen } = useUIStore();
+  const { sidebarOpen, setSidebarOpen, toggleSidebar } = useUIStore();
   const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down('lg'));
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
 
   return (
     <MotionConfig reducedMotion="user">
       <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
-        <Navbar />
+        <Navbar onMenuClick={isMobile ? toggleSidebar : undefined} />
         <Box sx={{ display: 'flex', flexGrow: 1, overflow: 'hidden' }}>
           <Sidebar
             items={ADMIN_NAV}
             title="Admin"
-            open={sidebarOpen && !isMobile}
+            open={sidebarOpen}
             onClose={() => setSidebarOpen(false)}
           />
           <Box

--- a/frontend/src/routes/layouts/SellerLayout.tsx
+++ b/frontend/src/routes/layouts/SellerLayout.tsx
@@ -22,19 +22,19 @@ const SELLER_NAV = [
 ];
 
 export default function SellerLayout() {
-  const { sidebarOpen, setSidebarOpen } = useUIStore();
+  const { sidebarOpen, setSidebarOpen, toggleSidebar } = useUIStore();
   const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down('lg'));
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
 
   return (
     <MotionConfig reducedMotion="user">
       <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
-        <Navbar />
+        <Navbar onMenuClick={isMobile ? toggleSidebar : undefined} />
         <Box sx={{ display: 'flex', flexGrow: 1, overflow: 'hidden' }}>
           <Sidebar
             items={SELLER_NAV}
             title="Seller Hub"
-            open={sidebarOpen && !isMobile}
+            open={sidebarOpen}
             onClose={() => setSidebarOpen(false)}
           />
           <Box

--- a/frontend/src/stores/ui.store.ts
+++ b/frontend/src/stores/ui.store.ts
@@ -28,7 +28,10 @@ export const useUIStore = create<UIState>()(
   persist(
     (set) => ({
       themeMode: 'dark',
-      sidebarOpen: true,
+      // Drives only the mobile (< md) temporary drawer; starts closed so it never
+      // auto-opens on first paint (that open->close race caused the old freeze).
+      // The desktop (md+) permanent sidebar is always visible regardless of this.
+      sidebarOpen: false,
       toastQueue: [],
 
       setThemeMode: (mode) => set({ themeMode: mode }),

--- a/frontend/src/utils/analytics.ts
+++ b/frontend/src/utils/analytics.ts
@@ -1,0 +1,67 @@
+/**
+ * Pure aggregation helpers for the Seller/Admin dashboards.
+ * Built only from data the API already returns (order/payment headers) — no
+ * extra backend. Real e-commerce dashboards (Amazon Seller Central, Shopify
+ * admin) center on: revenue/GMV over time, order/payment volume, AOV, and
+ * categorical breakdowns (status, payment method). These helpers feed exactly
+ * those charts.
+ */
+
+export interface DayPoint {
+  /** ISO day, YYYY-MM-DD — sortable + used as the x-axis key. */
+  date: string;
+  revenue: number;
+  count: number;
+}
+
+export interface Slice {
+  name: string;
+  value: number;
+}
+
+/** Group items with an `amount` + optional `createdDate` into per-day revenue & count. */
+export function revenueByDay<T extends { amount: number; createdDate?: string }>(
+  items: T[] | undefined
+): DayPoint[] {
+  const map = new Map<string, { revenue: number; count: number }>();
+  for (const it of items ?? []) {
+    if (!it.createdDate) continue;
+    const day = it.createdDate.slice(0, 10);
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(day)) continue;
+    const cur = map.get(day) ?? { revenue: 0, count: 0 };
+    cur.revenue += it.amount ?? 0;
+    cur.count += 1;
+    map.set(day, cur);
+  }
+  return [...map.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([date, v]) => ({ date, revenue: Math.round(v.revenue * 100) / 100, count: v.count }));
+}
+
+/** Count items grouped by a categorical key (status, payment method, …), desc. */
+export function countByKey<T>(
+  items: T[] | undefined,
+  key: (t: T) => string | undefined | null,
+  fallback = 'Unknown'
+): Slice[] {
+  const map = new Map<string, number>();
+  for (const it of items ?? []) {
+    const k = (key(it) ?? '').toString().trim() || fallback;
+    map.set(k, (map.get(k) ?? 0) + 1);
+  }
+  return [...map.entries()]
+    .map(([name, value]) => ({ name, value }))
+    .sort((a, b) => b.value - a.value);
+}
+
+/** Average order value = total revenue / order count (0 when no orders). */
+export function averageOrderValue<T extends { amount: number }>(items: T[] | undefined): number {
+  const list = items ?? [];
+  if (list.length === 0) return 0;
+  return list.reduce((s, i) => s + (i.amount ?? 0), 0) / list.length;
+}
+
+/** Short axis label from an ISO day: "06-24". */
+export function shortDay(isoDay: string): string {
+  return isoDay.length >= 10 ? isoDay.slice(5) : isoDay;
+}


### PR DESCRIPTION
# Session Report — Frontend Navigation & Dashboard Overhaul

## Status: Code-complete, lint + build gates green ✅ — awaiting live-stack rebuild proof

---

## Features Implemented

1. **Seller/Admin sidebar restored** (regression from prior session's freeze fix)
2. **Cart removed from Seller and Admin** (Seller/Admin don't buy)
3. **High-grade e-commerce charts** added to Seller and Admin dashboards (Recharts)

---

## Root Cause Investigation (Phase 1)

**Confirmed with git evidence and code reads — zero guessing:**

| Finding | File | Evidence |
|---|---|---|
| Sidebar items (Products/Orders/Inventory) were NOT deleted | `SellerLayout.tsx:16-22` | `SELLER_NAV` intact |
| Sidebar was invisible because `open={sidebarOpen && !isMobile}` where `!isMobile` = `lg` (1200px) | `SellerLayout.tsx:37`, `Sidebar.tsx:90` | Compound expression always false at user's ~900–1200px width |
| "Who bought" page (`OrderManagement.tsx`) existed and was correct | `OrderManagement.tsx` | Shows Reference/Amount/Payment/**Customer** from `ordersApi.getSeller` |
| Cart icon rendered regardless of role | `Navbar.tsx:119-130` | No role guard |
| Recharts already installed | `package.json:31` | `"recharts": "^3.8.1"` |

---

## Step-by-Step Execution

### Task A — Restore sidebar (the regression I caused)

1. Changed `isMobile` breakpoint from `down('lg')` → `down('md')` in `Sidebar.tsx` and both layouts
2. Made the **permanent drawer always visible at md+** (no longer gated on `sidebarOpen`)
3. Added **hamburger button** (`MenuIcon`) to `Navbar.tsx` via new `onMenuClick` prop — shown only `< md` in dashboard layouts
4. `SellerLayout` and `AdminLayout` pass `onMenuClick={isMobile ? toggleSidebar : undefined}` to Navbar
5. Changed `ui.store.ts` default `sidebarOpen` to `false` — temporary drawer starts closed, preventing the original freeze re-occurring
6. `npm run build` → ✅

### Task B — Remove cart from Seller/Admin

1. Wrapped cart icon in `Navbar.tsx` with `role !== 'SELLER' && role !== 'ADMIN'`
2. Wrapped cart action in `MobileNav.tsx` with `showCart` flag (same condition)
3. `npm run build` → ✅

### Task C — Real-ecommerce charts (Recharts)

1. Created `utils/analytics.ts` — pure aggregation helpers (`revenueByDay`, `countByKey`, `averageOrderValue`, `shortDay`) — no new API calls, only uses existing order/payment header fields
2. Created `components/data-display/DashboardCharts.tsx` — `RevenueAreaCard` (area hero), `BreakdownDonutCard` (donut), `ActivityBarCard` (bar) — reusable, themed with CSS vars (`--accent-primary`, `--border-default`, `--surface-overlay`)
3. Rewrote `SellerDashboard.tsx` — KPIs (revenue, AOV, products, low-stock) + revenue area + orders-by-status donut + payment-method donut
4. Enhanced `AdminDashboard.tsx` (Overview tab) — KPIs (GMV, AOV, customers, tenants) + GMV area + revenue-by-method donut + payments-per-day bar
5. Fixed Recharts v3 TS strict type on `formatter`/`labelFormatter` — coerce with `Number(value ?? 0)`, remove explicit param annotations
6. Fixed ESLint `react-refresh/only-export-components` — moved `CHART_PALETTE` from `export const` to local `const`
7. `npm run lint` clean + `npm run build` → ✅

---

## Mapping to SKILL Phases

| Phase | Work Done |
|---|---|
| **Phase 1 — Root Cause** | Git history read; all sidebar/layout files read; confirmed SELLER_NAV intact, Navbar has no cart role guard, Recharts installed |
| **Phase 2 — Pattern Analysis** | Compared failing layouts (Seller/Admin, have temporary Drawer) vs working ones (Public/Customer); identified `down('lg')` breakpoint as the invisible threshold |
| **Phase 3 — Hypothesis & Test** | One hypothesis: permanent drawer breakpoint wrong + no hamburger fallback → verified by tracing `open={sidebarOpen && !isMobile} && isMobile` = always false |
| **Phase 4 — Implementation** | Three independent tasks each fixed one root cause; build gate ran after each |

---

## Files Created / Modified

| Area | File | Change |
|---|---|---|
| frontend | [Sidebar.tsx](frontend/src/components/layout/Sidebar.tsx) | `down('lg')` → `down('md')`; permanent drawer always visible at md+; temporary drawer breakpoint aligned |
| frontend | [SellerLayout.tsx](frontend/src/routes/layouts/SellerLayout.tsx) | `down('lg')` → `down('md')`; `onMenuClick` passed to Navbar; `open={sidebarOpen}` |
| frontend | [AdminLayout.tsx](frontend/src/routes/layouts/AdminLayout.tsx) | Same as SellerLayout |
| frontend | [Navbar.tsx](frontend/src/components/layout/Navbar.tsx) | Added `MenuIcon` import + `onMenuClick` prop + hamburger button; cart guarded by `role !== 'SELLER' && role !== 'ADMIN'` |
| frontend | [MobileNav.tsx](frontend/src/components/layout/MobileNav.tsx) | Cart action wrapped with `showCart` flag |
| frontend | [ui.store.ts](frontend/src/stores/ui.store.ts) | `sidebarOpen` default `true` → `false` |
| frontend | [SellerDashboard.tsx](frontend/src/pages/seller/SellerDashboard.tsx) | Full rewrite with AOV KPI + revenue area + status/method donuts |
| frontend | [AdminDashboard.tsx](frontend/src/pages/admin/AdminDashboard.tsx) | Overview tab: GMV area + method donut + payments-per-day bar + AOV KPI |
| frontend | [utils/analytics.ts](frontend/src/utils/analytics.ts) | **New** — pure aggregation helpers |
| frontend | [components/data-display/DashboardCharts.tsx](frontend/src/components/data-display/DashboardCharts.tsx) | **New** — `RevenueAreaCard`, `BreakdownDonutCard`, `ActivityBarCard` |
| memory | [WORKING_STATE_frontend.md](../memory/WORKING_STATE_frontend.md) | **New** — canonical rules for roles/cart/sidebar/breakpoints/charts — read before touching layout/nav |
| memory | [project_seller_sidebar_cart_regression_fix.md](../memory/project_seller_sidebar_cart_regression_fix.md) | **New** — root cause + fix recorded |
| memory | [project_dashboard_charts.md](../memory/project_dashboard_charts.md) | **New** — chart components, Recharts v3 gotchas |
| memory | [MEMORY.md](../memory/MEMORY.md) | Updated index |

---

## Current State

- **Working tree:** all files above modified/created, uncommitted (per `feedback_no_git_actions` rule)
- **Gates:** `npm run lint` clean + `npm run build` `✓ built in ~10s`, 0 TS errors
- **Sidebar (code):** permanent at md+ (covers DevTools-open viewport); hamburger at <md; no auto-open freeze
- **Cart (code):** only for `role === 'USER'` and guests
- **Charts (code):** Seller → revenue area + AOV + status/method donuts; Admin → GMV area + AOV + method donut + volume bar
- **NOT proven live:** needs user's frontend container rebuild + real sessions for each role

---

## Next Steps

1. **User rebuilds frontend** and confirms in browser:
   - Seller sidebar visible and clickable at normal DevTools width
   - Seller → Orders shows "who bought" (customer name column)
   - No cart icon for Seller/Admin
   - Charts render on both dashboards

2. **If Seller Orders is empty** (not missing — empty table): the backend `GET /orders/seller` 500 fix (DISTINCT+ORDER BY, memory `project_seller_orders_500_distinct_orderby`) is pending a `order-service` container rebuild — not a frontend issue.

3. **Remaining product roadmap** (per `project_phases.md`): Phase 3 reliability (resilience4j tuning already mostly done), Phase 4 SaaS multi-tenancy.