### PR TITLE
feat: F2 is fixed. Both defects shared one root cause

### DIFF
--- a/authentication-service/src/main/java/code/with/vanilson/authentication/application/AccountResponse.java
+++ b/authentication-service/src/main/java/code/with/vanilson/authentication/application/AccountResponse.java
@@ -1,20 +1,28 @@
 package code.with.vanilson.authentication.application;
 
 import code.with.vanilson.authentication.domain.User;
+import com.fasterxml.jackson.annotation.JsonInclude;
 
 import java.time.LocalDateTime;
 
 /** AccountResponse — the authenticated user's own identity view (never another user's). */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record AccountResponse(
         Long id,
         String firstname,
         String lastname,
         String email,
         String role,
-        LocalDateTime createdAt
+        LocalDateTime createdAt,
+        // Live seller-approval status straight from the DB (null for non-sellers). The SPA polls
+        // this endpoint while a seller is PENDING_APPROVAL so approval/suspension are reflected
+        // without a re-login: on a change it silently refreshes the token (which re-reads this
+        // same status) and unlocks or locks the UI accordingly.
+        String sellerStatus
 ) {
     public static AccountResponse from(User user) {
         return new AccountResponse(user.getId(), user.getFirstname(), user.getLastname(),
-                user.getEmail(), user.getRole().name(), user.getCreatedAt());
+                user.getEmail(), user.getRole().name(), user.getCreatedAt(),
+                user.getSellerStatus() != null ? user.getSellerStatus().name() : null);
     }
 }

--- a/authentication-service/src/test/java/code/with/vanilson/authentication/application/AccountServiceTest.java
+++ b/authentication-service/src/test/java/code/with/vanilson/authentication/application/AccountServiceTest.java
@@ -1,6 +1,7 @@
 package code.with.vanilson.authentication.application;
 
 import code.with.vanilson.authentication.domain.Role;
+import code.with.vanilson.authentication.domain.SellerStatus;
 import code.with.vanilson.authentication.domain.User;
 import code.with.vanilson.authentication.exception.InvalidAccountPasswordException;
 import code.with.vanilson.authentication.exception.UserAlreadyExistsException;
@@ -67,6 +68,27 @@ class AccountServiceTest {
             assertThat(res.id()).isEqualTo(7L);
             assertThat(res.email()).isEqualTo("ana@x.com");
             assertThat(res.role()).isEqualTo("USER");
+        }
+
+        @Test
+        @DisplayName("leaves sellerStatus null for a non-seller account")
+        void non_seller_has_null_seller_status() {
+            when(userRepository.findById(7L)).thenReturn(Optional.of(user));
+            assertThat(service.getAccount(7L).sellerStatus()).isNull();
+        }
+
+        @Test
+        @DisplayName("exposes the live sellerStatus for a seller (drives the SPA poll → no re-login)")
+        void seller_status_is_mapped_from_the_entity() {
+            User seller = User.builder()
+                    .id(8L).firstname("Sam").lastname("Seller")
+                    .email("seller@x.com").password("$2a$10$hash")
+                    .role(Role.SELLER).tenantId("default")
+                    .sellerStatus(SellerStatus.PENDING_APPROVAL)
+                    .accountEnabled(true).accountLocked(false)
+                    .build();
+            when(userRepository.findById(8L)).thenReturn(Optional.of(seller));
+            assertThat(service.getAccount(8L).sellerStatus()).isEqualTo("PENDING_APPROVAL");
         }
     }
 

--- a/authentication-service/src/test/java/code/with/vanilson/authentication/bdd/steps/AccountStepDefinitions.java
+++ b/authentication-service/src/test/java/code/with/vanilson/authentication/bdd/steps/AccountStepDefinitions.java
@@ -64,6 +64,14 @@ public class AccountStepDefinitions {
                 .post(BASE + "/login").then().extract().response();
     }
 
+    private Response registerSeller(String email, String password) {
+        return given().contentType(ContentType.JSON)
+                .body(String.format(
+                        "{\"firstname\":\"Sell\",\"lastname\":\"Bdd\",\"role\":\"SELLER\","
+                        + "\"email\":\"%s\",\"password\":\"%s\"}", email, password))
+                .post(BASE + "/register").then().extract().response();
+    }
+
     // ------------------------------------------------------------------
 
     @Given("a registered user {string} with password {string}")
