### PR TITLE
feat: Order line security step definitions

### DIFF
--- a/order-service/src/main/java/code/with/vanilson/orderservice/orderLine/OrderLineRepository.java
+++ b/order-service/src/main/java/code/with/vanilson/orderservice/orderLine/OrderLineRepository.java
@@ -65,4 +65,20 @@ public interface OrderLineRepository extends JpaRepository<OrderLine, Integer> {
             + "WHERE ol.order.orderId = :orderId AND ol.sellerId = :sellerId")
     boolean existsByOrderIdAndSellerId(@Param("orderId") Integer orderId,
                                        @Param("sellerId") String sellerId);
+
+    /**
+     * Returns ONLY the lines of an order that belong to the given seller
+     * ({@code line.sellerId = product.createdBy}). A seller who sold one item in a
+     * multi-seller order must never see the other sellers' (or the platform/"system"-owned)
+     * lines — that is a cross-seller data leak. Customer-owners and ADMINs use
+     * {@link #findAllOrderById(Integer)} instead and see the whole order.
+     *
+     * @param orderId  the parent order ID
+     * @param sellerId the seller's userId (matched against {@code order_line.seller_id})
+     * @return the seller's own lines in that order
+     */
+    @Query("SELECT ol FROM OrderLine ol "
+            + "WHERE ol.order.orderId = :orderId AND ol.sellerId = :sellerId")
+    List<OrderLine> findByOrderIdAndSellerId(@Param("orderId") Integer orderId,
+                                             @Param("sellerId") String sellerId);
 }

