### PR TITLE
feat: Fase 4 — Category Management: BROWSER-VERIFIED

### DIFF
--- a/config-service/src/main/resources/configurations/gateway-service.yml
+++ b/config-service/src/main/resources/configurations/gateway-service.yml
@@ -221,7 +221,10 @@ spring:
         - id: product-service
           uri: lb://PRODUCT-SERVICE
           predicates:
-            - Path=/api/v1/products/**
+            # Fase 4: /categories is a new top-level resource also served by product-service
+            # (category admin CRUD). Same route/filters as products; write auth is enforced
+            # inside product-service (@PreAuthorize ADMIN), mirroring how products works.
+            - Path=/api/v1/products/**,/api/v1/categories/**
           filters:
             - AddResponseHeader=API-Version, v1
             - AddResponseHeader=Sunset, TBD
@@ -398,6 +401,9 @@ gateway:
   public-paths:
     - /api/v1/auth/**
     - /api/v1/products/**
+    # Fase 4: like products, the gateway lets categories through unauthenticated and
+    # product-service enforces write auth (GET public; POST/PUT/DELETE → ADMIN).
+    - /api/v1/categories/**
     - /actuator/**
     - /fallback/**
   load-shedding:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -451,7 +451,7 @@ services:
       JWT_SECRET: ${JWT_SECRET:-bXlTdXBlclNlY3VyZVNlY3JldEtleUZvckpXVEF1dGgxMjM0NTY3ODk=}
       GATEWAY_MAX_CONCURRENT: 5000
       GATEWAY_TENANT_SERVICE_BASE_URL: http://tenant-service:8095
-      GATEWAY_PUBLIC_PATHS: /api/v1/auth/**,/actuator/**,/fallback/**,/api/v1/products,/api/v1/products/**
+      GATEWAY_PUBLIC_PATHS: /api/v1/auth/**,/actuator/**,/fallback/**,/api/v1/products,/api/v1/products/**,/api/v1/categories,/api/v1/categories/**
       VAULT_ENABLED: ${VAULT_ENABLED:-false}
       VAULT_HOST: ${VAULT_HOST:-vault}
       VAULT_TOKEN: ${VAULT_TOKEN:-root-token}


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><p>Now <code>GET /api/v1/categories → 200 OK</code>. Gateway route works. Let me see the page.</p>
<p>The categories list loads with all seeded categories, edit (pencil) + delete (trash) actions per row. Now testing <strong>CREATE</strong>. Clicking "+ Add category".</p>
<p>The "New category" form dialog opened (Name required, Description, Create disabled until name entered). Filling it.</p>
<p><code>POST → 201 Created</code> (the 401→201 is the normal token-refresh-and-retry via the interceptor). Then the list refetched. Let me confirm the new category appears.</p>
<p>Dialog closed, list refetched. The new category has a high generated id so it's lower in the list. Let me confirm it's present via the list response.</p>
<p><strong>CREATE confirmed</strong> — <code>{"id":1402,"name":"Webcams F4",...}</code> is now in the list (id generated from <code>category_seq</code>, no collision — exactly as I verified). Now testing that it appears in the <strong>ProductForm dropdown</strong> (the key cross-feature check). Opening the seller product form as admin.</p>
<p>The New product form loaded with a Category dropdown. Opening it to confirm "Webcams F4" appears.</p>
<p>The dropdown is populated. "Webcams F4" is at the bottom (after Microphones). Scrolling the dropdown to confirm.</p>
<p><strong>"Webcams F4" appears at the bottom of the ProductForm dropdown</strong> — the cross-feature integration works (a category created via the new <code>/categories</code> endpoint shows in the product form's <code>/products/categories</code> dropdown). Closing this and testing <strong>UPDATE (rename)</strong> and the <strong>409 delete-guard</strong> back on the categories page.</p>
<p>Now testing the <strong>409 delete-guard</strong> — trying to delete "Keyboards" (which has products). Let me locate its delete button.</p>
<p>"Keyboards" (id 1, has products) delete button is ref_45. Clicking it → confirm → expecting the 409 guard.</p>
<p>Confirm dialog: "'Keyboards' will be removed. If any product still uses it, the delete is rejected." Clicking Delete — expecting a 409 and a clean toast.</p>
<p><strong>DELETE /categories/1 → 409 Conflict</strong> — the delete-guard works. Let me confirm the clean toast + that Keyboards is still in the list.</p>
<p>The 409 is clean and message-keyed: <code>category.delete.has.products</code> → "Category [Keyboards] cannot be deleted because [16] product(s) still reference it." Keyboards stays in the list. Now testing <strong>UPDATE (rename)</strong> on the new "Webcams F4" — locating its edit button via DOM.</p>
<p>"Edit category" dialog opened, prefilled with "Webcams F4" + its description. Renaming it.</p>
<p><strong>PUT /categories/1402 → 200 OK</strong> — rename works. Now the final case: <strong>DELETE an unreferenced category</strong> (Webcams F4 Renamed has no products → should succeed), which also cleans up the test artifact.</p>
<p><strong>DELETE /categories/1402 → 204 No Content</strong> — unreferenced delete succeeds, and the test artifact is cleaned up. Let me confirm it's gone from the list.</p>
<p>Full CRUD cycle verified and the test artifact is cleaned up (back to the original 25 categories). One last contract path — the <strong>duplicate-name 409</strong>. Quick test: create "Monitors" (already exists).</p>
<p>The "POST" filter matched URLs not methods. Let me check the categories requests for the duplicate attempt.</p>
<p><strong>POST "Monitors" → 409 Conflict</strong> — duplicate-name guard works. Let me confirm the response body and the toast.</p>
<p>The 409 is clean and message-keyed: <code>category.name.exists</code> → "A category with the name [Monitors] already exists." The form stays open so the admin can fix the name (correct UX). Closing the dialog.</p>
<p>F4 is fully verified in production. Every path exercised end-to-end in the browser:</p>
<h2>Fase 4 — Category Management: BROWSER-VERIFIED ✅</h2>

Flow | Result | Evidence
-- | -- | --
List | ✅ | GET /categories → 200, all 25 seeded categories render with edit/delete actions
Create | ✅ | POST /categories → 201, "Webcams F4" got id 1402 from category_seq (no collision — as I'd verified), tenant_id stamped (no NOT-NULL 500)
Dropdown integration | ✅ | "Webcams F4" appeared in the ProductForm category dropdown — the new /categories endpoint and the storefront's /products/categories share the DB, invalidation works
Delete-guard (409) | ✅ | DELETE /categories/1 → 409 category.name.exists... → "Category [Keyboards] cannot be deleted because [16] product(s) still reference it." Keyboards stayed in the list
Update (rename) | ✅ | PUT /categories/1402 → 200, renamed to "Webcams F4 Renamed"
Delete unreferenced | ✅ | DELETE /categories/1402 → 204, removed cleanly — test artifact cleaned up, list back to original 25
Duplicate name (409) | ✅ | POST "Monitors" → 409 category.name.exists → "A category with the name [Monitors] already exists.", form stays open to fix


<p><strong>The real bug this verification caught:</strong> the gateway didn't route <code>/api/v1/categories</code> (only <code>/api/v1/products/**</code>). Fixed the gateway route + public-paths in both sources of truth (config-service yml + docker-compose env), you recreated the gateway, and now every path works. That's exactly why we verify in the browser and not just with green tests — the unit/integration/BDD suites all pass but couldn't see the gateway gap.</p>
<p><strong>Left clean:</strong> no test artifacts in the DB (the Webcams category I created was deleted as the final test case). The earlier F3 artifacts (seller id 20, product #6652) are still there from that session.</p>
<p>Fase 4 is done and proven. Next in the plan is <strong>F5 — order fulfillment statuses</strong> (order-service: <code>SHIPPED</code>/<code>DELIVERED</code>/<code>REFUNDED</code>, migration V1_14, and auditing every <code>OrderStatus</code> switch including the saga timeout scheduler). Want me to start F5?</p></body></html><!--EndFragment-->
</body>
</html>