@@ -71,6 +79,32 @@ public class AccountStepDefinitions {
         Response r = register(uniqueEmail(emailSeed), password);
         assertThat(r.statusCode()).isEqualTo(201);
         accessToken = r.jsonPath().getString("accessToken");
+    }
+
+    @Given("a self-registered seller {string} with password {string}")
+    public void aSelfRegisteredSeller(String emailSeed, String password) {
+        Response r = registerSeller(uniqueEmail(emailSeed), password);
+        assertThat(r.statusCode()).isEqualTo(201);
+        accessToken = r.jsonPath().getString("accessToken");
+    }
+
+    @When("the seller fetches their account")
+    public void fetchesAccount() {
+        lastResponse = given()
+                .header("Authorization", "Bearer " + accessToken)
+                .get(BASE + "/account/me").then().extract().response();
+    }
+
+    @Then("the account view shows sellerStatus {string}")
+    public void accountShowsSellerStatus(String expected) {
+        assertThat(lastResponse.statusCode()).isEqualTo(200);
+        assertThat(lastResponse.jsonPath().getString("sellerStatus")).isEqualTo(expected);
+    }
+
+    @Then("the account view omits sellerStatus")
+    public void accountOmitsSellerStatus() {
+        assertThat(lastResponse.statusCode()).isEqualTo(200);
+        assertThat(lastResponse.jsonPath().getString("sellerStatus")).isNull();
     }
 
     @When("the user updates their name to {string} {string}")

--- a/authentication-service/src/test/java/code/with/vanilson/authentication/controller/AccountControllerTest.java
+++ b/authentication-service/src/test/java/code/with/vanilson/authentication/controller/AccountControllerTest.java
@@ -91,7 +91,7 @@ class AccountControllerTest {
 
     private AccountResponse account() {
         return new AccountResponse(7L, "Ana", "Silva", "ana@x.com", "USER",
-                LocalDateTime.of(2026, 1, 1, 0, 0));
+                LocalDateTime.of(2026, 1, 1, 0, 0), null);
     }
 
     @Nested @DisplayName("GET /me")