--- a/order-service/src/main/java/code/with/vanilson/orderservice/orderLine/OrderLineService.java
+++ b/order-service/src/main/java/code/with/vanilson/orderservice/orderLine/OrderLineService.java
@@ -115,19 +115,41 @@ public class OrderLineService {
                 .orElseThrow(() -> new OrderNotFoundException(
                         msg("order.not.found", orderId), "order.not.found"));
 
-        SecurityPrincipal principal = currentPrincipal();
-        if (principal != null && !"ADMIN".equals(principal.role())
-                && !order.getCustomerId().equals(String.valueOf(principal.userId()))
-                && !(principal.isSeller()
-                     && repository.existsByOrderIdAndSellerId(orderId, String.valueOf(principal.userId())))) {
-            throw new OrderForbiddenException(
-                    msg("order.access.denied"), "order.access.denied");
-        }
-
-        return repository.findAllOrderById(orderId)
+        return authorizeAndScopeLines(order, orderId)
                 .stream()
                 .map(mapper::toOrderLineResponse)
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * Authorizes the caller against this order and returns ONLY the lines they may see:
+     * <ul>
+     *   <li><b>ADMIN</b> — the whole order (platform oversight; only the admin sees everything).</li>
+     *   <li><b>Customer-owner</b> — the whole order (it is their own purchase).</li>
+     *   <li><b>SELLER</b> — ONLY their own lines ({@code seller_id = userId}). A seller who sold
+     *       one item in a multi-seller basket must never see the other sellers' lines nor the
+     *       platform/"system"-owned catalog lines — that was a cross-seller data leak.</li>
+     *   <li>anyone else — {@link OrderForbiddenException} (403).</li>
+     * </ul>
+     * No security context (trusted internal call) falls back to the full order, preserving prior behaviour.
+     */
+    private List<OrderLine> authorizeAndScopeLines(Order order, Integer orderId) {
+        SecurityPrincipal principal = currentPrincipal();
+        if (principal == null) {
+            return repository.findAllOrderById(orderId);
+        }
+        if (principal.isAdmin()
+                || order.getCustomerId().equals(String.valueOf(principal.userId()))) {
+            return repository.findAllOrderById(orderId);
+        }
+        if (principal.isSeller()) {
+            List<OrderLine> ownLines =
+                    repository.findByOrderIdAndSellerId(orderId, String.valueOf(principal.userId()));
+            if (!ownLines.isEmpty()) {
+                return ownLines;
+            }
+        }
+        throw new OrderForbiddenException(msg("order.access.denied"), "order.access.denied");
     }
 
     private SecurityPrincipal currentPrincipal() {

--- a/order-service/src/test/java/code/with/vanilson/orderservice/bdd/OrderLineSecurityStepDefinitions.java
+++ b/order-service/src/test/java/code/with/vanilson/orderservice/bdd/OrderLineSecurityStepDefinitions.java
@@ -1,0 +1,183 @@
+package code.with.vanilson.orderservice.bdd;
+
+import code.with.vanilson.orderservice.Order;
+import code.with.vanilson.orderservice.OrderRepository;
+import code.with.vanilson.orderservice.exception.OrderForbiddenException;
+import code.with.vanilson.orderservice.orderLine.OrderLine;
+import code.with.vanilson.orderservice.orderLine.OrderLineMapper;
+import code.with.vanilson.orderservice.orderLine.OrderLineRepository;
+import code.with.vanilson.orderservice.orderLine.OrderLineResponse;
+import code.with.vanilson.orderservice.orderLine.OrderLineService;
+import code.with.vanilson.orderservice.product.ProductClient;
+import code.with.vanilson.tenantcontext.TenantContext;
+import code.with.vanilson.tenantcontext.TenantHibernateFilterActivator;
+import code.with.vanilson.tenantcontext.security.SecurityPrincipal;
+import io.cucumber.datatable.DataTable;
+import io.cucumber.java.After;
+import io.cucumber.java.Before;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import org.mockito.Mockito;
+import org.springframework.context.MessageSource;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+/**
+ * BDD step definitions for seller data-isolation on order-line reads.
+ * <p>
+ * Wires a REAL {@link OrderLineService} over mocked repositories so the scenarios exercise the
+ * actual authorization-and-scoping branch ({@code findAllByOrderId}): ADMIN and the customer-owner
+ * see the whole order, a SELLER sees ONLY their own lines, and a seller with no line in the order
+ * is forbidden. Regression for the live bug where a seller saw another seller's / "system"-owned
+ * products in an order they only partly fulfilled.
+ * </p>
+ */
+public class OrderLineSecurityStepDefinitions {
+
+    private OrderLineRepository orderLineRepository;
+    private OrderLineMapper mapper;
+    private OrderRepository orderRepository;
+    private TenantHibernateFilterActivator filterActivator;
+    private MessageSource messageSource;
+    private ProductClient productClient;
+    private OrderLineService orderLineService;
+
+    // State
+    private List<OrderLineResponse> result;
+    private Exception caughtException;
+
+    @Before
+    public void setUp() {
+        orderLineRepository = Mockito.mock(OrderLineRepository.class);
+        mapper = Mockito.mock(OrderLineMapper.class);
+        orderRepository = Mockito.mock(OrderRepository.class);
+        filterActivator = Mockito.mock(TenantHibernateFilterActivator.class);
+        messageSource = Mockito.mock(MessageSource.class);
+        productClient = Mockito.mock(ProductClient.class);
+
+        orderLineService = new OrderLineService(
+                orderLineRepository, mapper, orderRepository, filterActivator, messageSource, productClient);
+
+        lenient().when(messageSource.getMessage(anyString(), any(), any(Locale.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+        // Map any line to a response preserving id + productId + quantity.
+        lenient().when(mapper.toOrderLineResponse(any(OrderLine.class)))
+                .thenAnswer(inv -> {
+                    OrderLine ol = inv.getArgument(0);
+                    return new OrderLineResponse(ol.getId(), ol.getProductId(), ol.getQuantity());
+                });
+
+        TenantContext.setCurrentTenantId("test-tenant");
+        result = null;
+        caughtException = null;
+    }
+
+    @After
+    public void tearDown() {
+        TenantContext.clear();
+        SecurityContextHolder.clearContext();
+    }
+
+    // ---- Given ----
+
+    @Given("order {int} owned by customer {string} has the lines:")
+    public void order_has_the_lines(Integer orderId, String customerId, DataTable table) {
+        Order order = Order.builder().orderId(orderId).customerId(customerId).tenantId("test-tenant").build();
+        when(orderRepository.findById(orderId)).thenReturn(Optional.of(order));
+
+        List<Map<String, String>> rows = table.asMaps();
+        List<OrderLine> allLines = rows.stream().map(row -> OrderLine.builder()
+                .id(Integer.parseInt(row.get("productId"))) // unique-enough id per row
+                .order(order)
+                .productId(Integer.parseInt(row.get("productId")))
+                .quantity(1.0)
+                .sellerId(row.get("sellerId"))
+                .build()).toList();
+
+        when(orderLineRepository.findAllOrderById(orderId)).thenReturn(allLines);
+
+        // Mirror the repository's findByOrderIdAndSellerId: a seller sees only the lines they own
+        // (sellers absent from the table own nothing → empty list → forbidden).
+        when(orderLineRepository.findByOrderIdAndSellerId(org.mockito.ArgumentMatchers.eq(orderId), anyString()))
+                .thenAnswer(inv -> {
+                    String sid = inv.getArgument(1);
+                    return allLines.stream().filter(l -> sid.equals(l.getSellerId())).toList();
+                });
+    }
+
+    // ---- When ----
+
+    @When("the seller {string} requests the lines of order {int}")
+    public void seller_requests_lines(String sellerId, Integer orderId) {
+        authenticateAs(Long.parseLong(sellerId), "SELLER");
+        invoke(orderId);
+    }
+
+    @When("the customer {string} requests the lines of order {int}")
+    public void customer_requests_lines(String customerId, Integer orderId) {
+        authenticateAs(Long.parseLong(customerId), "USER");
+        invoke(orderId);
+    }
+
+    @When("an admin requests the lines of order {int}")
+    public void admin_requests_lines(Integer orderId) {
+        authenticateAs(999L, "ADMIN");
+        invoke(orderId);
+    }
+
+    // ---- Then ----
+
+    @Then("exactly {int} order line is returned")
+    public void exactly_n_order_line_is_returned(int count) {
+        exactly_n_order_lines_are_returned(count);
+    }
+
+    @Then("exactly {int} order lines are returned")
+    public void exactly_n_order_lines_are_returned(int count) {
+        assertThat(caughtException).isNull();
+        assertThat(result).isNotNull().hasSize(count);
+    }
+
+    @Then("the returned order line is for product {int}")
+    public void the_returned_order_line_is_for_product(int productId) {
+        assertThat(result).isNotNull()
+                .extracting(OrderLineResponse::productId)
+                .containsExactly(productId);
+    }
+
+    @Then("the order line request is forbidden")
+    public void the_order_line_request_is_forbidden() {
+        assertThat(caughtException).isInstanceOf(OrderForbiddenException.class);
+    }
+
+    // ---- Helpers ----
+
+    private void invoke(Integer orderId) {
+        try {
+            result = orderLineService.findAllByOrderId(orderId);
+        } catch (Exception e) {
+            caughtException = e;
+        }
+    }
+
+    private void authenticateAs(long userId, String role) {
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(
+                        new SecurityPrincipal("user@test.com", userId, "test-tenant", role),
+                        null,
+                        List.of(new SimpleGrantedAuthority("ROLE_" + role))));
+    }
+}

--- a/order-service/src/test/java/code/with/vanilson/orderservice/orderLine/OrderLineControllerTest.java
+++ b/order-service/src/test/java/code/with/vanilson/orderservice/orderLine/OrderLineControllerTest.java
@@ -1,5 +1,7 @@
 package code.with.vanilson.orderservice.orderLine;
 
+import code.with.vanilson.orderservice.exception.OrderForbiddenException;
+import code.with.vanilson.orderservice.exception.OrderGlobalExceptionHandler;
 import code.with.vanilson.tenantcontext.TenantHibernateFilterActivator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -8,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.context.MessageSource;
 import org.springframework.test.web.servlet.MockMvc;
@@ -34,6 +37,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  */
 @WebMvcTest(OrderLineController.class)
 @AutoConfigureMockMvc(addFilters = false)
+@Import(OrderGlobalExceptionHandler.class)
 @DisplayName("OrderLineController — Web Layer Tests")
 class OrderLineControllerTest {
 
@@ -86,5 +90,31 @@ class OrderLineControllerTest {
                         .header("X-Tenant-ID", "test-tenant-123"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$", hasSize(0)));
+    }
+
+    @Test
+    @DisplayName("seller: returns exactly the service's seller-scoped lines (other sellers' lines never reach the wire)")
+    void shouldReturnOnlyTheSellerScopedLines() throws Exception {
+        // The service has already filtered to the caller-seller's own lines; the controller
+        // must surface only those — never the rest of the multi-seller basket.
+        when(orderLineService.findAllByOrderId(500))
+                .thenReturn(List.of(new OrderLineResponse(11, 9, 1.0)));
+
+        mockMvc.perform(get("/api/v1/order-lines/{order-id}", 500)
+                        .header("X-Tenant-ID", "test-tenant-123"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].productId", is(9)));
+    }
+
+    @Test
+    @DisplayName("should return 403 when the caller may not view the order's lines")
+    void shouldReturn403WhenForbidden() throws Exception {
+        when(orderLineService.findAllByOrderId(500))
+                .thenThrow(new OrderForbiddenException("order.access.denied", "order.access.denied"));
+
+        mockMvc.perform(get("/api/v1/order-lines/{order-id}", 500)
+                        .header("X-Tenant-ID", "test-tenant-123"))
+                .andExpect(status().isForbidden());
     }
 }

--- a/order-service/src/test/java/code/with/vanilson/orderservice/orderLine/OrderLineServiceTest.java
+++ b/order-service/src/test/java/code/with/vanilson/orderservice/orderLine/OrderLineServiceTest.java
@@ -203,6 +203,44 @@ class OrderLineServiceTest {
         }
 
         @Test
+        @DisplayName("seller: receives ONLY their own lines, never the full order (no cross-seller leak)")
+        void sellerGetsOnlyOwnLines() {
+            authenticateAs(55L, "SELLER");
+            when(orderRepository.findById(ORDER_ID)).thenReturn(Optional.of(orderOwnedBy(OWNER_ID)));
+
+            OrderLine sellerLine = OrderLine.builder()
+                    .id(11)
+                    .order(Order.builder().orderId(ORDER_ID).build())
+                    .productId(9)
+                    .quantity(1.0)
+                    .sellerId("55")
+                    .build();
+            when(repository.findByOrderIdAndSellerId(ORDER_ID, "55")).thenReturn(List.of(sellerLine));
+            when(mapper.toOrderLineResponse(sellerLine)).thenReturn(new OrderLineResponse(11, 9, 1.0));
+
+            List<OrderLineResponse> result = orderLineService.findAllByOrderId(ORDER_ID);
+
+            assertThat(result).hasSize(1)
+                    .first()
+                    .satisfies(r -> assertThat(r.productId()).isEqualTo(9));
+            // The seller path must NOT read the whole order — that is the leak being fixed.
+            verify(repository, never()).findAllOrderById(any());
+        }
+
+        @Test
+        @DisplayName("seller owning no line in the order: 403 (cannot view a basket they didn't sell into)")
+        void sellerWithNoOwnLinesForbidden() {
+            authenticateAs(77L, "SELLER");
+            when(orderRepository.findById(ORDER_ID)).thenReturn(Optional.of(orderOwnedBy(OWNER_ID)));
+            when(repository.findByOrderIdAndSellerId(ORDER_ID, "77")).thenReturn(List.of());
+
+            assertThatThrownBy(() -> orderLineService.findAllByOrderId(ORDER_ID))
+                    .isInstanceOf(OrderForbiddenException.class);
+
+            verify(repository, never()).findAllOrderById(any());
+        }
+
+        @Test
         @DisplayName("missing order: should throw OrderNotFoundException (404)")
         void missingOrder() {
             authenticateAs(7L, "USER");

--- a/order-service/src/test/resources/features/order.feature
+++ b/order-service/src/test/resources/features/order.feature
@@ -49,3 +49,39 @@ Feature: Async Order Creation and Status Polling
       | 2       | ORD-LIST-02 | 250.00 | cust-002   |
     When all orders are requested
     Then the system returns 2 orders
+
+  # ── Seller data-isolation: a seller must see ONLY the lines for their own products,
+  #    never other sellers' lines nor the platform/"system"-owned catalog lines. ──
+  Scenario: Seller sees only their own lines in a multi-seller order
+    Given order 500 owned by customer "cust-9" has the lines:
+      | productId | sellerId |
+      | 10        | 55       |
+      | 20        | 88       |
+      | 30        | system   |
+    When the seller "55" requests the lines of order 500
+    Then exactly 1 order line is returned
+    And the returned order line is for product 10
+
+  Scenario: Seller who sold nothing in the order cannot view it
+    Given order 500 owned by customer "cust-9" has the lines:
+      | productId | sellerId |
+      | 10        | 55       |
+      | 20        | 88       |
+    When the seller "77" requests the lines of order 500
+    Then the order line request is forbidden
+
+  Scenario: Customer-owner sees every line in their own order
+    Given order 500 owned by customer "9" has the lines:
+      | productId | sellerId |
+      | 10        | 55       |
+      | 20        | 88       |
+    When the customer "9" requests the lines of order 500
+    Then exactly 2 order lines are returned
+
+  Scenario: Admin sees every line in any order
+    Given order 500 owned by customer "cust-9" has the lines:
+      | productId | sellerId |
+      | 10        | 55       |
+      | 20        | 88       |
+    When an admin requests the lines of order 500
+    Then exactly 2 order lines are returned


### PR DESCRIPTION

## Files Created/Modified

### Backend (authentication-service)

| File | Change | Lines |
|---|---|---|
| `order-service/src/main/java/.../orderLine/OrderLineRepository.java` | ✨ Added `findByOrderIdAndSellerId` query method | +20 |
| `order-service/src/main/java/.../orderLine/OrderLineService.java` | 📝 Refactored `findAllByOrderId` to use `authorizeAndScopeLines` (new private method for branching by role) | +35 |
| `order-service/src/test/java/.../OrderLineServiceTest.java` | 📝 Added 2 new unit test cases (seller scoped, seller-no-line 403) | +45 |
| `order-service/src/test/java/.../OrderLineControllerTest.java` | 📝 Added 2 new controller slice cases (scoped list, 403 path); added @Import(OrderGlobalExceptionHandler) | +38 |
| `order-service/src/test/resources/features/order.feature` | 📝 Added 4 new BDD scenarios (seller isolation, owner/admin see all, seller-forbidden) | +45 |
| `order-service/src/test/java/.../bdd/OrderLineSecurityStepDefinitions.java` | ✨ NEW — BDD step definitions wiring a real OrderLineService with mocked repos | 180 |

### Frontend (frontend/)

| File | Change | Lines |
|---|---|---|
| `src/utils/orderSummary.ts` | ✨ NEW — `deriveSellerSummary(lines, productsById, taxRate)` utility | 30 |
| `src/utils/orderSummary.test.ts` | ✨ NEW — 5 test cases for seller summary derivation | 60 |
| `src/pages/customer/OrderDetailPage.tsx` | 📝 Detect seller view, derive seller-scoped summary, hide basket-level discounts for sellers | +25 |