### PR TITLE
feat: Idempotency as a platform convention

### DIFF
--- a/cart-service/src/main/java/code/with/vanilson/cartservice/application/CartService.java
+++ b/cart-service/src/main/java/code/with/vanilson/cartservice/application/CartService.java
@@ -77,7 +77,28 @@ public class CartService {
     // WRITE — add item
     // -------------------------------------------------------
 
+    /** Legacy entry point without idempotency — kept for callers that send no key. */
     public CartResponse addItem(String customerId, AddCartItemRequest request) {
+        return addItem(customerId, request, null);
+    }
+
+    /**
+     * Adds an item to the cart, idempotently when an {@code Idempotency-Key} is supplied.
+     * <p>
+     * B4: addItem is a RELATIVE mutation (it increments the quantity), so a client
+     * retry of the same request — e.g. after a false 503 from a stale gateway
+     * keep-alive on a write that actually succeeded, the same failure mode that
+     * duplicated orders — used to double the quantity. When the client sends an
+     * {@code Idempotency-Key}, keys already applied to this cart are answered with
+     * the current cart unchanged. The applied keys live on the cart hash itself
+     * (bounded FIFO), so the replay window expires with the cart's TTL / checkout
+     * clear — acceptable, because a cleared cart ends the shopping session the key
+     * belonged to. Absolute mutations (update quantity, remove, clear) are already
+     * replay-safe and take no key.
+     *
+     * @param idempotencyKey client-generated key, stable across retries of one add click; may be null
+     */
+    public CartResponse addItem(String customerId, AddCartItemRequest request, String idempotencyKey) {
         if (request.quantity() <= 0) {
             throw new CartValidationException(
                     msg("cart.item.quantity.invalid", request.productId()),
@@ -96,6 +117,15 @@ public class CartService {
             return newCart;
         });
 
+        boolean hasIdempotencyKey = idempotencyKey != null && !idempotencyKey.isBlank();
+
+        // Idempotent replay: this exact add was already applied — return the cart
+        // as it stands instead of incrementing the quantity a second time.
+        if (hasIdempotencyKey && cart.hasIdempotencyKey(idempotencyKey)) {
+            log.info(msg("cart.log.item.replayed", cartId, request.productId(), idempotencyKey));
+            return cartMapper.toResponse(cart);
+        }
+
         // Merge: if product already in cart, increment quantity
         cart.findItem(request.productId()).ifPresentOrElse(
                 existing -> existing.setQuantity(existing.getQuantity() + request.quantity()),
@@ -108,6 +138,10 @@ public class CartService {
                         .availableQuantity(request.availableQuantity())
                         .build())
         );
+
+        if (hasIdempotencyKey) {
+            cart.recordIdempotencyKey(idempotencyKey);
+        }
 
         cart.touch();
         cartRepository.save(cart);

--- a/cart-service/src/main/java/code/with/vanilson/cartservice/domain/Cart.java
+++ b/cart-service/src/main/java/code/with/vanilson/cartservice/domain/Cart.java
@@ -82,6 +82,16 @@ public class Cart implements Serializable {
     private LocalDateTime updatedAt  = LocalDateTime.now();
 
     /**
+     * B4 — Idempotency-Key values already applied to this cart's addItem.
+     * A retried POST (same key) is answered with the current cart instead of
+     * incrementing the quantity again. Bounded FIFO (see recordIdempotencyKey)
+     * and stored on the cart hash itself, so the record expires with the cart's
+     * own TTL — a cleared/expired cart ends the replay window by design.
+     */
+    @Builder.Default
+    private List<String> appliedIdempotencyKeys = new ArrayList<>();
+
+    /**
      * TTL: 86400 seconds = 24 hours.
      * Every write resets this — sliding window TTL.
      * Redis removes the key automatically when TTL expires.
@@ -122,5 +132,35 @@ public class Cart implements Serializable {
     public void touch() {
         this.updatedAt = LocalDateTime.now();
         this.ttl       = 86400L;
+    }
+
+    // -------------------------------------------------------
+    // B4 — addItem idempotency record
+    // -------------------------------------------------------
+
+    /** Cap on stored replay keys — plenty for one session's add clicks without unbounded growth. */
+    private static final int MAX_IDEMPOTENCY_KEYS = 50;
+
+    /** True when this Idempotency-Key was already applied to an addItem on this cart. */
+    public boolean hasIdempotencyKey(String key) {
+        return key != null && appliedIdempotencyKeys != null && appliedIdempotencyKeys.contains(key);
+    }
+
+    /**
+     * Records an applied Idempotency-Key, evicting the oldest beyond the cap.
+     * Carts serialised before this field existed deserialise it as null —
+     * initialised lazily here instead of assuming the builder default.
+     */
+    public void recordIdempotencyKey(String key) {
+        if (key == null || key.isBlank()) {
+            return;
+        }
+        if (appliedIdempotencyKeys == null) {
+            appliedIdempotencyKeys = new ArrayList<>();
+        }
+        appliedIdempotencyKeys.add(key);
+        while (appliedIdempotencyKeys.size() > MAX_IDEMPOTENCY_KEYS) {
+            appliedIdempotencyKeys.remove(0);
+        }
     }
 }

--- a/cart-service/src/main/java/code/with/vanilson/cartservice/presentation/CartController.java
+++ b/cart-service/src/main/java/code/with/vanilson/cartservice/presentation/CartController.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -63,7 +64,10 @@ public class CartController {
     }
 
     @Operation(summary = "Add item to cart",
-               description = "Creates the cart if it doesn't exist. If product already in cart, quantity is added.")
+               description = "Creates the cart if it doesn't exist. If product already in cart, quantity is added. "
+                       + "Send an optional Idempotency-Key header (stable across retries of one click) to make "
+                       + "the add replay-safe: a retried request with an already-applied key returns the current "
+                       + "cart without incrementing the quantity again.")
     @ApiResponses({
         @ApiResponse(responseCode = "201", description = "Item added to cart"),
         @ApiResponse(responseCode = "400", description = "Invalid item data")
@@ -72,9 +76,12 @@ public class CartController {
     @PostMapping("/{customerId}/items")
     public ResponseEntity<CartResponse> addItem(
             @PathVariable String customerId,
-            @RequestBody @Valid AddCartItemRequest request) {
+            @RequestBody @Valid AddCartItemRequest request,
+            @RequestHeader(value = "Idempotency-Key", required = false)
+            @Parameter(description = "Client-generated key, stable across retries of one add click")
+            String idempotencyKey) {
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(cartService.addItem(customerId, request));
+                .body(cartService.addItem(customerId, request, idempotencyKey));
     }
 
     @Operation(summary = "Update item quantity",

--- a/cart-service/src/main/resources/messages.properties
+++ b/cart-service/src/main/resources/messages.properties
@@ -28,6 +28,7 @@ error.resource.not.found=The requested resource was not found.
 # --- Logs ---
 cart.log.created=Cart created: cartId=[{0}] customerId=[{1}]
 cart.log.item.added=Item added to cart: cartId=[{0}] productId=[{1}] qty=[{2}]
+cart.log.item.replayed=Duplicate add-item replay ignored (idempotent): cartId=[{0}] productId=[{1}] idempotencyKey=[{2}]
 cart.log.item.removed=Item removed from cart: cartId=[{0}] productId=[{1}]
 cart.log.item.updated=Item updated in cart: cartId=[{0}] productId=[{1}] newQty=[{2}]
 cart.log.cleared=Cart cleared: cartId=[{0}]

--- a/cart-service/src/test/java/code/with/vanilson/cartservice/CartServiceTest.java
+++ b/cart-service/src/test/java/code/with/vanilson/cartservice/CartServiceTest.java
@@ -218,6 +218,94 @@ class CartServiceTest {
     }
 
     // -------------------------------------------------------
+    // addItem — Idempotency-Key (B4)
+    // -------------------------------------------------------
+    @Nested @DisplayName("addItem — Idempotency-Key (B4)")
+    class AddItemIdempotency {
+
+        private static final String KEY = "idem-key-001";
+
+        @Test @DisplayName("should record the key and apply the add on first delivery")
+        void shouldApplyAndRecordKeyOnFirstDelivery() {
+            CartResponse expectedResponse = buildResponse(CART_ID, CUSTOMER_ID, 1);
+            when(cartRepository.findById(CART_ID)).thenReturn(Optional.of(cartWithOneItem));
+            when(cartRepository.save(any(Cart.class))).thenReturn(cartWithOneItem);
+            when(cartMapper.toResponse(any(Cart.class))).thenReturn(expectedResponse);
+
+            cartService.addItem(CUSTOMER_ID, addLaptopRequest, KEY);
+
+            ArgumentCaptor<Cart> captor = ArgumentCaptor.forClass(Cart.class);
+            verify(cartRepository).save(captor.capture());
+            // The add applied (2 existing + 2 requested = 4) and the key was recorded
+            assertThat(captor.getValue().getItems().get(0).getQuantity()).isEqualTo(4.0);
+            assertThat(captor.getValue().hasIdempotencyKey(KEY)).isTrue();
+        }
+
+        @Test @DisplayName("should NOT increment quantity when the same key is replayed")
+        void shouldNotIncrementOnReplayedKey() {
+            // Cart state after the first (successful) add: key already applied
+            cartWithOneItem.recordIdempotencyKey(KEY);
+            CartResponse expectedResponse = buildResponse(CART_ID, CUSTOMER_ID, 1);
+            when(cartRepository.findById(CART_ID)).thenReturn(Optional.of(cartWithOneItem));
+            when(cartMapper.toResponse(any(Cart.class))).thenReturn(expectedResponse);
+
+            CartResponse result = cartService.addItem(CUSTOMER_ID, addLaptopRequest, KEY);
+
+            assertThat(result).isNotNull();
+            // Replay must not mutate or persist anything
+            verify(cartRepository, never()).save(any());
+            assertThat(cartWithOneItem.getItems().get(0).getQuantity()).isEqualTo(2.0);
+        }
+
+        @Test @DisplayName("should apply adds with different keys separately")
+        void shouldApplyDifferentKeysSeparately() {
+            cartWithOneItem.recordIdempotencyKey(KEY);
+            CartResponse expectedResponse = buildResponse(CART_ID, CUSTOMER_ID, 1);
+            when(cartRepository.findById(CART_ID)).thenReturn(Optional.of(cartWithOneItem));
+            when(cartRepository.save(any(Cart.class))).thenReturn(cartWithOneItem);
+            when(cartMapper.toResponse(any(Cart.class))).thenReturn(expectedResponse);
+
+            cartService.addItem(CUSTOMER_ID, addLaptopRequest, "idem-key-002");
+
+            // A different key is a different user action — the merge applies
+            ArgumentCaptor<Cart> captor = ArgumentCaptor.forClass(Cart.class);
+            verify(cartRepository).save(captor.capture());
+            assertThat(captor.getValue().getItems().get(0).getQuantity()).isEqualTo(4.0);
+            assertThat(captor.getValue().hasIdempotencyKey("idem-key-002")).isTrue();
+        }
+
+        @Test @DisplayName("should keep legacy merge behaviour when no key is sent")
+        void shouldKeepLegacyBehaviourWithoutKey() {
+            CartResponse expectedResponse = buildResponse(CART_ID, CUSTOMER_ID, 1);
+            when(cartRepository.findById(CART_ID)).thenReturn(Optional.of(cartWithOneItem));
+            when(cartRepository.save(any(Cart.class))).thenReturn(cartWithOneItem);
+            when(cartMapper.toResponse(any(Cart.class))).thenReturn(expectedResponse);
+
+            cartService.addItem(CUSTOMER_ID, addLaptopRequest, null);
+
+            ArgumentCaptor<Cart> captor = ArgumentCaptor.forClass(Cart.class);
+            verify(cartRepository).save(captor.capture());
+            assertThat(captor.getValue().getItems().get(0).getQuantity()).isEqualTo(4.0);
+            // No key sent → nothing recorded
+            assertThat(captor.getValue().getAppliedIdempotencyKeys()).isEmpty();
+        }
+
+        @Test @DisplayName("should treat a blank key as absent")
+        void shouldTreatBlankKeyAsAbsent() {
+            CartResponse expectedResponse = buildResponse(CART_ID, CUSTOMER_ID, 1);
+            when(cartRepository.findById(CART_ID)).thenReturn(Optional.of(cartWithOneItem));
+            when(cartRepository.save(any(Cart.class))).thenReturn(cartWithOneItem);
+            when(cartMapper.toResponse(any(Cart.class))).thenReturn(expectedResponse);
+
+            cartService.addItem(CUSTOMER_ID, addLaptopRequest, "   ");
+
+            ArgumentCaptor<Cart> captor = ArgumentCaptor.forClass(Cart.class);
+            verify(cartRepository).save(captor.capture());
+            assertThat(captor.getValue().getAppliedIdempotencyKeys()).isEmpty();
+        }
+    }
+
+    // -------------------------------------------------------
     // updateItemQuantity
     // -------------------------------------------------------
     @Nested @DisplayName("updateItemQuantity")

--- a/cart-service/src/test/java/code/with/vanilson/cartservice/bdd/CartStepDefinitions.java
+++ b/cart-service/src/test/java/code/with/vanilson/cartservice/bdd/CartStepDefinitions.java
@@ -106,6 +106,49 @@ public class CartStepDefinitions {
         }
     }
 
+    @When("I add product {int} with quantity {double} to the cart using idempotency key {string}")
+    public void i_add_product_with_idempotency_key(int productId, double quantity, String key) {
+        addWithIdempotencyKey(productId, quantity, key);
+    }
+
+    @When("I add product {int} with quantity {double} to the cart again using idempotency key {string}")
+    public void i_add_product_again_with_idempotency_key(int productId, double quantity, String key) {
+        addWithIdempotencyKey(productId, quantity, key);
+    }
+
+    /**
+     * B4 — drives the 3-arg addItem. Unlike the plain add step, the save stub here
+     * is STATEFUL: whatever CartService persists becomes what the next findById
+     * returns, so the second delivery sees the cart (and the applied key) exactly
+     * as the first delivery left it — the precondition the replay guard reads.
+     */
+    private void addWithIdempotencyKey(int productId, double quantity, String key) {
+        AddCartItemRequest req = new AddCartItemRequest(
+                productId, "TestProd", "Desc", BigDecimal.TEN, quantity, 20);
+
+        when(cartMapper.toResponse(any(Cart.class))).thenAnswer(inv -> {
+            Cart saved = inv.getArgument(0);
+            List<CartResponse.CartItemResponse> responses = saved.getItems().stream()
+                    .map(i -> new CartResponse.CartItemResponse(i.getProductId(), i.getProductName(),
+                            i.getProductDescription(), i.getUnitPrice(), i.getQuantity(), BigDecimal.TEN,
+                            i.getAvailableQuantity()))
+                    .toList();
+            return new CartResponse(saved.getCartId(), saved.getCustomerId(), responses, BigDecimal.TEN,
+                    saved.getItems().size(), null, null);
+        });
+        when(cartRepository.save(any(Cart.class))).thenAnswer(inv -> {
+            Cart saved = inv.getArgument(0);
+            when(cartRepository.findById(saved.getCartId())).thenReturn(Optional.of(saved));
+            return saved;
+        });
+
+        try {
+            resultCart = cartService.addItem(customerId, req, key);
+        } catch (Exception e) {
+            caughtException = e;
+        }
+    }
+
     @When("I attempt to add product {int} with quantity {double} to the cart")
     public void i_attempt_to_add_product_with_quantity_to_cart(int productId, double quantity) {
         AddCartItemRequest req = new AddCartItemRequest(

--- a/cart-service/src/test/java/code/with/vanilson/cartservice/integration/CartAddItemIdempotencyIntegrationTest.java
+++ b/cart-service/src/test/java/code/with/vanilson/cartservice/integration/CartAddItemIdempotencyIntegrationTest.java
@@ -1,0 +1,179 @@
+package code.with.vanilson.cartservice.integration;
+
+import code.with.vanilson.cartservice.domain.Cart;
+import code.with.vanilson.cartservice.infrastructure.CartRepository;
+import code.with.vanilson.tenantcontext.security.JwtAuthenticationFilter;
+import code.with.vanilson.tenantcontext.security.SecurityPrincipal;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * CartAddItemIdempotencyIntegrationTest — B4 (idempotency as a platform convention)
+ * <p>
+ * Full-context proof that a retried POST /items with the same {@code Idempotency-Key}
+ * does not increment the quantity twice: real security filter chain, real tenant
+ * interceptor, real CartController → CartService → Cart domain logic over HTTP.
+ * <p>
+ * Redis I/O is the ONLY stubbed seam: {@link CartRepository} is replaced by a
+ * map-backed stub because on this host the Lettuce client hangs inside the test
+ * JVM (same reason every integration test in this module mocks it — see
+ * {@link CartPrometheusScrapeIntegrationTest}). The map preserves state across
+ * requests, so the second delivery reads exactly the cart the first delivery
+ * persisted — the precondition the replay guard checks.
+ * JwtAuthenticationFilter is a pass-through mock and the authentication is
+ * injected per-request (same recipe as CartControllerSecurityTest); JWT parsing
+ * is not what this test proves.
+ * </p>
+ */
+@SpringBootTest(properties = {
+        "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration,org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration",
+        "application.security.jwt.secret-key=dGVzdFNlY3JldEtleUZvclRlc3RpbmdPbmx5Tm90Rm9yUHJvZHVjdGlvblVzYWdlMDAwMDAwMDAwMDAwMDAwMA==",
+        "management.health.redis.enabled=false"
+})
+@DisplayName("Cart addItem idempotency — cart-service (integration, B4)")
+class CartAddItemIdempotencyIntegrationTest {
+
+    @Autowired
+    WebApplicationContext context;
+
+    @MockBean
+    CartRepository cartRepository;
+
+    @MockBean
+    JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    private MockMvc mockMvc;
+
+    /** Map standing in for Redis — state survives across requests within a test. */
+    private final Map<String, Cart> redisStore = new ConcurrentHashMap<>();
+
+    private static final String TENANT_HDR = "X-Tenant-ID";
+    private static final String TENANT_VAL = "test-tenant-123";
+    private static final String CUSTOMER   = "42";
+    private static final String CART_KEY   = "cart:" + TENANT_VAL + ":" + CUSTOMER;
+    private static final String BODY =
+            "{\"productId\":1,\"productName\":\"Laptop\",\"productDescription\":\"Gaming\","
+                    + "\"unitPrice\":1200.0,\"quantity\":2.0,\"availableQuantity\":10}";
+
+    @BeforeEach
+    void setUp() throws Exception {
+        mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                .apply(SecurityMockMvcConfigurers.springSecurity())
+                .defaultRequest(get("/").header(TENANT_HDR, TENANT_VAL))
+                .build();
+
+        doAnswer(inv -> {
+            FilterChain chain = inv.getArgument(2);
+            chain.doFilter(inv.<ServletRequest>getArgument(0), inv.<ServletResponse>getArgument(1));
+            return null;
+        }).when(jwtAuthenticationFilter).doFilter(any(), any(), any());
+
+        redisStore.clear();
+        when(cartRepository.findById(anyString()))
+                .thenAnswer(inv -> Optional.ofNullable(redisStore.get(inv.<String>getArgument(0))));
+        when(cartRepository.save(any(Cart.class))).thenAnswer(inv -> {
+            Cart cart = inv.getArgument(0);
+            redisStore.put(cart.getCartId(), cart);
+            return cart;
+        });
+    }
+
+    private static UsernamePasswordAuthenticationToken userAuth() {
+        return new UsernamePasswordAuthenticationToken(
+                new SecurityPrincipal("user@test.com", 42L, TENANT_VAL, "USER"),
+                null,
+                List.of(new SimpleGrantedAuthority("ROLE_USER")));
+    }
+
+    private void postAddItem(String idempotencyKey, double expectedQuantity) throws Exception {
+        var request = post("/api/v1/carts/{customerId}/items", CUSTOMER)
+                .header(TENANT_HDR, TENANT_VAL)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(BODY)
+                .with(authentication(userAuth()));
+        if (idempotencyKey != null) {
+            request = request.header("Idempotency-Key", idempotencyKey);
+        }
+        mockMvc.perform(request)
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.items[0].quantity", is(expectedQuantity)));
+    }
+
+    @Nested
+    @DisplayName("POST /items with Idempotency-Key")
+    class WithIdempotencyKey {
+
+        @Test
+        @DisplayName("retrying the same add with the same key does not double the quantity")
+        void sameKeyTwice_quantityAppliedOnce() throws Exception {
+            postAddItem("idem-int-001", 2.0);
+            // Retry (e.g. after a false 503 on a write that succeeded) — same key
+            postAddItem("idem-int-001", 2.0);
+
+            Cart persisted = redisStore.get(CART_KEY);
+            assertThat(persisted).isNotNull();
+            assertThat(persisted.getItems()).hasSize(1);
+            assertThat(persisted.getItems().get(0).getQuantity())
+                    .as("A replayed Idempotency-Key must not increment the quantity again")
+                    .isEqualTo(2.0);
+            assertThat(persisted.hasIdempotencyKey("idem-int-001")).isTrue();
+        }
+
+        @Test
+        @DisplayName("adds with different keys are two distinct user actions and both apply")
+        void differentKeys_bothApply() throws Exception {
+            postAddItem("idem-int-A", 2.0);
+            postAddItem("idem-int-B", 4.0);
+
+            Cart persisted = redisStore.get(CART_KEY);
+            assertThat(persisted.getItems().get(0).getQuantity()).isEqualTo(4.0);
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /items without Idempotency-Key")
+    class WithoutIdempotencyKey {
+
+        @Test
+        @DisplayName("legacy behaviour preserved — repeated adds merge quantities")
+        void noKey_repeatedAddsMerge() throws Exception {
+            postAddItem(null, 2.0);
+            postAddItem(null, 4.0);
+
+            Cart persisted = redisStore.get(CART_KEY);
+            assertThat(persisted.getItems().get(0).getQuantity()).isEqualTo(4.0);
+        }
+    }
+}

--- a/cart-service/src/test/java/code/with/vanilson/cartservice/presentation/CartControllerSecurityTest.java
+++ b/cart-service/src/test/java/code/with/vanilson/cartservice/presentation/CartControllerSecurityTest.java
@@ -161,7 +161,7 @@ class CartControllerSecurityTest {
         @Test
         @DisplayName("201 when USER adds to own cart")
         void user_adds_to_own_cart() throws Exception {
-            when(cartService.addItem(anyString(), any())).thenReturn(sampleCart("42"));
+            when(cartService.addItem(anyString(), any(), any())).thenReturn(sampleCart("42"));
 
             mockMvc.perform(post(BASE + "/42/items")
                             .header(TENANT_HDR, TENANT_VAL)
@@ -185,7 +185,7 @@ class CartControllerSecurityTest {
         @Test
         @DisplayName("201 when ADMIN adds to any cart")
         void admin_adds_to_any_cart() throws Exception {
-            when(cartService.addItem(anyString(), any())).thenReturn(sampleCart("99"));
+            when(cartService.addItem(anyString(), any(), any())).thenReturn(sampleCart("99"));
 
             mockMvc.perform(post(BASE + "/99/items")
                             .header(TENANT_HDR, TENANT_VAL)

--- a/cart-service/src/test/java/code/with/vanilson/cartservice/presentation/CartControllerTest.java
+++ b/cart-service/src/test/java/code/with/vanilson/cartservice/presentation/CartControllerTest.java
@@ -27,7 +27,10 @@ import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -100,7 +103,8 @@ class CartControllerTest {
         @Test
         @DisplayName("should return 201 when item added")
         void shouldReturn201() throws Exception {
-            when(cartService.addItem(eq("c-01"), any(AddCartItemRequest.class))).thenReturn(cartResponse);
+            when(cartService.addItem(eq("c-01"), any(AddCartItemRequest.class), nullable(String.class)))
+                    .thenReturn(cartResponse);
 
             mockMvc.perform(post("/api/v1/carts/{customerId}/items", "c-01")
                             .header(TENANT_HEADER, TENANT_ID)
@@ -109,6 +113,38 @@ class CartControllerTest {
                     .andExpect(status().isCreated())
                     .andExpect(jsonPath("$.customerId", is("c-01")))
                     .andExpect(jsonPath("$.itemCount", is(1)));
+        }
+
+        @Test
+        @DisplayName("should forward the Idempotency-Key header to the service (B4)")
+        void shouldForwardIdempotencyKeyHeader() throws Exception {
+            when(cartService.addItem(eq("c-01"), any(AddCartItemRequest.class), eq("idem-abc")))
+                    .thenReturn(cartResponse);
+
+            mockMvc.perform(post("/api/v1/carts/{customerId}/items", "c-01")
+                            .header(TENANT_HEADER, TENANT_ID)
+                            .header("Idempotency-Key", "idem-abc")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(validRequest)))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.itemCount", is(1)));
+
+            verify(cartService).addItem(eq("c-01"), any(AddCartItemRequest.class), eq("idem-abc"));
+        }
+
+        @Test
+        @DisplayName("should pass a null key to the service when no Idempotency-Key header is sent")
+        void shouldPassNullKeyWithoutHeader() throws Exception {
+            when(cartService.addItem(eq("c-01"), any(AddCartItemRequest.class), isNull()))
+                    .thenReturn(cartResponse);
+
+            mockMvc.perform(post("/api/v1/carts/{customerId}/items", "c-01")
+                            .header(TENANT_HEADER, TENANT_ID)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(validRequest)))
+                    .andExpect(status().isCreated());
+
+            verify(cartService).addItem(eq("c-01"), any(AddCartItemRequest.class), isNull());
         }
 
         @Test

--- a/cart-service/src/test/resources/features/cart.feature
+++ b/cart-service/src/test/resources/features/cart.feature
@@ -40,3 +40,17 @@ Feature: Cart Management
     When I update product 1 quantity to 5.0
     Then the cart should contain 1 item with product ID 1
     And the total quantity for product 1 should be 5.0
+
+  Scenario: Retrying the same add with an idempotency key does not double the quantity
+    Given the cart for customer "cust-IDEM" is empty
+    When I add product 1 with quantity 2.0 to the cart using idempotency key "key-1"
+    And I add product 1 with quantity 2.0 to the cart again using idempotency key "key-1"
+    Then the cart should contain 1 item with product ID 1
+    And the total quantity for product 1 should be 2.0
+
+  Scenario: Adds with different idempotency keys are applied separately
+    Given the cart for customer "cust-IDEM2" is empty
+    When I add product 1 with quantity 2.0 to the cart using idempotency key "key-1"
+    And I add product 1 with quantity 2.0 to the cart again using idempotency key "key-2"
+    Then the cart should contain 1 item with product ID 1
+    And the total quantity for product 1 should be 4.0

--- a/frontend/src/api/cart.api.ts
+++ b/frontend/src/api/cart.api.ts
@@ -5,8 +5,19 @@ export const cartApi = {
   get: (customerId: string) =>
     apiClient.get<CartResponse>(`/carts/${customerId}`).then((r) => r.data),
 
-  addItem: (customerId: string, data: AddCartItemRequest) =>
-    apiClient.post<CartResponse>(`/carts/${customerId}/items`, data).then((r) => r.data),
+  // idempotencyKey: a stable per-click UUID. addItem is a RELATIVE mutation
+  // (it increments the quantity) and the add-to-cart mutations retry on 503 —
+  // the same false-503-on-a-succeeded-write pattern that once duplicated orders.
+  // Sending the same key on the retry lets cart-service return the current cart
+  // instead of incrementing the quantity again.
+  addItem: (customerId: string, data: AddCartItemRequest, idempotencyKey?: string) =>
+    apiClient
+      .post<CartResponse>(
+        `/carts/${customerId}/items`,
+        data,
+        idempotencyKey ? { headers: { 'Idempotency-Key': idempotencyKey } } : undefined,
+      )
+      .then((r) => r.data),
 
   updateQuantity: (customerId: string, productId: number, quantity: number) =>
     apiClient

--- a/frontend/src/components/product/ProductGrid.tsx
+++ b/frontend/src/components/product/ProductGrid.tsx
@@ -21,15 +21,22 @@ export default function ProductGrid({ products }: ProductGridProps) {
   const prevFailureCount = useRef(0);
 
   const { mutate: addToCart, isPending: isAddingToCart, failureCount } = useMutation({
-    mutationFn: (product: ProductResponse) =>
-      cartApi.addItem(userId!, {
-        productId: product.id,
-        productName: product.name,
-        productDescription: product.description,
-        unitPrice: product.price,
-        quantity: 1,
-        availableQuantity: product.availableQuantity,
-      }),
+    // The idempotency key is generated once per click (in handleAddToCart) and
+    // travels with the mutation variables, so the 503 retry reuses the SAME key
+    // and cart-service applies the add only once.
+    mutationFn: ({ product, idempotencyKey }: { product: ProductResponse; idempotencyKey: string }) =>
+      cartApi.addItem(
+        userId!,
+        {
+          productId: product.id,
+          productName: product.name,
+          productDescription: product.description,
+          unitPrice: product.price,
+          quantity: 1,
+          availableQuantity: product.availableQuantity,
+        },
+        idempotencyKey,
+      ),
     retry: (count, error) => count <= 1 && (error as unknown as AppError).status === 503,
     // Optimistic: confirm to the user the instant they click, not after the
     // server round-trip — the toast must feel immediate (ms, not seconds).
@@ -59,7 +66,7 @@ export default function ProductGrid({ products }: ProductGridProps) {
 
   const handleAddToCart = (product: ProductResponse) => {
     if (!isAuthenticated || !userId) return;
-    addToCart(product);
+    addToCart({ product, idempotencyKey: crypto.randomUUID() });
   };
 
   if (products.length === 0) {

--- a/frontend/src/pages/customer/AccountSettingsPage.tsx
+++ b/frontend/src/pages/customer/AccountSettingsPage.tsx
@@ -7,7 +7,7 @@ import {
 } from '@mui/material';
 import Visibility from '@mui/icons-material/Visibility';
 import VisibilityOff from '@mui/icons-material/VisibilityOff';
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
@@ -61,7 +61,7 @@ export default function AccountSettingsPage() {
     }
   }, [account]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const watchedEmail = identityForm.watch('email');
+  const watchedEmail = useWatch({ control: identityForm.control, name: 'email' });
   const emailChanged = !!account && !!watchedEmail
     && watchedEmail.toLowerCase() !== account.email.toLowerCase();
 

--- a/frontend/src/pages/public/ProductPage.tsx
+++ b/frontend/src/pages/public/ProductPage.tsx
@@ -42,15 +42,22 @@ export default function ProductPage() {
   const prevFailureCount = useRef(0);
 
   const { mutate: addToCart, isPending, failureCount } = useMutation({
-    mutationFn: () =>
-      cartApi.addItem(userId!, {
-        productId: product!.id,
-        productName: product!.name,
-        productDescription: product!.description,
-        unitPrice: product!.price,
-        quantity,
-        availableQuantity: product!.availableQuantity,
-      }),
+    // The idempotency key is generated once per click (at the onClick call site)
+    // and travels with the mutation variables, so the 503 retry reuses the SAME
+    // key and cart-service applies the add only once.
+    mutationFn: (idempotencyKey: string) =>
+      cartApi.addItem(
+        userId!,
+        {
+          productId: product!.id,
+          productName: product!.name,
+          productDescription: product!.description,
+          unitPrice: product!.price,
+          quantity,
+          availableQuantity: product!.availableQuantity,
+        },
+        idempotencyKey,
+      ),
     retry: (count, error) => count <= 1 && (error as unknown as AppError).status === 503,
     // Optimistic: confirm the instant the user clicks, not after the round-trip.
     onMutate: () => {
@@ -223,7 +230,7 @@ export default function ProductPage() {
                   size="large"
                   startIcon={isPending ? <CircularProgress size={16} color="inherit" /> : <ShoppingBag />}
                   disabled={!isAuthenticated || isPending}
-                  onClick={() => addToCart()}
+                  onClick={() => addToCart(crypto.randomUUID())}
                   sx={{ flex: 1 }}
                 >
                   {!isAuthenticated

--- a/product-service/src/main/java/code/with/vanilson/productservice/domain/InventoryReservationRepository.java
+++ b/product-service/src/main/java/code/with/vanilson/productservice/domain/InventoryReservationRepository.java
@@ -7,4 +7,14 @@ import java.util.List;
 public interface InventoryReservationRepository extends JpaRepository<InventoryReservation, Long> {
     List<InventoryReservation> findByCorrelationIdAndStatus(
             String correlationId, InventoryReservation.ReservationStatus status);
+
+    /**
+     * All reservation rows for a saga, regardless of status. Used as the
+     * idempotency record by the reservation consumer: any row for a
+     * correlationId means the order.requested event was already processed
+     * (the rows are written in the same transaction as the stock deduction),
+     * so a redelivered event must not deduct stock again. Served by the
+     * existing (correlation_id, status) index — correlation_id is its prefix.
+     */
+    List<InventoryReservation> findByCorrelationId(String correlationId);
 }

--- a/product-service/src/main/java/code/with/vanilson/productservice/kafka/InventoryReservationConsumer.java
+++ b/product-service/src/main/java/code/with/vanilson/productservice/kafka/InventoryReservationConsumer.java
@@ -4,6 +4,7 @@ import code.with.vanilson.productservice.domain.InventoryReservation;
 import code.with.vanilson.productservice.domain.InventoryReservationRepository;
 import code.with.vanilson.productservice.InventoryReservationService;
 import code.with.vanilson.productservice.Product;
+import code.with.vanilson.productservice.ProductRepository;
 import code.with.vanilson.productservice.exception.ProductPurchaseException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,7 +22,10 @@ import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * InventoryReservationConsumer — Infrastructure Layer (Saga Step 1)
@@ -34,12 +38,21 @@ import java.util.UUID;
  * 3a. SUCCESS → publish inventory.reserved → payment-service processes payment
  * 3b. FAILURE → publish inventory.insufficient → order-service cancels order
  * <p>
- * Idempotency: if the same eventId arrives twice (Kafka at-least-once),
- * the second reservation attempt will fail at the DB lock and the same
- * outcome event is published again — idempotent from order-service's perspective.
+ * Idempotency (B4): the InventoryReservation rows written in the SAME transaction
+ * as the stock deduction double as the processed-event record. On every delivery
+ * the consumer first checks for existing rows for the event's correlationId:
+ * - rows with status RESERVED → a previous delivery already deducted stock but the
+ *   publish/ack may have been lost → re-publish inventory.reserved rebuilt from the
+ *   persisted rows (at-least-once), WITHOUT touching stock again;
+ * - rows all RELEASED → the saga was already compensated (payment.failed) → ack and
+ *   skip; re-publishing inventory.reserved here would re-trigger payment for a dead
+ *   order;
+ * - no rows → first effective delivery → reserve normally. A redelivered event that
+ *   previously failed with insufficient stock leaves no rows, so it reprocesses and
+ *   republishes the same inventory.insufficient outcome — idempotent by outcome.
  * <p>
  * Manual acknowledgement: offset committed only after Kafka publish succeeds.
- * If publish fails → Kafka retries → product-service processes again (idempotent).
+ * If publish fails → Kafka retries → the guard above makes the retry safe.
  * </p>
  *
  * @author vamuhong
@@ -52,6 +65,7 @@ public class InventoryReservationConsumer {
 
     private final InventoryReservationService        inventoryReservationService;
     private final InventoryReservationRepository     reservationRepository;
+    private final ProductRepository                  productRepository;
     private final KafkaTemplate<String, Object>      kafkaTemplate;
     private final MeterRegistry                      meterRegistry;
     private final TransactionTemplate                transactionTemplate;
@@ -75,6 +89,17 @@ public class InventoryReservationConsumer {
 
             log.info("[InventoryConsumer] order.requested received: correlationId=[{}] products=[{}] partition=[{}] offset=[{}]",
                     event.correlationId(), event.products().size(), partition, offset);
+
+            // Idempotency guard (B4): reservation rows are committed in the same TX as
+            // the stock deduction, so any row for this correlationId means a previous
+            // delivery already deducted stock — deducting again would double-reserve.
+            List<InventoryReservation> priorReservations =
+                    reservationRepository.findByCorrelationId(event.correlationId());
+            if (!priorReservations.isEmpty()) {
+                handleDuplicateDelivery(event, priorReservations);
+                ack.acknowledge();
+                return;
+            }
 
             try {
                 // Programmatic TX instead of @Transactional on the listener:
@@ -108,6 +133,62 @@ public class InventoryReservationConsumer {
     }
 
     // -------------------------------------------------------
+
+    /**
+     * Handles a redelivered order.requested whose reservation already committed.
+     * <p>
+     * If the rows are still RESERVED the previous delivery deducted stock but its
+     * publish/ack may have been lost — re-publish inventory.reserved rebuilt from
+     * the persisted rows so the saga can progress (at-least-once; payment-service
+     * deduplicates by orderReference). If every row is already RELEASED the saga
+     * was compensated after a payment failure — publishing inventory.reserved now
+     * would re-trigger payment for a dead order, so the duplicate is only logged.
+     */
+    private void handleDuplicateDelivery(OrderRequestedEvent event,
+                                         List<InventoryReservation> priorReservations) {
+        List<InventoryReservation> stillReserved = priorReservations.stream()
+                .filter(r -> r.getStatus() == InventoryReservation.ReservationStatus.RESERVED)
+                .toList();
+
+        if (stillReserved.isEmpty()) {
+            log.info("[InventoryConsumer] Duplicate order.requested ignored — reservations already RELEASED (saga compensated). correlationId=[{}]",
+                    event.correlationId());
+            meterRegistry.counter("saga.step.duplicate", "step", "inventory", "outcome", "released").increment();
+            return;
+        }
+
+        publishInventoryReserved(event, rebuildReservedItems(stillReserved));
+        log.info("[InventoryConsumer] Duplicate order.requested — stock already reserved, re-published inventory.reserved without deducting again. correlationId=[{}]",
+                event.correlationId());
+        meterRegistry.counter("saga.step.duplicate", "step", "inventory", "outcome", "reserved").increment();
+    }
+
+    /**
+     * Rebuilds the reserved-items payload from persisted reservation rows.
+     * Product name/price come from the current catalog row (same source the
+     * original publish used); quantity comes from the reservation record.
+     */
+    private List<InventoryReservedEvent.ReservedItem> rebuildReservedItems(
+            List<InventoryReservation> reservations) {
+        Map<Integer, Product> productsById = productRepository.findAllById(
+                        reservations.stream().map(InventoryReservation::getProductId).distinct().toList())
+                .stream()
+                .collect(Collectors.toMap(Product::getId, Function.identity()));
+
+        List<InventoryReservedEvent.ReservedItem> items = new ArrayList<>();
+        for (InventoryReservation reservation : reservations) {
+            Product product = productsById.get(reservation.getProductId());
+            if (product == null) {
+                log.warn("[InventoryConsumer] Reserved product no longer in catalog — omitted from re-published event: productId=[{}] correlationId=[{}]",
+                        reservation.getProductId(), reservation.getCorrelationId());
+                continue;
+            }
+            items.add(new InventoryReservedEvent.ReservedItem(
+                    product.getId(), product.getName(),
+                    reservation.getReservedQuantity(), product.getPrice()));
+        }
+        return items;
+    }
 
     /**
      * Reserves stock via the shared InventoryReservationService (pessimistic

--- a/product-service/src/test/java/code/with/vanilson/productservice/bdd/CucumberTestRunner.java
+++ b/product-service/src/test/java/code/with/vanilson/productservice/bdd/CucumberTestRunner.java
@@ -27,6 +27,7 @@ import org.junit.platform.suite.api.Suite;
 @SelectClasspathResource("features/purchase_products.feature")
 @SelectClasspathResource("features/search_products.feature")
 @SelectClasspathResource("features/tenant_isolation.feature")
+@SelectClasspathResource("features/inventory_reservation_idempotency.feature")
 @ConfigurationParameter(key = Constants.GLUE_PROPERTY_NAME,
         value = "code.with.vanilson.productservice.bdd")
 @ConfigurationParameter(key = Constants.PLUGIN_PROPERTY_NAME,

--- a/product-service/src/test/java/code/with/vanilson/productservice/bdd/InventoryIdempotencySteps.java
+++ b/product-service/src/test/java/code/with/vanilson/productservice/bdd/InventoryIdempotencySteps.java
@@ -1,0 +1,239 @@
+package code.with.vanilson.productservice.bdd;
+
+import code.with.vanilson.productservice.InventoryReservationService;
+import code.with.vanilson.productservice.Product;
+import code.with.vanilson.productservice.ProductRepository;
+import code.with.vanilson.productservice.domain.InventoryReservation;
+import code.with.vanilson.productservice.domain.InventoryReservationRepository;
+import code.with.vanilson.productservice.kafka.InventoryReservationConsumer;
+import code.with.vanilson.productservice.kafka.OrderRequestedEvent;
+import io.cucumber.java.Before;
+import io.cucumber.java.en.And;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.mockito.Mockito;
+import org.springframework.context.MessageSource;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * InventoryIdempotencySteps — BDD Step Definitions (B4)
+ * <p>
+ * Implements inventory_reservation_idempotency.feature.
+ * <p>
+ * POJO + Mockito, like the sibling step classes in this glue package (this suite
+ * runs with DefaultObjectFactory, so there is no Spring context here). The product
+ * and reservation repositories are map/list-backed Mockito stubs; the REAL
+ * InventoryReservationConsumer and InventoryReservationService run the actual
+ * guard + fetch/validate/deduct logic, so the scenarios exercise the same
+ * idempotency path as production — just without a broker or database.
+ * </p>
+ */
+public class InventoryIdempotencySteps {
+
+    private static final String CORRELATION_ID = "corr-bdd-idem-001";
+    private static final String TOPIC_RESERVED = "inventory.reserved";
+
+    /** In-memory catalog backing the product repository stub. */
+    private final Map<Integer, Product> store = new LinkedHashMap<>();
+    /** In-memory reservation rows backing the reservation repository stub. */
+    private final List<InventoryReservation> reservationRows = new ArrayList<>();
+
+    private InventoryReservationConsumer consumer;
+    private KafkaTemplate<String, Object> kafkaTemplate;
+    private Acknowledgment acknowledgment;
+    private OrderRequestedEvent lastEvent;
+
+    @Before
+    public void resetState() {
+        // Hooks run for every scenario in the suite (Cucumber hooks are global to
+        // the glue path), so this must stay dependency-free and side-effect safe.
+        store.clear();
+        reservationRows.clear();
+        consumer = null;
+        kafkaTemplate = null;
+        acknowledgment = null;
+        lastEvent = null;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void init() {
+        ProductRepository productRepository = Mockito.mock(ProductRepository.class);
+        InventoryReservationRepository reservationRepository =
+                Mockito.mock(InventoryReservationRepository.class);
+        MessageSource messageSource = Mockito.mock(MessageSource.class);
+        kafkaTemplate = Mockito.mock(KafkaTemplate.class);
+        acknowledgment = Mockito.mock(Acknowledgment.class);
+
+        lenient().when(messageSource.getMessage(any(String.class), any(), any(Locale.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+
+        // Map-backed product repository: reserveStock() fetches with
+        // findAllByIdInOrderById and persists deductions with save(); the duplicate
+        // path rebuilds the outcome event with findAllById.
+        lenient().when(productRepository.findAllByIdInOrderById(any())).thenAnswer(inv -> {
+            List<Integer> ids = inv.getArgument(0);
+            return ids.stream()
+                    .distinct()
+                    .map(store::get)
+                    .filter(Objects::nonNull)
+                    .sorted(Comparator.comparing(Product::getId))
+                    .toList();
+        });
+        lenient().when(productRepository.findAllById(any())).thenAnswer(inv -> {
+            Iterable<Integer> ids = inv.getArgument(0);
+            List<Product> found = new ArrayList<>();
+            for (Integer id : ids) {
+                Product p = store.get(id);
+                if (p != null) {
+                    found.add(p);
+                }
+            }
+            return found;
+        });
+        lenient().when(productRepository.save(any(Product.class))).thenAnswer(inv -> {
+            Product p = inv.getArgument(0);
+            store.put(p.getId(), p);
+            return p;
+        });
+
+        // List-backed reservation repository: the consumer writes rows on first
+        // delivery and reads them back as the idempotency record on redelivery.
+        lenient().when(reservationRepository.findByCorrelationId(any(String.class)))
+                .thenAnswer(inv -> {
+                    String correlationId = inv.getArgument(0);
+                    return reservationRows.stream()
+                            .filter(r -> r.getCorrelationId().equals(correlationId))
+                            .toList();
+                });
+        lenient().when(reservationRepository.save(any(InventoryReservation.class)))
+                .thenAnswer(inv -> {
+                    InventoryReservation r = inv.getArgument(0);
+                    reservationRows.add(r);
+                    return r;
+                });
+
+        // TransactionTemplate over a mocked manager runs the callback inline,
+        // mirroring the production rollback semantics without a real datasource.
+        PlatformTransactionManager transactionManager =
+                Mockito.mock(PlatformTransactionManager.class);
+
+        consumer = new InventoryReservationConsumer(
+                new InventoryReservationService(productRepository, messageSource),
+                reservationRepository, productRepository, kafkaTemplate,
+                new SimpleMeterRegistry(),
+                new TransactionTemplate(transactionManager));
+    }
+
+    // -------------------------------------------------------
+    // Given
+    // -------------------------------------------------------
+
+    @Given("a reservation catalog with product {int} named {string} stocked at {int}")
+    public void aReservationCatalogWithProduct(int productId, String name, int stock) {
+        init();
+        store.put(productId, Product.builder()
+                .id(productId)
+                .name(name)
+                .description(name + " description")
+                .availableQuantity(stock)
+                .price(BigDecimal.valueOf(1200))
+                .build());
+    }
+
+    @And("the order was already compensated with a released reservation of {int} units of product {int}")
+    public void theOrderWasAlreadyCompensated(int quantity, int productId) {
+        reservationRows.add(InventoryReservation.builder()
+                .correlationId(CORRELATION_ID)
+                .productId(productId)
+                .reservedQuantity(quantity)
+                .status(InventoryReservation.ReservationStatus.RELEASED)
+                .createdAt(LocalDateTime.now())
+                .releasedAt(LocalDateTime.now())
+                .build());
+    }
+
+    // -------------------------------------------------------
+    // When
+    // -------------------------------------------------------
+
+    @When("an order requested event for product {int} with quantity {int} is delivered")
+    public void anOrderRequestedEventIsDelivered(int productId, int quantity) {
+        lastEvent = new OrderRequestedEvent(
+                "evt-bdd-001",
+                CORRELATION_ID,
+                "cust-001",
+                "ana@example.com",
+                "Ana",
+                "Silva",
+                List.of(new OrderRequestedEvent.ProductPurchaseItem(productId, quantity)),
+                BigDecimal.valueOf(3600),
+                "CREDIT_CARD",
+                "ORD-BDD-001",
+                "default",
+                42,
+                Instant.now(),
+                1
+        );
+        consumer.onOrderRequested(lastEvent, 0, 0L, acknowledgment);
+    }
+
+    @And("the same order requested event is delivered again")
+    public void theSameEventIsDeliveredAgain() {
+        consumer.onOrderRequested(lastEvent, 0, 1L, acknowledgment);
+    }
+
+    // -------------------------------------------------------
+    // Then
+    // -------------------------------------------------------
+
+    @Then("the reserved stock for product {int} should be {int}")
+    public void theReservedStockShouldBe(int productId, int expectedStock) {
+        Product product = store.get(productId);
+        assertThat(product)
+                .as("Product " + productId + " should exist in the catalog")
+                .isNotNull();
+        assertThat(product.getAvailableQuantity())
+                .as("Available stock for product " + productId)
+                .isEqualTo(expectedStock);
+    }
+
+    @And("only one reservation record should exist for the order")
+    public void onlyOneReservationRecordShouldExist() {
+        List<InventoryReservation> rows = reservationRows.stream()
+                .filter(r -> r.getCorrelationId().equals(CORRELATION_ID))
+                .toList();
+        assertThat(rows)
+                .as("A duplicate delivery must not add a second reservation row")
+                .hasSize(1);
+    }
+
+    @And("the inventory reserved event should have been published {int} times")
+    public void theInventoryReservedEventShouldHaveBeenPublished(int expectedTimes) {
+        verify(kafkaTemplate, times(expectedTimes))
+                .send(eq(TOPIC_RESERVED), eq(CORRELATION_ID), any());
+    }
+}

--- a/product-service/src/test/java/code/with/vanilson/productservice/integration/InventoryReservationIdempotencyIntegrationTest.java
+++ b/product-service/src/test/java/code/with/vanilson/productservice/integration/InventoryReservationIdempotencyIntegrationTest.java
@@ -1,0 +1,205 @@
+package code.with.vanilson.productservice.integration;
+
+import code.with.vanilson.productservice.Product;
+import code.with.vanilson.productservice.ProductRepository;
+import code.with.vanilson.productservice.domain.InventoryReservation;
+import code.with.vanilson.productservice.domain.InventoryReservationRepository;
+import code.with.vanilson.productservice.kafka.OrderRequestedEvent;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * InventoryReservationIdempotencyIntegrationTest — B4 (idempotency as a platform convention)
+ * <p>
+ * Proves that a redelivered order.requested event (Kafka at-least-once) does NOT
+ * deduct stock a second time: the InventoryReservation rows committed in the same
+ * transaction as the deduction act as the processed-event record, and the consumer
+ * skips the reservation core when rows for the correlationId already exist.
+ * <p>
+ * Recipe (same as {@link InventoryCompensationIntegrationTest}):
+ * - Real PostgreSQL via Testcontainers (never H2) — the {@code test} profile declares
+ *   the PostgreSQL driver but no JDBC url, so the datasource comes from the container.
+ * - EmbeddedKafka for the real listener path (broker index preallocation capped).
+ * - Redis mocked: the L2 cache is not what this test proves, and on this host the
+ *   Lettuce client hangs inside the test JVM.
+ * - Products seeded without category: the consumer flow never touches ProductMapper,
+ *   which is the only place that requires a category.
+ * </p>
+ */
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        properties = {
+                "spring.cloud.config.enabled=false",
+                "spring.cloud.config.import-check.enabled=false",
+                "spring.config.import=optional:configserver:",
+                "spring.kafka.bootstrap-servers=${spring.embedded.kafka.brokers}",
+                "spring.kafka.consumer.group-id=test-inventory-idempotency",
+                "application.security.jwt.secret-key=404E635266556A586E3272357538782F413F4428472B4B6250645367566B5970",
+                "management.health.redis.enabled=false",
+                "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.data.redis.RedisReactiveAutoConfiguration"
+        })
+@Testcontainers
+@EmbeddedKafka(
+        partitions = 1,
+        brokerProperties = {
+                "auto.create.topics.enable=true",
+                "log.retention.hours=1",
+                // Cap internal-topic index preallocation — without these the embedded
+                // broker preallocates ~2.3 GB of index files per run in %TEMP%.
+                "offsets.topic.num.partitions=1",
+                "transaction.state.log.num.partitions=1",
+                "transaction.state.log.replication.factor=1",
+                "transaction.state.log.min.isr=1",
+                "log.index.size.max.bytes=1048576"
+        })
+@ActiveProfiles("test")
+@DisplayName("Inventory Reservation Idempotency Integration Tests (B4)")
+class InventoryReservationIdempotencyIntegrationTest {
+
+    @Container
+    static PostgreSQLContainer<?> postgres =
+            new PostgreSQLContainer<>("postgres:16-alpine")
+                    .withDatabaseName("product_inventory_idempotency_test")
+                    .withUsername("test")
+                    .withPassword("test");
+
+    @DynamicPropertySource
+    static void configureContainers(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url",      postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+    }
+
+    @MockBean StringRedisTemplate stringRedisTemplate;
+    @MockBean RedisConnectionFactory redisConnectionFactory;
+
+    @Autowired ProductRepository productRepository;
+    @Autowired InventoryReservationRepository reservationRepository;
+    @Autowired KafkaTemplate<String, Object> kafkaTemplate;
+
+    private Product laptop;
+
+    @BeforeEach
+    void setUp() {
+        reservationRepository.deleteAll();
+        productRepository.deleteAll();
+
+        // Ids are sequence-generated: assigning them by hand makes Spring Data treat the
+        // entity as detached and merge it under a *different* id, so every findById(1) misses.
+        // tenant_id / created_by are NOT NULL since the Phase 4 tenant + RBAC migrations.
+        laptop = productRepository.save(Product.builder()
+                .name("Laptop")
+                .description("Gaming Laptop")
+                .availableQuantity(10.0)
+                .price(BigDecimal.valueOf(1200))
+                .tenantId("default")
+                .createdBy("system")
+                .build());
+    }
+
+    @AfterEach
+    void tearDown() {
+        reservationRepository.deleteAll();
+        productRepository.deleteAll();
+    }
+
+    private OrderRequestedEvent orderRequested(String correlationId, double quantity) {
+        return new OrderRequestedEvent(
+                "evt-" + correlationId,
+                correlationId,
+                "cust-001",
+                "ana@example.com",
+                "Ana",
+                "Silva",
+                List.of(new OrderRequestedEvent.ProductPurchaseItem(laptop.getId(), quantity)),
+                BigDecimal.valueOf(3600),
+                "CREDIT_CARD",
+                "ORD-" + correlationId,
+                "default",
+                42,
+                Instant.now(),
+                1
+        );
+    }
+
+    @Nested
+    @DisplayName("Duplicate order.requested delivery")
+    class DuplicateDelivery {
+
+        @Test
+        @DisplayName("should deduct stock exactly once when the same event is delivered twice")
+        void shouldDeductStockOnceOnDuplicateDelivery() throws Exception {
+            String correlationId = "corr-idem-res-001";
+            OrderRequestedEvent event = orderRequested(correlationId, 3.0);
+
+            kafkaTemplate.send("order.requested", correlationId, event);
+            Thread.sleep(2000);
+            kafkaTemplate.send("order.requested", correlationId, event);
+            Thread.sleep(2000);
+
+            // Stock deducted once: 10 - 3 = 7, NOT 4
+            Product after = productRepository.findById(laptop.getId()).orElseThrow();
+            assertThat(after.getAvailableQuantity())
+                    .as("A redelivered order.requested must not deduct stock a second time")
+                    .isEqualTo(7.0);
+
+            // Exactly one reservation row — the duplicate must not add another
+            List<InventoryReservation> rows = reservationRepository.findByCorrelationId(correlationId);
+            assertThat(rows).hasSize(1);
+            assertThat(rows.get(0).getStatus()).isEqualTo(InventoryReservation.ReservationStatus.RESERVED);
+            assertThat(rows.get(0).getReservedQuantity()).isEqualTo(3);
+        }
+
+        @Test
+        @DisplayName("should not re-reserve when the saga was already compensated (rows RELEASED)")
+        void shouldNotReReserveAfterCompensation() throws Exception {
+            String correlationId = "corr-idem-res-002";
+
+            // Simulate a saga that reserved and was then compensated: the row is
+            // RELEASED and the stock is back at its full level.
+            reservationRepository.save(InventoryReservation.builder()
+                    .correlationId(correlationId)
+                    .productId(laptop.getId())
+                    .reservedQuantity(3)
+                    .status(InventoryReservation.ReservationStatus.RELEASED)
+                    .createdAt(LocalDateTime.now())
+                    .releasedAt(LocalDateTime.now())
+                    .build());
+
+            kafkaTemplate.send("order.requested", correlationId, orderRequested(correlationId, 3.0));
+            Thread.sleep(2000);
+
+            // Stock untouched — the dead saga must not reserve again
+            Product after = productRepository.findById(laptop.getId()).orElseThrow();
+            assertThat(after.getAvailableQuantity()).isEqualTo(10.0);
+
+            // Still exactly one row, still RELEASED
+            List<InventoryReservation> rows = reservationRepository.findByCorrelationId(correlationId);
+            assertThat(rows).hasSize(1);
+            assertThat(rows.get(0).getStatus()).isEqualTo(InventoryReservation.ReservationStatus.RELEASED);
+        }
+    }
+}

--- a/product-service/src/test/java/code/with/vanilson/productservice/kafka/InventoryReservationConsumerTest.java
+++ b/product-service/src/test/java/code/with/vanilson/productservice/kafka/InventoryReservationConsumerTest.java
@@ -85,13 +85,18 @@ class InventoryReservationConsumerTest {
         lenient().when(meterRegistry.counter(anyString(), any(String[].class)))
                 .thenReturn(org.mockito.Mockito.mock(io.micrometer.core.instrument.Counter.class));
 
+        // B4 idempotency guard runs first on every delivery — default to "no prior
+        // reservations" so the pre-existing scenarios exercise the first-delivery path.
+        lenient().when(reservationRepository.findByCorrelationId(anyString()))
+                .thenReturn(List.of());
+
         // Real shared reservation core wired over the mocked repository — the
         // consumer test exercises the actual fetch/validate/deduct logic.
         // TransactionTemplate over a mocked manager: runs the callback inline
         // and rethrows on failure, mirroring the production rollback semantics.
         consumer = new InventoryReservationConsumer(
                 new InventoryReservationService(productRepository, messageSource),
-                reservationRepository, kafkaTemplate, meterRegistry,
+                reservationRepository, productRepository, kafkaTemplate, meterRegistry,
                 new org.springframework.transaction.support.TransactionTemplate(transactionManager));
 
         Category category = Category.builder().id(1).name("Electronics").description("Electronic items").build();
@@ -285,6 +290,97 @@ class InventoryReservationConsumerTest {
             consumer.onOrderRequested(overRequest, 0, 0L, acknowledgment);
 
             // Offset must still be acknowledged — DLQ handles retries, not requeue
+            verify(acknowledgment, times(1)).acknowledge();
+        }
+    }
+
+    // -------------------------------------------------------
+    // Idempotency guard (B4) — duplicate delivery
+    // -------------------------------------------------------
+
+    @Nested
+    @DisplayName("onOrderRequested — duplicate delivery (B4 idempotency guard)")
+    class DuplicateDelivery {
+
+        private InventoryReservation reservedRow() {
+            return InventoryReservation.builder()
+                    .id(1L)
+                    .correlationId(CORRELATION_ID)
+                    .productId(1)
+                    .reservedQuantity(3)
+                    .status(InventoryReservation.ReservationStatus.RESERVED)
+                    .build();
+        }
+
+        private InventoryReservation releasedRow() {
+            return InventoryReservation.builder()
+                    .id(2L)
+                    .correlationId(CORRELATION_ID)
+                    .productId(1)
+                    .reservedQuantity(3)
+                    .status(InventoryReservation.ReservationStatus.RELEASED)
+                    .build();
+        }
+
+        @Test
+        @DisplayName("should NOT deduct stock again when the same correlationId was already reserved")
+        void shouldNotDeductStockOnDuplicateDelivery() {
+            when(reservationRepository.findByCorrelationId(CORRELATION_ID))
+                    .thenReturn(List.of(reservedRow()));
+            when(productRepository.findAllById(List.of(1))).thenReturn(List.of(laptop));
+
+            consumer.onOrderRequested(validEvent, 0, 1L, acknowledgment);
+
+            // The reservation core must never run: no locked fetch, no stock save,
+            // no second reservation row.
+            verify(productRepository, times(0)).findAllByIdInOrderById(any());
+            verify(productRepository, times(0)).save(any());
+            verify(reservationRepository, times(0)).save(any());
+        }
+
+        @Test
+        @DisplayName("should re-publish inventory.reserved rebuilt from the persisted rows on duplicate")
+        void shouldRepublishReservedOnDuplicate() {
+            when(reservationRepository.findByCorrelationId(CORRELATION_ID))
+                    .thenReturn(List.of(reservedRow()));
+            when(productRepository.findAllById(List.of(1))).thenReturn(List.of(laptop));
+
+            consumer.onOrderRequested(validEvent, 0, 1L, acknowledgment);
+
+            ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+            verify(kafkaTemplate).send(eq(TOPIC_RESERVED), eq(CORRELATION_ID), captor.capture());
+            InventoryReservedEvent republished = (InventoryReservedEvent) captor.getValue();
+            assertThat(republished.correlationId()).isEqualTo(CORRELATION_ID);
+            assertThat(republished.reservedItems()).hasSize(1);
+            assertThat(republished.reservedItems().get(0).productId()).isEqualTo(1);
+            // Quantity must come from the persisted reservation row, not the event
+            assertThat(republished.reservedItems().get(0).quantity()).isEqualTo(3.0);
+            verify(acknowledgment, times(1)).acknowledge();
+        }
+
+        @Test
+        @DisplayName("should NOT re-publish inventory.reserved when reservations were already RELEASED (saga compensated)")
+        void shouldNotRepublishWhenAlreadyReleased() {
+            when(reservationRepository.findByCorrelationId(CORRELATION_ID))
+                    .thenReturn(List.of(releasedRow()));
+
+            consumer.onOrderRequested(validEvent, 0, 1L, acknowledgment);
+
+            // Re-publishing inventory.reserved would re-trigger payment for a dead order
+            verify(kafkaTemplate, times(0)).send(anyString(), anyString(), any());
+            verify(productRepository, times(0)).save(any());
+            verify(acknowledgment, times(1)).acknowledge();
+        }
+
+        @Test
+        @DisplayName("should still acknowledge the duplicate offset so it is not redelivered forever")
+        void shouldAcknowledgeDuplicateOffset() {
+            when(reservationRepository.findByCorrelationId(CORRELATION_ID))
+                    .thenReturn(List.of(reservedRow()));
+            when(productRepository.findAllById(List.of(1))).thenReturn(List.of(laptop));
+
+            consumer.onOrderRequested(validEvent, 0, 1L, acknowledgment);
+
             verify(acknowledgment, times(1)).acknowledge();
         }
     }

--- a/product-service/src/test/resources/features/inventory_reservation_idempotency.feature
+++ b/product-service/src/test/resources/features/inventory_reservation_idempotency.feature
@@ -1,0 +1,26 @@
+Feature: Inventory reservation idempotency
+  As the order saga
+  I want redelivered order.requested events to reserve stock only once
+  So that duplicate Kafka deliveries never double-deduct inventory
+
+  Scenario: A redelivered reservation event does not deduct stock twice
+    Given a reservation catalog with product 1 named "Laptop" stocked at 10
+    When an order requested event for product 1 with quantity 3 is delivered
+    And the same order requested event is delivered again
+    Then the reserved stock for product 1 should be 7
+    And only one reservation record should exist for the order
+    And the inventory reserved event should have been published 2 times
+
+  Scenario: A duplicate delivery after saga compensation is ignored
+    Given a reservation catalog with product 1 named "Laptop" stocked at 10
+    And the order was already compensated with a released reservation of 3 units of product 1
+    When an order requested event for product 1 with quantity 3 is delivered
+    Then the reserved stock for product 1 should be 10
+    And the inventory reserved event should have been published 0 times
+
+  Scenario: First delivery reserves stock and records the reservation
+    Given a reservation catalog with product 1 named "Laptop" stocked at 10
+    When an order requested event for product 1 with quantity 4 is delivered
+    Then the reserved stock for product 1 should be 6
+    And only one reservation record should exist for the order
+    And the inventory reserved event should have been published 1 times


### PR DESCRIPTION
# Session Report — 2026-07-10 · branch `hotfix/backend-frontend-03`

## Features Implemented

**B4 — Idempotency as a platform convention** (fully written, awaiting user's test run + rebuild).

Three interconnected idempotency guards in product-service (stock reservation), cart-service (addItem), and frontend (per-click UUID):

1. **product-service** — InventoryReservation rows as processed-event record; redelivered `order.requested` re-publishes `inventory.reserved` from persisted rows instead of deducting stock again.
2. **cart-service** — `Idempotency-Key` header on POST /items; replayed keys return current cart without incrementing (bounded FIFO on cart hash, expires with TTL/clear).
3. **frontend** — per-click `crypto.randomUUID()` sent on add-to-cart; 503 retry reuses the same key (mirrors checkout).

## Step-by-Step Execution

| Step | Component | Root Cause | Implementation |
|------|-----------|-----------|---|
| 1 | product-service | `InventoryReservationConsumer` javadoc falsely claimed idempotency; pessimistic lock only serializes, never deduplicates | Added idempotency guard: `findByCorrelationId` → prior rows RESERVED (re-publish) / RELEASED (ignore) / absent (normal). No migration (index exists). Consumer constructor +`ProductRepository` |
| 2 | cart-service | `addItem` is RELATIVE mutation (increments qty); retry duplicates. SPA mutations retry on 503 (false-503 pattern from past duplicated orders) | 3-arg `addItem(customerId, request, idempotencyKey)` with `Cart.appliedIdempotencyKeys` (FIFO cap 50, on cart hash). 2-arg overload kept for backwards compat |
| 3 | cart-service controller | Missing header binding | `CartController.addItem` accepts optional `Idempotency-Key` header → service |
| 4 | frontend | No idempotency key on add-to-cart mutations | `ProductGrid` / `ProductPage` generate `crypto.randomUUID()` **outside** mutationFn (so retry reuses same key). `cartApi.addItem` sends header |
| 5 | unit tests | Pre-existing Consumer constructor stubs incomplete; CartService idempotency untested | Consumer `DuplicateDelivery` ×4; `CartServiceTest.AddItemIdempotency` ×5; Controller stubs in both `CartControllerTest` and `CartControllerSecurityTest` migrated to 3-arg |
| 6 | controller slice tests | Stub signature changed but tests not updated | `CartControllerTest` + new header tests; no new product slice (Kafka consumer, no HTTP surface) |
| 7 | integration tests | No proof of idempotency end-to-end | `InventoryReservationIdempotencyIntegrationTest` (Testcontainers PG+EmbeddedKafka, event sent 2× → deducted 1×; post-compensation ignored); `CartAddItemIdempotencyIntegrationTest` (real security + tenant interceptor, map-backed Redis) |
| 8 | BDD | No feature coverage for idempotency | `inventory_reservation_idempotency.feature` ×3 (POJO steps, registered on runner); `cart.feature` +2 (stateful save stub) |
| 9 | documentation | No record of B4 implementation | backlog updated (tradeoffs documented), CLAUDE.md idempotency section, memory file created |

## Mapping to SKILL Phases

**Preparation** (understanding the problem):
- Read B3 Phase 1b proof state (user confirmed `mvn verify` green + product rebuilt)
- Traced root causes: InventoryReservationConsumer javadoc vs. reality, cart retry + false-503 pattern
- Examined existing idempotency in order-service (Idempotency-Key → correlationId)

**Implementation** (code + 4 test layers):
- product: guard logic + Consumer constructor update + repository method + new tests
- cart: domain field + service overload + controller header binding + new tests
- frontend: mutations refactored to generate UUID outside callback, header sent
- Tests: 4 layers (unit ×9, slice ×2 modules, integration ×2, BDD ×5 scenarios) — all written, not run

**Verification**:
- `mvn test-compile -pl product-service,cart-service` clean
- `npm run build` + `lint` green
- All 20 modified files + 4 new files accounted for
- git diff reviewed (read-only)

## Files Created/Modified This Session

**Modified (20):**
- `product-service/src/main/java/.../domain/InventoryReservationRepository.java` — new `findByCorrelationId`
- `product-service/src/main/java/.../kafka/InventoryReservationConsumer.java` — guard logic + helpers + javadoc + constructor
- `product-service/src/test/java/.../kafka/InventoryReservationConsumerTest.java` — constructor update + DuplicateDelivery ×4
- `product-service/src/test/java/.../bdd/CucumberTestRunner.java` — feature registration
- `cart-service/src/main/java/.../domain/Cart.java` — appliedIdempotencyKeys + hasIdempotencyKey/recordIdempotencyKey
- `cart-service/src/main/java/.../application/CartService.java` — 3-arg overload + replay guard
- `cart-service/src/main/java/.../presentation/CartController.java` — header binding + javadoc
- `cart-service/src/main/resources/messages.properties` — new log key
- `cart-service/src/test/java/.../CartServiceTest.java` — AddItemIdempotency ×5
- `cart-service/src/test/java/.../presentation/CartControllerTest.java` — stubs migrated to 3-arg + header tests
- `cart-service/src/test/java/.../presentation/CartControllerSecurityTest.java` — stubs migrated to 3-arg
- `cart-service/src/test/java/.../bdd/CartStepDefinitions.java` — idempotent step definitions
- `cart-service/src/test/resources/features/cart.feature` — +2 scenarios
- `frontend/src/api/cart.api.ts` — optional key parameter + header
- `frontend/src/components/product/ProductGrid.tsx` — per-click UUID + refactored mutation
- `frontend/src/pages/public/ProductPage.tsx` — per-click UUID + refactored mutation
- `CLAUDE.md` — idempotency section updated
- `.claude/docs/IMPROVEMENT_BACKLOG.md` — B4 section expanded + state table updated

**Created (4):**
- `product-service/src/test/java/.../integration/InventoryReservationIdempotencyIntegrationTest.java`
- `product-service/src/test/java/.../bdd/InventoryIdempotencySteps.java`
- `product-service/src/test/resources/features/inventory_reservation_idempotency.feature`
- `cart-service/src/test/java/.../integration/CartAddItemIdempotencyIntegrationTest.java`

**Memory (1):**
- `.claude/projects/.../memory/project_b4_idempotency_platform.md` — full session record + tradeoffs

## Current State

✅ **Code complete** — 4 test layers written, test-compile green on both modules.
✅ **Frontend built** — `npm run build` + `eslint` green (1 pre-existing warning in untouched file).
✅ **Documentation** — backlog + CLAUDE.md + memory updated; no Flyway migration needed.
❌ **Tests not executed** — by design (user runs them).
❌ **Not live** — awaiting your `mvn verify -pl product-service,cart-service` + container rebuild.

## Next Steps (for user)

1. **Test phase** — `mvn verify -pl product-service,cart-service` (will run all 4 layers for the first time).
2. **Container rebuild** — product-service only (no migration; code change to `InventoryReservationConsumer`).
3. **Live proof** — retry an add-to-cart click (browser devtools network) or redeliver an order event (Kafka tool) and confirm `Duplicate... ignored` / `re-published` log lines.
4. **Success criteria** — stock deducted exactly once per correlationId; cart quantity never doubled on key replay.