@@ -103,6 +103,27 @@ class AccountControllerTest {
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.email", is("ana@x.com")))
                     .andExpect(jsonPath("$.role", is("USER")));
+        }
+
+        @Test
+        @DisplayName("omits sellerStatus entirely for a non-seller (NON_NULL)")
+        void non_seller_omits_seller_status() throws Exception {
+            when(service.getAccount(7L)).thenReturn(account());
+            mockMvc.perform(get(BASE + "/me").with(user(userPrincipal)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.sellerStatus").doesNotExist());
+        }
+
+        @Test
+        @DisplayName("exposes the live sellerStatus for a seller so the SPA can poll it")
+        void seller_status_is_returned() throws Exception {
+            when(service.getAccount(8L)).thenReturn(new AccountResponse(
+                    8L, "Sam", "Seller", "seller@x.com", "SELLER",
+                    LocalDateTime.of(2026, 1, 1, 0, 0), "APPROVED"));
+            mockMvc.perform(get(BASE + "/me").with(user(sellerPrincipal)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.role", is("SELLER")))
+                    .andExpect(jsonPath("$.sellerStatus", is("APPROVED")));
         }
 
         @Test
@@ -131,7 +152,7 @@ class AccountControllerTest {
             when(service.updateAccount(eq(7L), any(UpdateAccountRequest.class)))
                     .thenReturn(new AccountUpdateResponse(
                             new AccountResponse(7L, "Ana", "Silva", "new@x.com", "USER",
-                                    LocalDateTime.of(2026, 1, 1, 0, 0)), tokens));
+                                    LocalDateTime.of(2026, 1, 1, 0, 0), null), tokens));
             mockMvc.perform(patch(BASE + "/me").with(user(userPrincipal))
                             .contentType(MediaType.APPLICATION_JSON)
                             .content("{\"firstname\":\"Ana\",\"lastname\":\"Silva\","

--- a/authentication-service/src/test/java/code/with/vanilson/authentication/integration/AdminUserManagementIntegrationTest.java
+++ b/authentication-service/src/test/java/code/with/vanilson/authentication/integration/AdminUserManagementIntegrationTest.java
@@ -23,6 +23,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -490,6 +491,59 @@ class AdminUserManagementIntegrationTest {
             mockMvc.perform(post(BASE + "/login")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(json("email", email, "password", "SellerPass1!")))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.sellerStatus", is("APPROVED")));
+        }
+
+        @Test
+        @DisplayName("approval takes effect WITHOUT a re-login: /me reflects APPROVED and the "
+                + "existing refresh token rotates to an APPROVED token pair")
+        void approvalReflectedWithoutRelogin() throws Exception {
+            String email = uniqueEmail();
+
+            MvcResult registered = mockMvc.perform(post(BASE + "/register")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(json("firstname", "Pending", "lastname", "Seller",
+                                    "email", email, "password", "SellerPass1!",
+                                    "role", "SELLER")))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.sellerStatus", is("PENDING_APPROVAL")))
+                    .andReturn();
+            long sellerId = bodyOf(registered).get("userId").asLong();
+
+            // The seller signs in ONCE while still pending — this is the session that must
+            // survive approval without a logout/login round-trip.
+            MvcResult login = mockMvc.perform(post(BASE + "/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(json("email", email, "password", "SellerPass1!")))
+                    .andExpect(status().isOk())
+                    .andReturn();
+            String pendingAccess = bodyOf(login).get("accessToken").asText();
+            String refreshToken  = bodyOf(login).get("refreshToken").asText();
+
+            // /me with the pre-approval token shows PENDING (the SPA polls this).
+            mockMvc.perform(get(BASE + "/account/me")
+                            .header("Authorization", "Bearer " + pendingAccess))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.sellerStatus", is("PENDING_APPROVAL")));
+
+            // Admin approves — no token revocation on APPROVED.
+            mockMvc.perform(patch(USERS + "/" + sellerId + "/seller-status")
+                            .header("Authorization", "Bearer " + adminToken())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(json("status", "APPROVED")))
+                    .andExpect(status().isOk());
+
+            // Without re-authenticating: /me is a live DB read, so it already reports APPROVED.
+            mockMvc.perform(get(BASE + "/account/me")
+                            .header("Authorization", "Bearer " + pendingAccess))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.sellerStatus", is("APPROVED")));
+
+            // And the still-valid refresh token rotates to a token pair whose sellerStatus is
+            // APPROVED — the mechanism the SPA uses to unlock writes without a logout/login.
+            mockMvc.perform(post(BASE + "/refresh")
+                            .header("Authorization", "Bearer " + refreshToken))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.sellerStatus", is("APPROVED")));
         }

--- a/authentication-service/src/test/resources/features/account-settings.feature
+++ b/authentication-service/src/test/resources/features/account-settings.feature
@@ -25,6 +25,18 @@ Feature: Account settings — edit own data and delete own account
     Then login with the new email "settings.chpw@bdd.com" and password "NewPassw0rd!2" succeeds
     And login with the old email "settings.chpw@bdd.com" and password "Passw0rd!1" fails with 401
 
+  Scenario: A seller reads their live approval status from their own account
+    # Backs the SPA poll that unlocks selling after approval without a re-login:
+    # GET /account/me is a live DB read, so it always reflects the current sellerStatus.
+    Given a self-registered seller "seller.status@bdd.com" with password "Passw0rd!1"
+    When the seller fetches their account
+    Then the account view shows sellerStatus "PENDING_APPROVAL"
+
+  Scenario: A non-seller account exposes no sellerStatus field
+    Given a registered user "plain.status@bdd.com" with password "Passw0rd!1"
+    When the seller fetches their account
+    Then the account view omits sellerStatus
+
   Scenario: Delete my account, then re-register with the same email
     Given a registered user "settings.delete@bdd.com" with password "Passw0rd!1"
     When the user deletes their account with password "Passw0rd!1"

--- a/config-service/src/main/resources/configurations/authentication-service.yml
+++ b/config-service/src/main/resources/configurations/authentication-service.yml
@@ -102,8 +102,15 @@ application:
   security:
     jwt:
       secret-key: ${JWT_SECRET}
-      expiration: 86400000         # 24 hours in ms
-      refresh-expiration: 604800000 # 7 days in ms
+      # Access token is deliberately short-lived (15 min). It carries authorization claims
+      # (role, sellerStatus) that must not outlive a status change: when an admin SUSPENDS a
+      # seller we revoke their refresh tokens, but the already-issued *access* token stays
+      # cryptographically valid until it expires. A 15-min ceiling bounds that window (was 24h,
+      # which let a suspended seller keep writing for a full day). The SPA renews silently via
+      # the refresh interceptor, and each renewal re-reads the live sellerStatus from the DB —
+      # so approval/suspension take effect within one token cycle without a re-login.
+      expiration: ${JWT_ACCESS_EXPIRATION:900000}   # 15 minutes in ms
+      refresh-expiration: 604800000                 # 7 days in ms
 
 springdoc:
   api-docs:

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -37,6 +37,9 @@ export interface AccountResponse {
   email: string;
   role: Role;
   createdAt: string;
+  /** Live seller-approval status (backend omits it for non-sellers). The seller UI polls
+   *  this so approval/suspension take effect without a re-login. */
+  sellerStatus?: SellerStatus;
 }
 
 export interface UpdateAccountRequest {

--- a/frontend/src/hooks/useSellerStatusSync.ts
+++ b/frontend/src/hooks/useSellerStatusSync.ts
@@ -1,0 +1,109 @@
+import { useEffect, useRef } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { authApi } from '../api/auth.api';
+import { useAuthStore } from '../stores/auth.store';
+import { useUIStore } from '../stores/ui.store';
+import { reconcileSellerStatus } from '../utils/sellerStatusSync';
+
+// A seller who is still waiting is likely watching the screen — poll briskly so approval
+// feels instant. Once approved we only need to catch a (rare) suspension, so we back off to
+// keep background traffic light. Each poll is a single tiny request (one findById).
+const PENDING_POLL_MS = 20000;
+const APPROVED_POLL_MS = 60000;
+
+/**
+ * Keeps a SELLER's session in sync with their LIVE approval status WITHOUT a re-login.
+ *
+ * Problem this solves: the JWT bakes `sellerStatus` at login, so before this hook a seller
+ * had to log out and back in to see an approval, and a suspension only took effect when the
+ * (formerly 24h) access token expired. Here we poll `GET /auth/account/me` (a live DB read)
+ * while the seller is not already suspended, and react the moment it changes:
+ *   - APPROVED  → silently rotate the token (the new token carries the APPROVED claim, so
+ *                 product writes are unlocked), show a success toast, drop the banner.
+ *   - SUSPENDED → toast + force logout.
+ *
+ * NOTE (verified in production): for an already-authenticated seller, suspension is normally
+ * enforced *before* this SUSPENDED branch runs — auth-service revokes the tokens, so the very
+ * next `/account/me` poll returns 401, the shared 401 interceptor tries a refresh (also 401,
+ * revoked) and clears auth + redirects to /login. The SUSPENDED branch below is the fallback
+ * for the case where `/me` actually returns a SUSPENDED body (e.g. an access token still
+ * accepted for reads); both paths end in an immediate logout.
+ *
+ * Mount once, high in the seller tree (SellerLayout).
+ */
+export function useSellerStatusSync() {
+  const role = useAuthStore((s) => s.role);
+  const storedStatus = useAuthStore((s) => s.sellerStatus);
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+
+  // Poll for any seller who is not already suspended: catches PENDING→APPROVED (unlock) and
+  // APPROVED→SUSPENDED (lockout). A suspended session is terminal — it gets logged out.
+  const shouldPoll = isAuthenticated && role === 'SELLER' && storedStatus !== 'SUSPENDED';
+  const pollMs = storedStatus === 'PENDING_APPROVAL' ? PENDING_POLL_MS : APPROVED_POLL_MS;
+
+  const { data } = useQuery({
+    queryKey: ['seller-status-sync'],
+    queryFn: () => authApi.getAccount(),
+    enabled: shouldPoll,
+    refetchInterval: shouldPoll ? pollMs : false,
+    refetchOnWindowFocus: shouldPoll,
+    staleTime: 0,
+    retry: false,
+  });
+
+  // Guards against firing the async token rotation twice while it is in flight.
+  const busy = useRef(false);
+
+  useEffect(() => {
+    const live = data?.sellerStatus ?? null;
+    const action = reconcileSellerStatus(storedStatus, live);
+    if (action === 'none' || busy.current) return;
+
+    const { refreshToken, setTokens, setSellerStatus, clearAuth } = useAuthStore.getState();
+    const { addToast } = useUIStore.getState();
+
+    if (action === 'unlock') {
+      busy.current = true;
+      void (async () => {
+        try {
+          if (refreshToken) {
+            // Rotating the token is what actually unlocks writes: the fresh access token
+            // carries sellerStatus=APPROVED, which the product-service guard reads.
+            const res = await authApi.refresh(refreshToken);
+            setTokens(res.accessToken, res.refreshToken);
+            setSellerStatus(res.sellerStatus ?? 'APPROVED');
+          } else {
+            setSellerStatus('APPROVED');
+          }
+          addToast({
+            id: 'seller-approved',
+            message: 'Your seller account was approved — you can start adding products now.',
+            variant: 'success',
+          });
+        } catch {
+          // If the silent refresh fails, still reflect the status; the next authenticated
+          // call refreshes or bounces to login through the normal 401 interceptor path.
+          setSellerStatus('APPROVED');
+        } finally {
+          busy.current = false;
+        }
+      })();
+      return;
+    }
+
+    if (action === 'suspend') {
+      setSellerStatus('SUSPENDED');
+      addToast({
+        id: 'seller-suspended',
+        message: 'Your seller account has been suspended. Contact support to restore access.',
+        variant: 'error',
+      });
+      clearAuth();
+      window.location.href = '/login';
+      return;
+    }
+
+    // 'sync' — mirror any other transition (e.g. re-queued to PENDING_APPROVAL).
+    setSellerStatus(live);
+  }, [data, storedStatus]);
+}

--- a/frontend/src/routes/layouts/SellerLayout.tsx
+++ b/frontend/src/routes/layouts/SellerLayout.tsx
@@ -5,6 +5,7 @@ import Navbar from '@components/layout/Navbar';
 import Sidebar from '@components/layout/Sidebar';
 import { useUIStore } from '@stores/ui.store';
 import { useAuthStore } from '@stores/auth.store';
+import { useSellerStatusSync } from '@hooks/useSellerStatusSync';
 import { ROUTES } from '@utils/constants';
 import {
   Dashboard,
@@ -30,6 +31,10 @@ export default function SellerLayout() {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
 
+  // Reconcile the seller's baked JWT status with their live status so approval/suspension
+  // take effect here without a manual logout/login.
+  useSellerStatusSync();
+
   return (
     <MotionConfig reducedMotion="user">
       <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
@@ -47,8 +52,9 @@ export default function SellerLayout() {
           >
             {sellerStatus === 'PENDING_APPROVAL' && (
               <Alert severity="warning" sx={{ mb: 3 }}>
-                Your seller account is pending approval. You can browse your dashboard,
-                but product management is locked until an administrator approves you.
+                Your seller account is pending approval. You can browse your dashboard, but
+                product management is locked until an administrator approves you. This page
+                unlocks automatically the moment you're approved — no need to sign out.
               </Alert>
             )}
             {sellerStatus === 'SUSPENDED' && (

--- a/frontend/src/stores/auth.store.ts
+++ b/frontend/src/stores/auth.store.ts
@@ -24,6 +24,8 @@ interface AuthState {
   }) => void;
   setTokens: (accessToken: string, refreshToken: string) => void;
   setEmail: (email: string) => void;
+  /** Update the seller-approval status in place (driven by the live status poll). */
+  setSellerStatus: (sellerStatus: SellerStatus | null) => void;
   clearAuth: () => void;
 }
 
@@ -55,6 +57,8 @@ export const useAuthStore = create<AuthState>()(
         set({ accessToken, refreshToken }),
 
       setEmail: (email) => set({ email }),
+
+      setSellerStatus: (sellerStatus) => set({ sellerStatus: sellerStatus ?? null }),
 
       clearAuth: () =>
         set({

--- a/frontend/src/utils/sellerStatusSync.test.ts
+++ b/frontend/src/utils/sellerStatusSync.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { reconcileSellerStatus } from './sellerStatusSync';
+
+describe('reconcileSellerStatus', () => {
+  it('does nothing when there is no live value yet', () => {
+    expect(reconcileSellerStatus('PENDING_APPROVAL', null)).toBe('none');
+    expect(reconcileSellerStatus('PENDING_APPROVAL', undefined)).toBe('none');
+  });
+
+  it('does nothing when live matches the stored status', () => {
+    expect(reconcileSellerStatus('PENDING_APPROVAL', 'PENDING_APPROVAL')).toBe('none');
+    expect(reconcileSellerStatus('APPROVED', 'APPROVED')).toBe('none');
+    expect(reconcileSellerStatus('SUSPENDED', 'SUSPENDED')).toBe('none');
+  });
+
+  it('unlocks when a pending seller becomes approved', () => {
+    expect(reconcileSellerStatus('PENDING_APPROVAL', 'APPROVED')).toBe('unlock');
+  });
+
+  it('suspends when an approved seller becomes suspended', () => {
+    expect(reconcileSellerStatus('APPROVED', 'SUSPENDED')).toBe('suspend');
+  });
+
+  it('suspends when a pending seller is suspended outright', () => {
+    expect(reconcileSellerStatus('PENDING_APPROVAL', 'SUSPENDED')).toBe('suspend');
+  });
+
+  it('re-syncs when a seller is re-queued to pending (e.g. from approved)', () => {
+    expect(reconcileSellerStatus('APPROVED', 'PENDING_APPROVAL')).toBe('sync');
+  });
+
+  it('unlocks a suspended seller who is reactivated to approved', () => {
+    expect(reconcileSellerStatus('SUSPENDED', 'APPROVED')).toBe('unlock');
+  });
+
+  it('treats a null stored status (fresh session) becoming approved as an unlock', () => {
+    expect(reconcileSellerStatus(null, 'APPROVED')).toBe('unlock');
+  });
+});

--- a/frontend/src/utils/sellerStatusSync.ts
+++ b/frontend/src/utils/sellerStatusSync.ts
@@ -1,0 +1,26 @@
+import type { SellerStatus } from '../api/types';
+
+export type SellerStatusAction = 'none' | 'unlock' | 'suspend' | 'sync';
+
+/**
+ * Decide what the SPA should do when the LIVE seller status (from GET /auth/account/me)
+ * differs from what the auth store currently holds. Pure + framework-free so it is unit
+ * testable in isolation.
+ *
+ *  - `unlock`  : became APPROVED  → silently refresh the token (new APPROVED claim), toast,
+ *                unlock the UI. No logout/login.
+ *  - `suspend` : became SUSPENDED → toast + force logout (the refresh token is already
+ *                revoked server-side, so the session cannot continue).
+ *  - `sync`    : any other change (e.g. re-queued to PENDING_APPROVAL) → mirror it into the
+ *                store so the banner matches reality.
+ *  - `none`    : unchanged, or there is nothing to act on (no live value yet).
+ */
+export function reconcileSellerStatus(
+  stored: SellerStatus | null,
+  live: SellerStatus | null | undefined,
+): SellerStatusAction {
+  if (live == null || live === stored) return 'none';
+  if (live === 'APPROVED') return 'unlock';
+  if (live === 'SUSPENDED') return 'suspend';
+  return 'sync';
+}


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body>
<p>Port guardado. Agora a verificação. Following my mandatory consistency-check rule: I'll verify the running implementation actually matches what Task 2.6 claims. <strong>First check — is the 15-min TTL actually deployed?</strong> Let me open the browser and inspect a fresh login token.</p>
<p>Browser open. Let me first verify the <strong>15-min TTL is actually deployed</strong> by registering a fresh seller and decoding the token's <code>exp - iat</code> (should be 900s, not 86400s).</p>
<p><strong>TTL = 900s (15 min) confirmed deployed.</strong> Now verify <code>GET /auth/account/me</code> exposes live <code>sellerStatus</code> (the new backend field).</p>
<p><code>/auth/account/me</code> now returns <code>sellerStatus</code> — backend field deployed. Now the real test: <strong>approval without logout</strong>. Let me log in as the pending seller in the UI (so the polling hook runs), then approve from an admin tab and watch it auto-unlock.</p>
<p>The pending seller is on the ProductForm — and the banner shows my <strong>new copy</strong>: <em>"This page unlocks automatically the moment you're approved — no need to sign out."</em> So the frontend rebuild is live. The poll hook is now running on this tab. Let me open an admin tab and approve this seller, then return here <strong>without touching tab-2</strong> to confirm it auto-unlocks.</p>
<p>Let me approve the seller via the admin API in tab-3 (admin login → find the seller → PATCH approve).</p>
<p>Approved seller id 8 → 200 APPROVED. Now, <strong>without editing tab-2</strong>, let me return to it and watch it auto-unlock (poll/focus → silent refresh → toast + enabled form).</p>
<p><strong>It auto-unlocked with no logout</strong> — pending banner gone, form alert gone, "Create product" enabled. Let me confirm the mechanism fired (silent refresh → APPROVED token) via network + store state.</p>
<p>The network trace is textbook: <code>/account/me</code> poll returned APPROVED → hook fired <code>POST /auth/refresh</code> → 200, and the store + token claim are now APPROVED (TTL 900s). No logout occurred. Let me confirm a create actually succeeds now with the rotated token.</p>
<p><strong>Create → 201 (product #6604).</strong> Bug 2 (approval without logout) is fully verified in production. Now <strong>Bug 1 — immediate suspension</strong>. Let me suspend seller 8 from the admin tab, then return to the seller tab and confirm it gets bounced to login.</p>
<p>Suspended (200). Now return to the seller tab — the focus/poll should detect it and bounce to login.</p>
<p>The seller was <strong>immediately bounced to login</strong> on returning to the tab, and the nav shows logged-out ("Entrar"). Let me confirm the store was cleared and see which mechanism fired.</p>
<p>Evidence is definitive. Suspension enforcement path: poll <code>/account/me</code> → <strong>401</strong> (auth-service rejects the revoked token) → interceptor <code>refresh</code> → <strong>401</strong> (refresh revoked) → <code>clearAuth</code> + redirect. Store fully cleared, now at <code>/login</code>. <strong>Immediate lockout confirmed.</strong></p>
<p>One honest consistency note (per my new rule): the hook's <em>explicit</em> "SUSPENDED → toast" branch didn't fire here — auth-service rejects the revoked token before <code>/me</code> can return a <code>SUSPENDED</code> body, so the interceptor's 401→logout path handles it instead. Same outcome (immediate logout), just no toast. Let me confirm the re-login still shows the suspended banner + 403.</p>
<p>Re-login shows the SUSPENDED banner. Final confirmation — create blocked with <code>seller.suspended</code>:</p>
<p><strong>All Task 2.6 checks pass in production:</strong></p>

Check | Result
-- | --
Access-token TTL now 15 min | ttlSeconds: 900 ✓
/auth/account/me exposes live sellerStatus | 200, field present ✓
Approval without logout | pending tab auto-unlocked (poll→refresh→APPROVED token), create 201 (#6604), no re-login ✓
Immediate suspension | approved seller bounced to /login, store cleared ✓
Re-login after suspend | SUSPENDED banner + create 403 seller.suspended ✓


<p>Now applying my two new mandatory rules — the consistency check surfaced one real doc↔impl divergence, and the code is correct, so I update the doc (not the code):</p>
<p><strong>Divergence:</strong> the hook's comment says <em>"SUSPENDED → toast + force logout"</em>, but in production auth-service rejects the revoked token on <code>/me</code> with <strong>401</strong> <em>before</em> it can return a <code>SUSPENDED</code> body, so the <strong>interceptor's 401→refresh-fail→logout</strong> path does the lockout (no toast). The <code>suspend</code> branch is effectively a fallback. Outcome is identical and immediate — code is correct — so I'll fix the comment to match reality.</p>
<p>That comment edit isn't browser-observable (doc only), so no re-verification needed. Now the end-of-task closeout: mark Task 2.6 verified in the plan and update memory.</p>
<p>F2 Task 2.6 is <strong>verified in production and closed out</strong>. Both defects you flagged are fixed and proven live:</p>
<ul>
<li><strong>Approval no longer needs a logout</strong> — I approved a logged-in pending seller from an admin tab and the seller's page unlocked on its own (poll → silent token refresh → APPROVED), then a product create returned 201. No sign-out.</li>
<li><strong>Suspension is immediate</strong> — suspending bounced the seller straight to <code>/login</code> (revoked token → 401 → refresh fails → auto-logout); re-login shows the suspended banner and create is blocked <code>403 seller.suspended</code>. Access-token TTL is confirmed down to 15 min.</li>
</ul>
<p>Closeout done per the new mandatory rules: consistency check run (found + corrected one doc↔code nuance — the suspend-toast is a fallback; the 401 interceptor does the real logout), plan checkbox marked <strong>verified</strong> with evidence, and memory updated.</p>
<p><strong>Test artifacts left in the DB</strong> (not deleted, per your rule): seller <code>pending.seller.f2c@test.com</code> (id 8, now SUSPENDED) and product #6604.</p>
<p>That clears F2 entirely. The remaining item is the one you raised twice: <strong>the app being slow / pages taking too long to load</strong>. I'm ready to start that now — a read-only diagnosis first (gateway/service response times, then frontend bundle + query waterfall) before proposing any change. Want me to go ahead?</p></body></html><!--EndFragment-->
</body>
</html>