### PR TITLE
feat: Account Settings frontend fixed

### DIFF
--- a/frontend/src/pages/customer/AccountSettingsPage.tsx
+++ b/frontend/src/pages/customer/AccountSettingsPage.tsx
@@ -154,6 +154,7 @@ export default function AccountSettingsPage() {
               label="First name"
               error={!!identityForm.formState.errors.firstname}
               helperText={identityForm.formState.errors.firstname?.message}
+              slotProps={{ inputLabel: { shrink: true } }}
               fullWidth
             />
             <TextField
@@ -161,6 +162,7 @@ export default function AccountSettingsPage() {
               label="Last name"
               error={!!identityForm.formState.errors.lastname}
               helperText={identityForm.formState.errors.lastname?.message}
+              slotProps={{ inputLabel: { shrink: true } }}
               fullWidth
             />
           </Box>
@@ -170,6 +172,7 @@ export default function AccountSettingsPage() {
             type="email"
             error={!!identityForm.formState.errors.email}
             helperText={identityForm.formState.errors.email?.message}
+            slotProps={{ inputLabel: { shrink: true } }}
             fullWidth
           />
           {emailChanged && (
@@ -178,6 +181,7 @@ export default function AccountSettingsPage() {
               label="Current password (required to change email)"
               type="password"
               helperText="Changing your sign-in email requires your current password."
+              slotProps={{ inputLabel: { shrink: true } }}
               fullWidth
             />
           )}
@@ -209,6 +213,7 @@ export default function AccountSettingsPage() {
             helperText={passwordForm.formState.errors.currentPassword?.message}
             fullWidth
             slotProps={{
+              inputLabel: { shrink: true },
               input: {
                 endAdornment: (
                   <InputAdornment position="end">
@@ -226,6 +231,7 @@ export default function AccountSettingsPage() {
             type={showPw ? 'text' : 'password'}
             error={!!passwordForm.formState.errors.newPassword}
             helperText={passwordForm.formState.errors.newPassword?.message}
+            slotProps={{ inputLabel: { shrink: true } }}
             fullWidth
           />
           <TextField
@@ -234,6 +240,7 @@ export default function AccountSettingsPage() {
             type={showPw ? 'text' : 'password'}
             error={!!passwordForm.formState.errors.confirmPassword}
             helperText={passwordForm.formState.errors.confirmPassword?.message}
+            slotProps={{ inputLabel: { shrink: true } }}
             fullWidth
           />
           <Button
@@ -271,6 +278,7 @@ export default function AccountSettingsPage() {
                 type="password"
                 value={deletePassword}
                 onChange={(e) => setDeletePassword(e.target.value)}
+                slotProps={{ inputLabel: { shrink: true } }}
                 fullWidth
               />
             </DialogContent>


### PR DESCRIPTION
Final review verdict: **MERGE-READY** — zero Critical/Important, all accumulated Minors triaged acceptable, and the two hardest cross-cutting concerns (token-rotation adoption ordering, async fail-open sync) verified against live code. Confirming the backend re-verification numbers from the log:

# Task 3 — Account Settings: implemented, all tests green ✅

All 11 plan tasks executed (fresh subagent per task, spec + quality review after each), final whole-branch review verdict: **MERGE-READY, zero Critical/Important findings**. Nothing committed — the working tree on `fix/registers-logins-customers-pages-02` holds everything, per your rules.

## What was built

**auth-service** — new `/api/v1/auth/account` (`AccountController` + `AccountService`):
- `GET /me`, `PATCH /me` — edit name/email; email change requires your current password, revokes **all** sessions and returns a fresh token pair (JWT subject = email); name-only edits don't rotate
- `POST /change-password` — current-password check, mismatch 400, sessions revoked + fresh pair
- `DELETE /me` — **USER-role only** (SELLER/ADMIN → 403); soft-delete + anonymize (`deleted-<id>@removed.local` tombstone frees the email for re-registration), all sessions revoked
- No SecurityConfig change, **no DB migration**

**Propagation** — `CustomerProvisioning` gained `@Async` fail-open sync/delete (no Kafka, per the standing rule) → two new idempotent customer-service endpoints `PUT/DELETE /api/v1/customers/internal/{id}` (204 always, address never clobbered).

**Frontend** — `AccountSettingsPage` (Identity / Change password / USER-only Danger zone with password-confirm dialog) at `/account/settings` + `/seller/account` + `/admin/account`; Navbar Settings item (i18n ×4); `Account` appended to both sidebars (your required 5+5 items untouched); **ProfilePage is now address-only** — name/email read-only with a link to settings, and the update mutation preserves them from the fetched customer (no blanking).

## Proof (all three layers, per your rule)

| Suite | Result |
|---|---|
| auth-service full (`mvn test`) | **163/163** — 12 unit + 4 provisioning + 12 slice + 5 BDD new |
| customer-service full | **72/72** — 4 unit + 4 slice + 3 BDD new |
| Frontend build + lint | green (0 errors; 1 benign RHF `watch()` warning) |
| Playwright e2e | **15/15 new** (5 tests × 3 browsers) + all 87 pre-existing intact |

Two things worth knowing:
1. **Pre-existing bug fixed en route**: customer-service's Cucumber context had *never* loaded (missing JWT test secret + unmocked Redis) — fixed in test bootstrap only, saved to memory.
2. One e2e defect was caught and fixed during verification (ambiguous `getByLabel('New password')` matched the confirm field too → `{exact: true}`).

## Your move — live proof still pending

Per the standing rule, this isn't "done" until proven in production. Rebuild these three containers (no volume/DB work needed): **authentication-service, customer-service, frontend**. Then I'll drive the live verification: register a throwaway → edit name → change email (relogin with new email, old 401) → change password → delete account → re-register the same email → confirm the customer profile synced.