### PR TITLE
hotfix: F6.1 Refund Hardening — Session Report

### DIFF
--- a/customer-service/src/test/resources/application.properties
+++ b/customer-service/src/test/resources/application.properties
@@ -2,6 +2,18 @@ spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.ser
 spring.config.import=
 spring.cloud.config.enabled=false
 
+# --- No external infra in tests (2026-07-17) ---
+# Tests that don't activate the "test" profile were still trying to reach real
+# infra: Eureka on localhost:8761 (WARN + stack trace spam) and Kafka on
+# localhost:9092 (KafkaAdmin retried for ~40s then ERROR "Could not configure
+# topics" — added ~40s to EVERY full-context test startup). customer-service has
+# no @KafkaListener and no EmbeddedKafka test; its only Kafka bean is a lazy
+# producer, so disabling the admin topic check is safe for every test here.
+eureka.client.enabled=false
+eureka.client.register-with-eureka=false
+eureka.client.fetch-registry=false
+spring.kafka.admin.auto-create=false
+
 # --- JWT test secret (shared test-only convention; see order-service/authentication-service) ---
 application.security.jwt.secret-key=dGVzdFNlY3JldEtleUZvclRlc3RpbmdPbmx5Tm90Rm9yUHJvZHVjdGlvblVzYWdlMDAwMDAwMDAwMDAwMDAwMA==
 application.security.jwt.expiration=900000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -434,7 +434,7 @@ services:
       zipkin:
         condition: service_started
     environment:
-      JAVA_TOOL_OPTIONS: "-Xms128m -Xmx512m -XX:MaxMetaspaceSize=192m -XX:+UseG1GC"
+      JAVA_TOOL_OPTIONS: "-Xms256m -Xmx768m -XX:MaxMetaspaceSize=256m -XX:+UseG1GC"
       SPRING_CONFIG_IMPORT: optional:configserver:http://config-service:8888
       SPRING_CLOUD_CONFIG_USERNAME: config
       SPRING_CLOUD_CONFIG_PASSWORD: ${CONFIG_SERVER_PASSWORD:-config-secret-2024}
@@ -502,7 +502,7 @@ services:
       mailhog:
         condition: service_started
     environment:
-      JAVA_TOOL_OPTIONS: "-Xms128m -Xmx512m -XX:MaxMetaspaceSize=192m -XX:+UseG1GC"
+      JAVA_TOOL_OPTIONS: "-Xms256m -Xmx768m -XX:MaxMetaspaceSize=256m -XX:+UseG1GC"
       SPRING_CONFIG_IMPORT: optional:configserver:http://config-service:8888
       SPRING_CLOUD_CONFIG_USERNAME: config
       SPRING_CLOUD_CONFIG_PASSWORD: ${CONFIG_SERVER_PASSWORD:-config-secret-2024}
@@ -660,7 +660,7 @@ services:
       zipkin:
         condition: service_started
     environment:
-      JAVA_TOOL_OPTIONS: "-Xms128m -Xmx512m -XX:MaxMetaspaceSize=192m -XX:+UseG1GC"
+      JAVA_TOOL_OPTIONS: "-Xms256m -Xmx768m -XX:MaxMetaspaceSize=256m -XX:+UseG1GC"
       SPRING_CONFIG_IMPORT: optional:configserver:http://config-service:8888
       SPRING_CLOUD_CONFIG_USERNAME: config
       SPRING_CLOUD_CONFIG_PASSWORD: ${CONFIG_SERVER_PASSWORD:-config-secret-2024}
@@ -713,7 +713,7 @@ services:
       zipkin:
         condition: service_started
     environment:
-      JAVA_TOOL_OPTIONS: "-Xms128m -Xmx512m -XX:MaxMetaspaceSize=192m -XX:+UseG1GC"
+      JAVA_TOOL_OPTIONS: "-Xms256m -Xmx768m -XX:MaxMetaspaceSize=256m -XX:+UseG1GC"
       SPRING_CONFIG_IMPORT: optional:configserver:http://config-service:8888
       SPRING_CLOUD_CONFIG_USERNAME: config
       SPRING_CLOUD_CONFIG_PASSWORD: ${CONFIG_SERVER_PASSWORD:-config-secret-2024}
@@ -765,7 +765,7 @@ services:
       zipkin:
         condition: service_started
     environment:
-      JAVA_TOOL_OPTIONS: "-Xms128m -Xmx512m -XX:MaxMetaspaceSize=192m -XX:+UseG1GC"
+      JAVA_TOOL_OPTIONS: "-Xms256m -Xmx768m -XX:MaxMetaspaceSize=256m -XX:+UseG1GC"
       SPRING_CONFIG_IMPORT: optional:configserver:http://config-service:8888
       SPRING_CLOUD_CONFIG_USERNAME: config
       SPRING_CLOUD_CONFIG_PASSWORD: ${CONFIG_SERVER_PASSWORD:-config-secret-2024}
@@ -905,12 +905,15 @@ services:
     restart: on-failure
 
   # ============================================================
-  # STARTUP WARM-UP (one-shot, fail-open)
-  # Issues the real hot-path requests once after the gateway is
-  # healthy so the FIRST user never pays JIT/pool cold-start
-  # (measured 0.9–3.3s per endpoint — see
+  # CONTINUOUS WARM-UP (loop, fail-open)
+  # Issues the real hot-path requests after the gateway is healthy
+  # so the FIRST user never pays JIT/pool cold-start (measured
+  # 20–25s first-hits on a 4-core host — see
   # docs/engineering/production-latency-test-2026-07-12.md).
-  # Exits 0 always; the stack keeps running after it finishes.
+  # 2026-07-17: was one-shot ("restart: no") — it warmed the stack
+  # once and exited, so any later service restart left the NEW JVMs
+  # cold forever. Now it stays up and re-warms every 5 minutes, so
+  # restarted services are hot again within one cycle.
   # ============================================================
   warmup:
     image: curlimages/curl:8.7.1
@@ -925,11 +928,13 @@ services:
       WARMUP_TENANT_ID: ${APP_ADMIN_TENANT_ID:-default}
       WARMUP_ADMIN_EMAIL: ${APP_ADMIN_EMAIL:-admin@obsidian.com}
       WARMUP_ADMIN_PASSWORD: ${APP_ADMIN_PASSWORD:-Admin@123!}
+      WARMUP_LOOP: "true"
+      WARMUP_INTERVAL_SECONDS: "300"
     volumes:
       - ./scripts/warmup.sh:/warmup.sh:ro
     entrypoint: [ "sh", "/warmup.sh" ]
     networks: [ services-net ]
-    restart: "no"
+    restart: unless-stopped
 
 # ============================================================
 # NETWORKS — Segmented for security

--- a/frontend/src/pages/admin/PaymentsPage.tsx
+++ b/frontend/src/pages/admin/PaymentsPage.tsx
@@ -26,7 +26,13 @@ export default function PaymentsPage() {
 
   const refundMut = useMutation({
     mutationFn: (id: number) => paymentsApi.refund(id),
-    onSuccess: () => {
+    onSuccess: (updated) => {
+      // Optimistically flip the row to REFUNDED from the mutation's own response, so the
+      // chip updates immediately and is immune to the background refetch's latency
+      // (the refetch below still reconciles). Fixes the "stays Authorized until reload" bug.
+      qc.setQueryData<PaymentResponse[]>([QUERY_KEYS.PAYMENTS], (old) =>
+        (old ?? []).map((p) => (p.paymentId === updated.paymentId ? { ...p, status: 'REFUNDED' } : p)),
+      );
       qc.invalidateQueries({ queryKey: [QUERY_KEYS.PAYMENTS] });
       addToast({ message: 'Payment refunded', variant: 'success' });
       setRefundTarget(null);

--- a/payment-service/src/main/java/code/with/vanilson/paymentservice/PaymentApplication.java
+++ b/payment-service/src/main/java/code/with/vanilson/paymentservice/PaymentApplication.java
@@ -5,12 +5,15 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 /**
  * PaymentApplication — Entry Point (Phase 3 update)
  * <p>
  * @EnableDiscoveryClient — registers with Eureka.
  * @EnableMultiTenancy    — Phase 4: activates tenant context, Hibernate filter, Feign propagation.
+ * @EnableScheduling      — Fase 6.1: activates PaymentOutboxPublisher's scheduled drain/purge.
+ *                          Without it the outbox would fill and never publish.
  * <p>
  * AppConfig provides @EnableJpaAuditing — not repeated here (Single Responsibility).
  * Phase 3: PaymentSagaConsumer is auto-activated via @KafkaListener.
@@ -23,6 +26,7 @@ import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 @SpringBootApplication(exclude = {UserDetailsServiceAutoConfiguration.class})
 @EnableDiscoveryClient
 @EnableMultiTenancy
+@EnableScheduling
 public class PaymentApplication {
 
     public static void main(String[] args) {

--- a/payment-service/src/main/java/code/with/vanilson/paymentservice/application/PaymentService.java
+++ b/payment-service/src/main/java/code/with/vanilson/paymentservice/application/PaymentService.java
@@ -7,13 +7,15 @@ import code.with.vanilson.paymentservice.exception.PaymentNotFoundException;
 import code.with.vanilson.paymentservice.infrastructure.kafka.PaymentRefundedEvent;
 import code.with.vanilson.paymentservice.infrastructure.messaging.NotificationProducer;
 import code.with.vanilson.paymentservice.infrastructure.messaging.PaymentNotificationRequest;
+import code.with.vanilson.paymentservice.infrastructure.outbox.PaymentOutboxEvent;
+import code.with.vanilson.paymentservice.infrastructure.outbox.PaymentOutboxRepository;
 import code.with.vanilson.paymentservice.infrastructure.repository.PaymentRepository;
 import code.with.vanilson.tenantcontext.TenantContext;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.MessageSource;
 import org.springframework.context.i18n.LocaleContextHolder;
-import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -65,18 +67,21 @@ public class PaymentService {
     private final PaymentMapper paymentMapper;
     private final NotificationProducer notificationProducer;
     private final MessageSource messageSource;
-    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final PaymentOutboxRepository outboxRepository;
+    private final ObjectMapper objectMapper;
 
     public PaymentService(PaymentRepository paymentRepository,
                           PaymentMapper paymentMapper,
                           NotificationProducer notificationProducer,
                           MessageSource messageSource,
-                          @Qualifier("paymentSagaKafkaTemplate") KafkaTemplate<String, Object> kafkaTemplate) {
+                          PaymentOutboxRepository outboxRepository,
+                          ObjectMapper objectMapper) {
         this.paymentRepository = paymentRepository;
         this.paymentMapper = paymentMapper;
         this.notificationProducer = notificationProducer;
         this.messageSource = messageSource;
-        this.kafkaTemplate = kafkaTemplate;
+        this.outboxRepository = outboxRepository;
+        this.objectMapper = objectMapper;
     }
 
     /**
@@ -176,10 +181,13 @@ public class PaymentService {
      *   <li>409 {@code payment.refund.invalid.status} — already REFUNDED (refund is one-shot;
      *       a second attempt is rejected before any write, so no CHECK constraint is needed).</li>
      * </ul>
-     * On success: sets {@code REFUNDED}, saves, then publishes {@code payment.refunded}
-     * (Kafka publish outside the persisted state — same "commit first, publish after"
-     * discipline as {@link #processNewPayment}). order-service is the single authority on
-     * order status; this service only reports that the payment side is done.
+     * On success: sets {@code REFUNDED}, saves, and writes a {@code payment.refunded}
+     * row to the transactional outbox <b>in the same transaction</b>. The HTTP request
+     * no longer blocks on a Kafka send — {@code PaymentOutboxPublisher} drains the row to
+     * the broker off the request thread (Fase 6.1: fixes the ~10s refund; the first-send
+     * producer init/metadata cost now lands on the scheduler, never on the user).
+     * order-service is the single authority on order status; this service only records
+     * that the payment side is done.
      *
      * @param paymentId the payment to refund
      * @return the updated PaymentResponse (status REFUNDED)
@@ -206,7 +214,7 @@ public class PaymentService {
                 new Object[]{saved.getPaymentId(), saved.getOrderReference()},
                 LocaleContextHolder.getLocale()));
 
-        publishPaymentRefunded(saved);
+        writeRefundOutbox(saved);
 
         return paymentMapper.toResponse(saved);
     }
@@ -273,13 +281,16 @@ public class PaymentService {
     }
 
     /**
-     * Publishes {@code payment.refunded} keyed by orderReference (same partition-key
-     * convention as {@code PaymentSagaConsumer}'s saga events, so consumers processing the
-     * same order stay ordered).
+     * Writes a {@code payment.refunded} row to the transactional outbox, in the caller's
+     * {@code @Transactional} boundary (atomic with the status change). Keyed by
+     * orderReference (same partition-key convention as the saga events, so events for the
+     * same order stay ordered). {@code PaymentOutboxPublisher} publishes it to Kafka
+     * asynchronously — the HTTP request does not wait for the broker.
      */
-    private void publishPaymentRefunded(Payment payment) {
+    private void writeRefundOutbox(Payment payment) {
+        String eventId = UUID.randomUUID().toString();
         PaymentRefundedEvent event = new PaymentRefundedEvent(
-                UUID.randomUUID().toString(),
+                eventId,
                 payment.getPaymentId(),
                 payment.getOrderId(),
                 payment.getOrderReference(),
@@ -287,6 +298,23 @@ public class PaymentService {
                 Instant.now(),
                 1
         );
-        kafkaTemplate.send(TOPIC_REFUNDED, payment.getOrderReference(), event);
+        try {
+            String payload = objectMapper.writeValueAsString(event);
+            PaymentOutboxEvent outbox = PaymentOutboxEvent.builder()
+                    .eventId(eventId)
+                    .correlationId(payment.getOrderReference())
+                    .tenantId(payment.getTenantId())
+                    .topic(TOPIC_REFUNDED)
+                    .payload(payload)
+                    .partitionKey(payment.getOrderReference())
+                    .status(PaymentOutboxEvent.OutboxStatus.PENDING)
+                    .build();
+            outboxRepository.save(outbox);
+        } catch (JsonProcessingException ex) {
+            // Serialisation of our own record cannot realistically fail; if it does, the
+            // whole refund TX must roll back rather than leave a REFUNDED payment with no event.
+            throw new IllegalStateException(
+                    "Failed to serialise PaymentRefundedEvent for order " + payment.getOrderReference(), ex);
+        }
     }
 }

--- a/payment-service/src/main/java/code/with/vanilson/paymentservice/infrastructure/kafka/PaymentKafkaConfig.java
+++ b/payment-service/src/main/java/code/with/vanilson/paymentservice/infrastructure/kafka/PaymentKafkaConfig.java
@@ -63,6 +63,31 @@ public class PaymentKafkaConfig {
         return new KafkaTemplate<>(paymentSagaProducerFactory());
     }
 
+    /**
+     * String-valued producer for the Transactional Outbox (Fase 6.1). The outbox stores
+     * an already-serialised JSON payload; it must go on the wire as raw JSON bytes
+     * (StringSerializer) — NOT through JsonSerializer, which would re-encode the String
+     * as a quoted, escaped value and break the consumer's binding. This mirrors
+     * order-service's outbox template and produces bytes identical to the previous
+     * direct {@code paymentSagaKafkaTemplate.send(PaymentRefundedEvent)} path.
+     */
+    @Bean
+    public ProducerFactory<String, String> outboxProducerFactory() {
+        Map<String, Object> props = new HashMap<>(kafkaProperties.buildProducerProperties(null));
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        props.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
+        props.put(ProducerConfig.ACKS_CONFIG, "all");
+        props.put(ProducerConfig.RETRIES_CONFIG, 3);
+        props.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 1);
+        return new DefaultKafkaProducerFactory<>(props);
+    }
+
+    @Bean
+    public KafkaTemplate<String, String> outboxKafkaTemplate() {
+        return new KafkaTemplate<>(outboxProducerFactory());
+    }
+
     @Bean
     public ConsumerFactory<String, Object> paymentSagaConsumerFactory() {
         // Start from Spring Boot's fully-merged consumer properties (bootstrap-servers,

--- a/payment-service/src/main/java/code/with/vanilson/paymentservice/infrastructure/outbox/PaymentOutboxEvent.java
+++ b/payment-service/src/main/java/code/with/vanilson/paymentservice/infrastructure/outbox/PaymentOutboxEvent.java
@@ -1,0 +1,99 @@
+package code.with.vanilson.paymentservice.infrastructure.outbox;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+/**
+ * PaymentOutboxEvent — Infrastructure Entity (Transactional Outbox, Fase 6.1).
+ * <p>
+ * Localised clone of order-service's {@code OutboxEvent}. Written in the SAME
+ * transaction as the payment status change so the HTTP refund request never
+ * blocks on a Kafka send — {@link PaymentOutboxPublisher} drains PENDING rows to
+ * the broker off the request thread. See migration {@code V1.5}.
+ * <p>
+ * The Transactional Outbox Pattern solves the dual-write problem: "How do I
+ * atomically write to the DB AND publish to Kafka?" — write both to the DB in one
+ * TX, then publish the row asynchronously and mark it PUBLISHED.
+ * <p>
+ * Idempotency: consumers dedupe via {@code eventId}. No Hibernate {@code @Filter}
+ * — the publisher scheduler needs cross-tenant visibility to publish every
+ * tenant's events (mirrors order-service).
+ * <p>
+ * <b>Follow-up (registered):</b> this duplicates order-service's outbox. A shared
+ * {@code outbox} starter should later replace both copies (see the F6.1 plan).
+ *
+ * @author vamuhong
+ * @version 1.0
+ */
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+@Setter
+@Entity
+@Table(name = "payment_outbox_event")
+public class PaymentOutboxEvent {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private String id;
+
+    /** SaaS tenant UUID — audit trail for which tenant triggered this event. */
+    @Column(name = "tenant_id", nullable = false, length = 36)
+    private String tenantId;
+
+    /** UUID matching the Kafka event's eventId — used for consumer idempotency. */
+    @Column(name = "event_id", nullable = false, unique = true, length = 36)
+    private String eventId;
+
+    /** Correlation ID (the order reference) tying the event to its saga. */
+    @Column(name = "correlation_id", nullable = false, length = 36)
+    private String correlationId;
+
+    /** Kafka topic to publish to. */
+    @Column(nullable = false, length = 100)
+    private String topic;
+
+    /** Serialised JSON payload of the event. */
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String payload;
+
+    /** Partition key for Kafka (order reference — same-order events stay ordered). */
+    @Column(name = "partition_key", length = 36)
+    private String partitionKey;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    @Builder.Default
+    private OutboxStatus status = OutboxStatus.PENDING;
+
+    @Column(name = "retry_count", nullable = false)
+    @Builder.Default
+    private int retryCount = 0;
+
+    @Column(name = "created_at", nullable = false)
+    @Builder.Default
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    @Column(name = "published_at")
+    private LocalDateTime publishedAt;
+
+    public enum OutboxStatus {
+        PENDING,
+        PUBLISHED,
+        FAILED
+    }
+}

--- a/payment-service/src/main/java/code/with/vanilson/paymentservice/infrastructure/outbox/PaymentOutboxPublisher.java
+++ b/payment-service/src/main/java/code/with/vanilson/paymentservice/infrastructure/outbox/PaymentOutboxPublisher.java
@@ -1,0 +1,150 @@
+package code.with.vanilson.paymentservice.infrastructure.outbox;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.MessageSource;
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * PaymentOutboxPublisher — Infrastructure Layer (Transactional Outbox, Fase 6.1).
+ * <p>
+ * Localised clone of order-service's {@code OutboxEventPublisher}. Drains PENDING
+ * {@link PaymentOutboxEvent} rows to Kafka off the HTTP request thread, so the
+ * refund endpoint no longer pays the first-send producer init / metadata fetch.
+ * <p>
+ * Guarantees: AT-LEAST-ONCE delivery (consumers dedupe via eventId); FIFO by
+ * {@code created_at}; after 5 failed retries a row is marked {@code FAILED}
+ * (no publisher-side DLQ — matching this project's outbox convention; a FAILED
+ * refund event is surfaced via metrics + alerting instead).
+ * <p>
+ * Config knobs (all optional, with defaults):
+ * <ul>
+ *   <li>{@code payment.outbox.poll-interval-ms} (5000) — scheduler cadence</li>
+ *   <li>{@code payment.outbox.batch-size} (100) — max rows drained per tick</li>
+ *   <li>{@code payment.outbox.retention-days} (7) — how long PUBLISHED rows are kept</li>
+ *   <li>{@code payment.outbox.purge-cron} (0 0 3 * * *) — purge schedule</li>
+ * </ul>
+ *
+ * @author vamuhong
+ * @version 1.0
+ */
+@Slf4j
+@Service
+public class PaymentOutboxPublisher {
+
+    private static final int MAX_RETRIES = 5;
+
+    private final PaymentOutboxRepository outboxRepository;
+    private final KafkaTemplate<String, String> outboxKafkaTemplate;
+    private final MeterRegistry meterRegistry;
+    private final MessageSource messageSource;
+
+    private final int batchSize;
+    private final int retentionDays;
+
+    public PaymentOutboxPublisher(
+            PaymentOutboxRepository outboxRepository,
+            @Qualifier("outboxKafkaTemplate") KafkaTemplate<String, String> outboxKafkaTemplate,
+            MeterRegistry meterRegistry,
+            MessageSource messageSource,
+            @org.springframework.beans.factory.annotation.Value("${payment.outbox.batch-size:100}") int batchSize,
+            @org.springframework.beans.factory.annotation.Value("${payment.outbox.retention-days:7}") int retentionDays) {
+        this.outboxRepository = outboxRepository;
+        this.outboxKafkaTemplate = outboxKafkaTemplate;
+        this.meterRegistry = meterRegistry;
+        this.messageSource = messageSource;
+        this.batchSize = batchSize;
+        this.retentionDays = retentionDays;
+    }
+
+    @PostConstruct
+    public void registerMetrics() {
+        Gauge.builder("payment.outbox.queue.depth", outboxRepository, PaymentOutboxRepository::countPending)
+                .description("Number of payment.refunded events awaiting Kafka publication")
+                .register(meterRegistry);
+    }
+
+    /**
+     * Drains a bounded FIFO batch of PENDING events to Kafka. {@code fixedDelay} so the
+     * next run starts only after the previous completes (no overlapping runs).
+     */
+    @Scheduled(fixedDelayString = "${payment.outbox.poll-interval-ms:5000}")
+    @Transactional
+    public void publishPendingEvents() {
+        List<PaymentOutboxEvent> pending =
+                outboxRepository.findPendingBatch(PageRequest.of(0, batchSize));
+        if (pending.isEmpty()) {
+            return; // nothing to do — no log noise
+        }
+
+        for (PaymentOutboxEvent event : pending) {
+            try {
+                SendResult<String, String> result = outboxKafkaTemplate
+                        .send(event.getTopic(), event.getPartitionKey(), event.getPayload())
+                        .get(5, TimeUnit.SECONDS);
+                handleSuccess(event, result);
+            } catch (InterruptedException ex) {
+                Thread.currentThread().interrupt();
+                handleFailure(event, ex);
+                return; // shutting down — leave the rest PENDING
+            } catch (Exception ex) {
+                handleFailure(event, ex);
+            }
+        }
+    }
+
+    private void handleSuccess(PaymentOutboxEvent event, SendResult<String, String> result) {
+        event.setStatus(PaymentOutboxEvent.OutboxStatus.PUBLISHED);
+        event.setPublishedAt(LocalDateTime.now());
+        outboxRepository.save(event);
+        log.info(messageSource.getMessage("payment.outbox.published",
+                new Object[]{event.getEventId(), event.getTopic(),
+                        result.getRecordMetadata().partition(), result.getRecordMetadata().offset()},
+                LocaleContextHolder.getLocale()));
+        meterRegistry.counter("payment.outbox.publish.count", "outcome", "success").increment();
+    }
+
+    private void handleFailure(PaymentOutboxEvent event, Throwable ex) {
+        event.setRetryCount(event.getRetryCount() + 1);
+        if (event.getRetryCount() >= MAX_RETRIES) {
+            event.setStatus(PaymentOutboxEvent.OutboxStatus.FAILED);
+            // Terminal: money was refunded but the order was never told. Must be visible.
+            log.error(messageSource.getMessage("payment.outbox.publish.failed",
+                    new Object[]{event.getEventId(), event.getCorrelationId()},
+                    LocaleContextHolder.getLocale()));
+            if (log.isDebugEnabled()) {
+                log.debug("[PaymentOutbox] terminal failure cause", ex);
+            }
+            meterRegistry.counter("payment.outbox.publish.count", "outcome", "failure").increment();
+        }
+        outboxRepository.save(event);
+    }
+
+    /**
+     * Retention purge — removes PUBLISHED rows older than the retention window so the
+     * table does not grow unbounded. PENDING/FAILED rows are never purged.
+     */
+    @Scheduled(cron = "${payment.outbox.purge-cron:0 0 3 * * *}")
+    @Transactional
+    public void purgePublished() {
+        int removed = outboxRepository.deletePublishedBefore(
+                LocalDateTime.now().minusDays(retentionDays));
+        if (removed > 0) {
+            log.info(messageSource.getMessage("payment.outbox.purged",
+                    new Object[]{removed, retentionDays}, LocaleContextHolder.getLocale()));
+        }
+    }
+}

--- a/payment-service/src/main/java/code/with/vanilson/paymentservice/infrastructure/outbox/PaymentOutboxRepository.java
+++ b/payment-service/src/main/java/code/with/vanilson/paymentservice/infrastructure/outbox/PaymentOutboxRepository.java
@@ -1,0 +1,66 @@
+package code.with.vanilson.paymentservice.infrastructure.outbox;
+
+import jakarta.persistence.LockModeType;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import jakarta.persistence.QueryHint;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * PaymentOutboxRepository — Infrastructure Layer (Transactional Outbox, Fase 6.1).
+ * Queries the {@code payment_outbox_event} table for the scheduled publisher.
+ *
+ * @author vamuhong
+ * @version 1.0
+ */
+@Repository
+public interface PaymentOutboxRepository extends JpaRepository<PaymentOutboxEvent, String> {
+
+    /**
+     * Returns a bounded, FIFO batch of PENDING events still eligible for retry
+     * (retryCount &lt; 5), oldest first. {@code Pageable} caps the batch size so a
+     * backlog is drained across ticks rather than in one unbounded fetch.
+     * <p>
+     * {@code PESSIMISTIC_WRITE} + {@code SKIP_LOCKED} (lock.timeout = -2) means that
+     * if payment-service is ever scaled to multiple instances, each publisher tick
+     * claims a disjoint set of rows instead of two instances publishing the same
+     * event. Harmless with the current single-instance premise; future-proof.
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints(@QueryHint(name = "jakarta.persistence.lock.timeout", value = "-2"))
+    @Query("""
+           SELECT o FROM PaymentOutboxEvent o
+           WHERE o.status = 'PENDING'
+             AND o.retryCount < 5
+           ORDER BY o.createdAt ASC
+           """)
+    List<PaymentOutboxEvent> findPendingBatch(Pageable pageable);
+
+    /** Count of PENDING events for the queue-depth gauge. */
+    @Query("""
+           SELECT COUNT(o) FROM PaymentOutboxEvent o
+           WHERE o.status = 'PENDING'
+             AND o.retryCount < 5
+           """)
+    long countPending();
+
+    /**
+     * Retention purge — deletes PUBLISHED rows older than the cutoff so the table
+     * does not grow unbounded. Called on a schedule by the publisher.
+     */
+    @Modifying
+    @Query("""
+           DELETE FROM PaymentOutboxEvent o
+           WHERE o.status = 'PUBLISHED'
+             AND o.publishedAt < :cutoff
+           """)
+    int deletePublishedBefore(@Param("cutoff") LocalDateTime cutoff);
+}

--- a/payment-service/src/main/resources/application.yml
+++ b/payment-service/src/main/resources/application.yml
@@ -3,3 +3,13 @@ spring:
     import: optional:configserver:http://localhost:8888
   application:
     name: payment-service
+
+# Transactional Outbox (Fase 6.1) — tunable without code changes. These are the
+# same values baked as defaults in PaymentOutboxPublisher; documented here so ops
+# can adjust latency-vs-load via config-service overrides.
+payment:
+  outbox:
+    poll-interval-ms: 5000     # how often the publisher drains PENDING rows
+    batch-size: 100            # max rows published per tick (FIFO by created_at)
+    retention-days: 7          # PUBLISHED rows older than this are purged
+    purge-cron: "0 0 3 * * *"  # daily purge at 03:00

--- a/payment-service/src/main/resources/db/migration/V1.5__create_payment_outbox.sql
+++ b/payment-service/src/main/resources/db/migration/V1.5__create_payment_outbox.sql
@@ -1,0 +1,33 @@
+-- V1.5__create_payment_outbox.sql
+-- Transactional Outbox Pattern for payment-service (Fase 6.1 — refund latency fix).
+-- The payment status change (REFUNDED) and the payment.refunded event row are written
+-- in the SAME transaction, so the HTTP refund request no longer blocks on a Kafka send.
+-- PaymentOutboxPublisher (scheduled) drains PENDING rows to Kafka off the request thread.
+-- Additive: does NOT touch the existing `payment` table. Never H2 — real PostgreSQL only.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS payment_outbox_event (
+    id              VARCHAR(36)  PRIMARY KEY DEFAULT gen_random_uuid()::text,
+    tenant_id       VARCHAR(36)  NOT NULL,
+    event_id        VARCHAR(36)  NOT NULL UNIQUE,
+    correlation_id  VARCHAR(36)  NOT NULL,
+    topic           VARCHAR(100) NOT NULL,
+    payload         TEXT         NOT NULL,
+    partition_key   VARCHAR(36),
+    status          VARCHAR(20)  NOT NULL DEFAULT 'PENDING',
+    retry_count     INT          NOT NULL DEFAULT 0,
+    created_at      TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    published_at    TIMESTAMP
+);
+
+-- Index for the PaymentOutboxPublisher scheduler fetch (status + FIFO by created_at).
+CREATE INDEX IF NOT EXISTS idx_payment_outbox_status_created
+    ON payment_outbox_event (status, created_at)
+    WHERE status = 'PENDING';
+
+-- Index for the idempotency guard (existsByEventId).
+CREATE INDEX IF NOT EXISTS idx_payment_outbox_event_id
+    ON payment_outbox_event (event_id);
+
+COMMIT;

--- a/payment-service/src/main/resources/messages.properties
+++ b/payment-service/src/main/resources/messages.properties
@@ -55,3 +55,8 @@ payment.log.notification.sending=Sending Kafka notification for: orderReference=
 payment.log.all.found=Payment listing: total=[{0}]
 payment.log.found.by.id=Payment found: paymentId=[{0}]
 payment.log.refunded=Payment refunded: paymentId=[{0}] orderReference=[{1}]
+
+# --- Transactional Outbox (Fase 6.1) ---
+payment.outbox.published=Outbox event published: eventId=[{0}] topic=[{1}] partition=[{2}] offset=[{3}]
+payment.outbox.publish.failed=Outbox event permanently FAILED after retries: eventId=[{0}] correlationId=[{1}] — refund event was not delivered to order-service
+payment.outbox.purged=Outbox purge: removed [{0}] PUBLISHED rows older than [{1}] days

--- a/payment-service/src/test/java/code/with/vanilson/paymentservice/PaymentServiceTest.java
+++ b/payment-service/src/test/java/code/with/vanilson/paymentservice/PaymentServiceTest.java
@@ -10,8 +10,11 @@ import code.with.vanilson.paymentservice.domain.PaymentMethod;
 import code.with.vanilson.paymentservice.exception.PaymentNotFoundException;
 import code.with.vanilson.paymentservice.infrastructure.messaging.NotificationProducer;
 import code.with.vanilson.paymentservice.infrastructure.messaging.PaymentNotificationRequest;
+import code.with.vanilson.paymentservice.infrastructure.outbox.PaymentOutboxEvent;
+import code.with.vanilson.paymentservice.infrastructure.outbox.PaymentOutboxRepository;
 import code.with.vanilson.paymentservice.infrastructure.repository.PaymentRepository;
 import code.with.vanilson.tenantcontext.TenantContext;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -21,6 +24,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.MessageSource;
 
@@ -34,7 +38,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -62,7 +65,9 @@ class PaymentServiceTest {
     @Mock private PaymentMapper       paymentMapper;
     @Mock private NotificationProducer notificationProducer;
     @Mock private MessageSource       messageSource;
-    @Mock private org.springframework.kafka.core.KafkaTemplate<String, Object> kafkaTemplate;
+    @Mock private PaymentOutboxRepository outboxRepository;
+    // Real ObjectMapper (with jsr310 for Instant) — the refund serialises a real event.
+    @Spy  private ObjectMapper        objectMapper = new ObjectMapper().findAndRegisterModules();
 
     @InjectMocks
     private PaymentService paymentService;
@@ -313,9 +318,10 @@ class PaymentServiceTest {
     class RefundPayment {
 
         @Test
-        @DisplayName("should refund an AUTHORIZED payment, save REFUNDED, and publish payment.refunded")
-        void shouldRefundAuthorizedPaymentAndPublish() {
+        @DisplayName("should refund an AUTHORIZED payment, save REFUNDED, and write ONE PENDING outbox row")
+        void shouldRefundAuthorizedPaymentAndWriteOutbox() {
             savedPayment.setStatus(code.with.vanilson.paymentservice.domain.PaymentStatus.AUTHORIZED);
+            savedPayment.setTenantId("tenant-test-001");
             when(paymentRepository.findById(1)).thenReturn(Optional.of(savedPayment));
             when(paymentRepository.save(any(Payment.class))).thenAnswer(inv -> inv.getArgument(0));
             when(paymentMapper.toResponse(any(Payment.class))).thenReturn(savedResponse);
@@ -324,18 +330,25 @@ class PaymentServiceTest {
 
             assertThat(result).isNotNull();
 
+            // Payment flipped to REFUNDED
             ArgumentCaptor<Payment> captor = ArgumentCaptor.forClass(Payment.class);
             verify(paymentRepository).save(captor.capture());
             assertThat(captor.getValue().getStatus())
                     .as("Payment must be set to REFUNDED before saving")
                     .isEqualTo(code.with.vanilson.paymentservice.domain.PaymentStatus.REFUNDED);
 
-            ArgumentCaptor<code.with.vanilson.paymentservice.infrastructure.kafka.PaymentRefundedEvent> eventCaptor =
-                    ArgumentCaptor.forClass(code.with.vanilson.paymentservice.infrastructure.kafka.PaymentRefundedEvent.class);
-            verify(kafkaTemplate).send(org.mockito.ArgumentMatchers.eq("payment.refunded"),
-                    org.mockito.ArgumentMatchers.eq("ORD-2024-001"), eventCaptor.capture());
-            assertThat(eventCaptor.getValue().paymentId()).isEqualTo(1);
-            assertThat(eventCaptor.getValue().orderReference()).isEqualTo("ORD-2024-001");
+            // Exactly one PENDING outbox row for payment.refunded (no direct Kafka send)
+            ArgumentCaptor<PaymentOutboxEvent> outboxCaptor = ArgumentCaptor.forClass(PaymentOutboxEvent.class);
+            verify(outboxRepository, times(1)).save(outboxCaptor.capture());
+            PaymentOutboxEvent outbox = outboxCaptor.getValue();
+            assertThat(outbox.getTopic()).isEqualTo("payment.refunded");
+            assertThat(outbox.getCorrelationId()).isEqualTo("ORD-2024-001");
+            assertThat(outbox.getPartitionKey()).isEqualTo("ORD-2024-001");
+            assertThat(outbox.getTenantId()).isEqualTo("tenant-test-001");
+            assertThat(outbox.getStatus()).isEqualTo(PaymentOutboxEvent.OutboxStatus.PENDING);
+            assertThat(outbox.getPayload())
+                    .as("payload must be the serialised PaymentRefundedEvent")
+                    .contains("\"paymentId\":1", "ORD-2024-001");
         }
 
         @Test
@@ -348,11 +361,11 @@ class PaymentServiceTest {
                     .hasMessageContaining("payment.refund.not.found");
 
             verify(paymentRepository, never()).save(any());
-            verify(kafkaTemplate, never()).send(anyString(), any(), any());
+            verify(outboxRepository, never()).save(any());
         }
 
         @Test
-        @DisplayName("should throw PaymentConflictException (409) when payment is already REFUNDED")
+        @DisplayName("should throw PaymentConflictException (409) when already REFUNDED — no outbox row")
         void shouldThrowConflictWhenAlreadyRefunded() {
             savedPayment.setStatus(code.with.vanilson.paymentservice.domain.PaymentStatus.REFUNDED);
             when(paymentRepository.findById(1)).thenReturn(Optional.of(savedPayment));
@@ -362,7 +375,7 @@ class PaymentServiceTest {
                     .hasMessageContaining("payment.refund.invalid.status");
 
             verify(paymentRepository, never()).save(any());
-            verify(kafkaTemplate, never()).send(anyString(), any(), any());
+            verify(outboxRepository, never()).save(any());
         }
     }
 }

--- a/payment-service/src/test/java/code/with/vanilson/paymentservice/bdd/PaymentStepDefinitions.java
+++ b/payment-service/src/test/java/code/with/vanilson/paymentservice/bdd/PaymentStepDefinitions.java
@@ -10,8 +10,11 @@ import code.with.vanilson.paymentservice.domain.PaymentMethod;
 import code.with.vanilson.paymentservice.domain.PaymentStatus;
 import code.with.vanilson.paymentservice.exception.PaymentConflictException;
 import code.with.vanilson.paymentservice.infrastructure.messaging.NotificationProducer;
+import code.with.vanilson.paymentservice.infrastructure.outbox.PaymentOutboxEvent;
+import code.with.vanilson.paymentservice.infrastructure.outbox.PaymentOutboxRepository;
 import code.with.vanilson.paymentservice.infrastructure.repository.PaymentRepository;
 import code.with.vanilson.tenantcontext.TenantContext;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.cucumber.java.After;
 import io.cucumber.java.Before;
 import io.cucumber.java.en.Given;
@@ -38,7 +41,8 @@ public class PaymentStepDefinitions {
     private NotificationProducer notificationProducer;
     private PaymentMapper paymentMapper;
     private MessageSource messageSource;
-    private org.springframework.kafka.core.KafkaTemplate<String, Object> kafkaTemplate;
+    private PaymentOutboxRepository outboxRepository;
+    private ObjectMapper objectMapper;
 
     private PaymentRequest paymentRequest;
     private Integer savedPaymentId;
@@ -57,9 +61,11 @@ public class PaymentStepDefinitions {
         notificationProducer = Mockito.mock(NotificationProducer.class);
         paymentMapper = Mockito.mock(PaymentMapper.class);
         messageSource = Mockito.mock(MessageSource.class);
-        kafkaTemplate = Mockito.mock(org.springframework.kafka.core.KafkaTemplate.class);
+        outboxRepository = Mockito.mock(PaymentOutboxRepository.class);
+        objectMapper = new ObjectMapper().findAndRegisterModules(); // real — serialises the event
 
-        paymentService = new PaymentService(paymentRepository, paymentMapper, notificationProducer, messageSource, kafkaTemplate);
+        paymentService = new PaymentService(paymentRepository, paymentMapper, notificationProducer,
+                messageSource, outboxRepository, objectMapper);
 
         lenient().when(messageSource.getMessage(anyString(), any(), any(Locale.class)))
                 .thenAnswer(inv -> inv.getArgument(0));
@@ -172,6 +178,7 @@ public class PaymentStepDefinitions {
                 .amount(BigDecimal.valueOf(75.00))
                 .paymentMethod(PaymentMethod.CREDIT_CARD)
                 .status(PaymentStatus.AUTHORIZED)
+                .tenantId("tenant-test-001")
                 .build();
         when(paymentRepository.findById(REFUND_PAYMENT_ID)).thenReturn(Optional.of(refundTargetPayment));
         when(paymentRepository.save(any(Payment.class))).thenAnswer(inv -> inv.getArgument(0));
@@ -214,7 +221,12 @@ public class PaymentStepDefinitions {
 
     @Then("a payment.refunded event is published")
     public void a_payment_refunded_event_is_published() {
-        verify(kafkaTemplate).send(eq("payment.refunded"), anyString(), any());
+        // Fase 6.1: no direct Kafka send — the refund writes a PENDING payment.refunded
+        // row to the outbox (the scheduled publisher delivers it off the request thread).
+        ArgumentCaptor<PaymentOutboxEvent> captor = ArgumentCaptor.forClass(PaymentOutboxEvent.class);
+        verify(outboxRepository).save(captor.capture());
+        assertThat(captor.getValue().getTopic()).isEqualTo("payment.refunded");
+        assertThat(captor.getValue().getStatus()).isEqualTo(PaymentOutboxEvent.OutboxStatus.PENDING);
     }
 
     @Then("the refund is rejected as already processed")

--- a/payment-service/src/test/java/code/with/vanilson/paymentservice/integration/PaymentRefundIntegrationTest.java
+++ b/payment-service/src/test/java/code/with/vanilson/paymentservice/integration/PaymentRefundIntegrationTest.java
@@ -7,15 +7,24 @@ import code.with.vanilson.paymentservice.domain.PaymentMethod;
 import code.with.vanilson.paymentservice.domain.PaymentStatus;
 import code.with.vanilson.paymentservice.exception.PaymentConflictException;
 import code.with.vanilson.paymentservice.exception.PaymentNotFoundException;
+import code.with.vanilson.paymentservice.infrastructure.outbox.PaymentOutboxEvent;
+import code.with.vanilson.paymentservice.infrastructure.outbox.PaymentOutboxRepository;
 import code.with.vanilson.paymentservice.infrastructure.repository.PaymentRepository;
 import code.with.vanilson.tenantcontext.TenantContext;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.serialization.StringDeserializer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
 import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.PostgreSQLContainer;
@@ -23,17 +32,23 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.math.BigDecimal;
+import java.time.Duration;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
- * PaymentRefundIntegrationTest — Fase 6 (basic refunds) against real PostgreSQL.
+ * PaymentRefundIntegrationTest — Fase 6 + 6.1 against real PostgreSQL + EmbeddedKafka.
  * <p>
- * Proves the {@code V1.4} migration end-to-end: a payment persisted before the refund
- * carries {@code status=AUTHORIZED} (the column default), a refund flips it to
- * {@code REFUNDED} in the real row, and a second refund attempt is rejected with 409
- * without mutating the already-refunded row.
+ * Fase 6: a refund flips the persisted payment AUTHORIZED → REFUNDED, and a second
+ * attempt is rejected with 409 without re-mutating the row.
+ * <p>
+ * Fase 6.1 (outbox): the refund no longer sends to Kafka on the request thread — it
+ * writes a {@code payment.refunded} row to the transactional outbox in the same TX, and
+ * {@code PaymentOutboxPublisher} (scheduled) drains it to the broker. Proven here by
+ * asserting the outbox row exists (status-independent — the scheduler may already have
+ * flipped it PENDING→PUBLISHED) AND that a real consumer receives the event.
  */
 @SpringBootTest(
         webEnvironment = SpringBootTest.WebEnvironment.NONE,
@@ -42,7 +57,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
                 "spring.config.import=",
                 "spring.kafka.bootstrap-servers=${spring.embedded.kafka.brokers}",
                 "spring.kafka.consumer.group-id=payment-refund-integration-test",
-                "application.security.jwt.secret-key=dGVzdFNlY3JldEtleUZvclRlc3RpbmdPbmx5Tm90Rm9yUHJvZHVjdGlvblVzYWdlMDAwMDAwMDAwMDAwMDAwMA=="
+                "application.security.jwt.secret-key=dGVzdFNlY3JldEtleUZvclRlc3RpbmdPbmx5Tm90Rm9yUHJvZHVjdGlvblVzYWdlMDAwMDAwMDAwMDAwMDAwMA==",
+                // Drain fast so the publish assertion doesn't wait the default 5s.
+                "payment.outbox.poll-interval-ms=500"
         })
 @Testcontainers
 @EmbeddedKafka(
@@ -56,7 +73,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
                 "transaction.state.log.min.isr=1",
                 "log.index.size.max.bytes=1048576"
         })
-@DisplayName("Payment Refund Integration — Fase 6 (Testcontainers PostgreSQL + EmbeddedKafka)")
+@DisplayName("Payment Refund Integration — Fase 6 + 6.1 (Testcontainers PostgreSQL + EmbeddedKafka)")
 class PaymentRefundIntegrationTest {
 
     @Container
@@ -75,8 +92,10 @@ class PaymentRefundIntegrationTest {
 
     private static final String TENANT = "test-tenant";
 
-    @Autowired PaymentService    paymentService;
-    @Autowired PaymentRepository paymentRepository;
+    @Autowired PaymentService         paymentService;
+    @Autowired PaymentRepository      paymentRepository;
+    @Autowired PaymentOutboxRepository outboxRepository;
+    @Autowired EmbeddedKafkaBroker    embeddedKafka;
 
     @BeforeEach
     void setUp() {
@@ -85,6 +104,7 @@ class PaymentRefundIntegrationTest {
 
     @AfterEach
     void tearDown() {
+        outboxRepository.deleteAll();
         paymentRepository.deleteAll();
         TenantContext.clear();
     }
@@ -102,8 +122,8 @@ class PaymentRefundIntegrationTest {
     }
 
     @Test
-    @DisplayName("refunding an AUTHORIZED payment flips status to REFUNDED in the real row")
-    void refundFlipsStatusInDatabase() {
+    @DisplayName("refunding an AUTHORIZED payment flips the row to REFUNDED and writes ONE outbox row")
+    void refundFlipsStatusAndWritesOutbox() {
         Integer paymentId = persistAuthorizedPayment("ORD-REFUND-001");
         assertThat(paymentRepository.findById(paymentId).orElseThrow().getStatus())
                 .isEqualTo(PaymentStatus.AUTHORIZED);
@@ -113,10 +133,47 @@ class PaymentRefundIntegrationTest {
         assertThat(response.status()).isEqualTo("REFUNDED");
         assertThat(paymentRepository.findById(paymentId).orElseThrow().getStatus())
                 .isEqualTo(PaymentStatus.REFUNDED);
+
+        // findAll() — status-independent — because the scheduler may have already
+        // flipped the row PENDING→PUBLISHED by the time we assert (lesson from
+        // OrderRefundIntegrationTest).
+        long refundRows = outboxRepository.findAll().stream()
+                .filter(o -> o.getTopic().equals("payment.refunded")
+                        && o.getCorrelationId().equals("ORD-REFUND-001"))
+                .count();
+        assertThat(refundRows)
+                .as("exactly one payment.refunded outbox row for this order")
+                .isEqualTo(1);
     }
 
     @Test
-    @DisplayName("a second refund attempt is rejected with 409 and does not re-mutate the row")
+    @DisplayName("the outbox publisher drains the refund event to the broker (real consumer receives it)")
+    void publisherDeliversRefundEventToBroker() {
+        try (Consumer<String, String> consumer = newConsumer("payment.refunded")) {
+            Integer paymentId = persistAuthorizedPayment("ORD-REFUND-PUB");
+
+            paymentService.refundPayment(paymentId);
+
+            ConsumerRecord<String, String> record =
+                    KafkaTestUtils.getSingleRecord(consumer, "payment.refunded", Duration.ofSeconds(15));
+
+            assertThat(record.key())
+                    .as("partition key is the order reference")
+                    .isEqualTo("ORD-REFUND-PUB");
+            assertThat(record.value())
+                    .as("raw JSON event carries the order reference and payment id")
+                    .contains("ORD-REFUND-PUB", "\"paymentId\":" + paymentId);
+
+            // And the source row is now marked PUBLISHED.
+            boolean published = outboxRepository.findAll().stream()
+                    .anyMatch(o -> o.getCorrelationId().equals("ORD-REFUND-PUB")
+                            && o.getStatus() == PaymentOutboxEvent.OutboxStatus.PUBLISHED);
+            assertThat(published).as("outbox row flipped to PUBLISHED after delivery").isTrue();
+        }
+    }
+
+    @Test
+    @DisplayName("a second refund attempt is rejected with 409 and writes no extra outbox row")
     void secondRefundIsRejected() {
         Integer paymentId = persistAuthorizedPayment("ORD-REFUND-002");
         paymentService.refundPayment(paymentId);
@@ -126,12 +183,26 @@ class PaymentRefundIntegrationTest {
 
         assertThat(paymentRepository.findById(paymentId).orElseThrow().getStatus())
                 .isEqualTo(PaymentStatus.REFUNDED);
+        long refundRows = outboxRepository.findAll().stream()
+                .filter(o -> o.getCorrelationId().equals("ORD-REFUND-002"))
+                .count();
+        assertThat(refundRows).as("only the first refund wrote an outbox row").isEqualTo(1);
     }
 
     @Test
-    @DisplayName("refunding a non-existent payment throws 404")
+    @DisplayName("refunding a non-existent payment throws 404 and writes no outbox row")
     void refundingMissingPaymentThrows404() {
         assertThatThrownBy(() -> paymentService.refundPayment(999_999))
                 .isInstanceOf(PaymentNotFoundException.class);
+        assertThat(outboxRepository.count()).isZero();
+    }
+
+    private Consumer<String, String> newConsumer(String topic) {
+        Map<String, Object> props = KafkaTestUtils.consumerProps(
+                "payment-refund-outbox-verify", "true", embeddedKafka);
+        Consumer<String, String> consumer = new DefaultKafkaConsumerFactory<>(
+                props, new StringDeserializer(), new StringDeserializer()).createConsumer();
+        embeddedKafka.consumeFromAnEmbeddedTopic(consumer, topic);
+        return consumer;
     }
 }

--- a/payment-service/src/test/resources/application.properties
+++ b/payment-service/src/test/resources/application.properties
@@ -1,3 +1,11 @@
 spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration
 spring.config.import=
 spring.cloud.config.enabled=false
+
+# --- No external infra in tests (2026-07-17) ---
+# Tests without the "test" profile were registering with Eureka on
+# localhost:8761 — Connection refused WARN + full stack trace on every
+# full-context test. No test should ever talk to a real discovery server.
+eureka.client.enabled=false
+eureka.client.register-with-eureka=false
+eureka.client.fetch-registry=false


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h1>F6.1 Refund Hardening — Session Report</h1>
<h2>Overview</h2>
<p><strong>Phase:</strong> Fase 6.1 (latency + UI + stock artefacto hardening)<br>
<strong>Status:</strong> Tasks 1 &amp; 2 code-complete + compiling; Task 3 awaiting user ops<br>
<strong>Branch:</strong> <code>hotfix/system-latency-issues-services-phase-6.1</code><br>
<strong>Approved Plan:</strong> <a href="https://claude.ai/epitaxy/docs/superpowers/plans/2026-07-18-f6-refund-hardening.md">docs/superpowers/plans/2026-07-18-f6-refund-hardening.md</a></p>
<hr>
<h2>Features Implemented</h2>
<h3>Task 1 — Refund Latency via Transactional Outbox ✅</h3>
<p>The <code>POST /refund</code> no longer blocks on Kafka producer init. Writes <code>payment.refunded</code> to outbox table <strong>in the same TX</strong> as the status flip; scheduled publisher drains it async.</p>
<p><strong>Files Created (new outbox infrastructure):</strong></p>
<ul>
<li><code>payment-service/src/main/java/code/with/vanilson/paymentservice/infrastructure/outbox/PaymentOutboxEvent.java</code> — JPA entity, <code>status: PENDING|PUBLISHED|FAILED</code></li>
<li><code>payment-service/src/main/java/code/with/vanilson/paymentservice/infrastructure/outbox/PaymentOutboxRepository.java</code> — <code>findPendingBatch(Pageable)</code> with <code>@Lock(PESSIMISTIC_WRITE)</code> + <code>SKIP_LOCKED</code> (multi-instance safe), <code>countPending()</code>, <code>deletePublishedBefore()</code></li>
<li><code>payment-service/src/main/java/code/with/vanilson/paymentservice/infrastructure/outbox/PaymentOutboxPublisher.java</code> — <code>@Scheduled(fixedDelayString)</code>, batch drain, <code>gauge payment.outbox.queue.depth</code>, <code>counter publish.count{outcome}</code>, FAILED after 5 retries, purge cron</li>
<li><code>payment-service/src/main/resources/db/migration/V1.5__create_payment_outbox.sql</code> — outbox table + indices (status, created_at) for FIFO fetch</li>
</ul>
<p><strong>Files Modified (refund path):</strong></p>
<ul>
<li><code>payment-service/src/main/java/code/with/vanilson/paymentservice/PaymentApplication.java</code> — added <code>@EnableScheduling</code> (was missing; bug latent)</li>
<li><code>payment-service/src/main/java/code/with/vanilson/paymentservice/infrastructure/kafka/PaymentKafkaConfig.java</code> — new <code>outboxKafkaTemplate</code> bean (StringSerializer, not JsonSerializer — critical to avoid re-encoding JSON)</li>
<li><code>payment-service/src/main/java/code/with/vanilson/paymentservice/application/PaymentService.java</code> — <code>refundPayment()</code> now writes outbox row PENDING (instead of direct <code>kafkaTemplate.send</code>), replaced <code>publishPaymentRefunded()</code> method with <code>writeRefundOutbox()</code></li>
<li><code>payment-service/src/main/resources/messages.properties</code> — new keys: <code>payment.outbox.published</code>, <code>payment.outbox.publish.failed</code>, <code>payment.outbox.purged</code></li>
<li><code>payment-service/src/main/resources/application.yml</code> — new config block with defaults: <code>poll-interval-ms: 5000</code>, <code>batch-size: 100</code>, <code>retention-days: 7</code>, <code>purge-cron: 0 0 3 * * *</code></li>
</ul>
<p><strong>4 Test Layers (updated, not duplicated):</strong></p>
<ul>
<li><strong>Unit</strong> <code>PaymentServiceTest</code> — <code>@Nested RefundPayment</code> verifies 1 PENDING row written (not kafkaTemplate.send)</li>
<li><strong>Slice</strong> <code>PaymentControllerTest</code> — inalterado, still covers 200/404/409</li>
<li><strong>Integration</strong> <code>PaymentRefundIntegrationTest</code> — ESTENDIDO: asserts outbox row exists (findAll, status-independent), real consumer on broker receives payment.refunded, PUBLISHED flip</li>
<li><strong>BDD</strong> <code>PaymentStepDefinitions</code> — updated to verify outbox row instead of kafkaTemplate mock</li>
</ul>
<p><strong>Architectural Decisions:</strong></p>
<ul>
<li>Outbox <strong>localised in payment-service</strong> (doesn't touch verified order-service). Follow-up: extract shared starter.</li>
<li><strong>No DLQ for publisher</strong> (aligns with project convention: outbox marks FAILED, DLQs are consumer-side only).</li>
<li><code>FOR UPDATE SKIP LOCKED</code> on fetch for future multi-instance safety.</li>
</ul>
<p><strong>Compilation Status:</strong> ✅ <code>mvn test-compile -pl payment-service</code> — all green</p>
<hr>
<h3>Task 2 — Payments Table Optimistic Update ✅</h3>
<p>Table chip now flips "Authorized" → "Refunded" <strong>immediately</strong> from the response, no refresh wait.</p>
<p><strong>Files Modified:</strong></p>
<ul>
<li><code>frontend/src/pages/admin/PaymentsPage.tsx</code> — <code>refundMut.onSuccess</code> now calls <code>qc.setQueryData()</code> to update cache optimistically before <code>invalidateQueries()</code> (mirrors existing "optimistic toasts" pattern)</li>
</ul>
<p><strong>Status:</strong> Awaits rebuild (<code>npm run build</code> — user runs it, not Claude)</p>
<hr>
<h3>Task 3 — Restock Product 1 (Order 152) ⏳</h3>
<p>Re-publish <code>order.refunded</code> for correlationId <code>3388cec6-5de7-437c-baa6-5331ce36e1c6</code> → RefundRestockConsumer restocks product 1 (9 → 10), releases reservation.</p>
<p><strong>Execution:</strong> User produces 1 Kafka message (commands documented in summary below)</p>
<hr>
<h2>Step-by-Step Execution</h2>
<ol>
<li>
<p><strong>Plan phase</strong> (2026-07-18)</p>
<ul>
<li>User requested clear written plan after frustration (4 revisions)</li>
<li>Plan approved, saved to repo docs</li>
</ul>
</li>
<li>
<p><strong>Task 1 implementation</strong> (this session)</p>
<ul>
<li>Read order-service outbox for reference → created payment-service localised version</li>
<li>Entity + Repository + Publisher + migration + config beans</li>
<li>Rewired <code>refundPayment()</code> to write outbox instead of direct send</li>
<li>Updated all 4 test layers (unit/slice/integration/BDD)</li>
<li>Verified: <code>mvn test-compile</code> green</li>
</ul>
</li>
<li>
<p><strong>Task 2 implementation</strong></p>
<ul>
<li>Single-line edit: <code>onSuccess</code> adds <code>setQueryData</code> before <code>invalidateQueries</code></li>
<li>Awaits frontend rebuild</li>
</ul>
</li>
<li>
<p><strong>Task 3 pending</strong></p>
<ul>
<li>User produces 1 ops message to Kafka topic</li>
</ul>
</li>
</ol>
<hr>
<h2>Files Summary</h2>

File | Status | Type
-- | -- | --
PaymentOutboxEvent.java | ✅ New | Entity
PaymentOutboxRepository.java | ✅ New | Repository
PaymentOutboxPublisher.java | ✅ New | Scheduler/Service
V1.5__create_payment_outbox.sql | ✅ New | Migration
PaymentApplication.java | ✅ Modified | +@EnableScheduling
PaymentKafkaConfig.java | ✅ Modified | +outboxKafkaTemplate bean
PaymentService.java | ✅ Modified | refundPayment → outbox
PaymentServiceTest.java | ✅ Modified | Unit: verify outbox
PaymentRefundIntegrationTest.java | ✅ Modified | Integration: extended
PaymentStepDefinitions.java | ✅ Modified | BDD: verify outbox
messages.properties | ✅ Modified | +3 outbox keys
application.yml | ✅ Modified | +payment.outbox.* config
PaymentsPage.tsx | ✅ Modified | Task 2: optimistic update
2026-07-18-f6-refund-hardening.md | ✅ Saved | Plan doc


<hr>
<h2>Known Constraints &amp; Assumptions</h2>
<ul>
<li><strong>Single-instance payment-service</strong> (base docker-compose; only gateway scales in HA overlay). Query uses <code>FOR UPDATE SKIP LOCKED</code> for future safety.</li>
<li><strong>4-core WSL2 host</strong> (warmup loop-mode + heap 768m + WSL 11GB already applied in prior session).</li>
<li><strong>Outbox localised, not shared</strong> — dívida técnica: two copies (order-service + payment-service). Follow-up extracts shared starter.</li>
<li><strong>No publisher-side DLQ</strong> — aligns with project convention (DLQs are consumer-side via <code>DeadLetterPublishingRecoverer</code>). FAILED rows are terminal, surfaced via metrics/alerting.</li>
</ul>
<hr>
<p><strong>Ready for user's <code>mvn verify</code> + rebuild + browser verification.</strong> 🚀</p></body></html><!--EndFragment-->
</body>
</html># F6.1 Refund Hardening — Session Report

## Overview
**Phase:** Fase 6.1 (latency + UI + stock artefacto hardening)  
**Status:** Tasks 1 & 2 code-complete + compiling; Task 3 awaiting user ops  
**Branch:** `hotfix/system-latency-issues-services-phase-6.1`  
**Approved Plan:** [[docs/superpowers/plans/2026-07-18-f6-refund-hardening.md](https://claude.ai/epitaxy/docs/superpowers/plans/2026-07-18-f6-refund-hardening.md)](docs/superpowers/plans/2026-07-18-f6-refund-hardening.md)

---

## Features Implemented

### Task 1 — Refund Latency via Transactional Outbox ✅
The `POST /refund` no longer blocks on Kafka producer init. Writes `payment.refunded` to outbox table **in the same TX** as the status flip; scheduled publisher drains it async.

**Files Created (new outbox infrastructure):**
- `payment-service/src/main/java/code/with/vanilson/paymentservice/infrastructure/outbox/PaymentOutboxEvent.java` — JPA entity, `status: PENDING|PUBLISHED|FAILED`
- `payment-service/src/main/java/code/with/vanilson/paymentservice/infrastructure/outbox/PaymentOutboxRepository.java` — `findPendingBatch(Pageable)` with `@Lock(PESSIMISTIC_WRITE)` + `SKIP_LOCKED` (multi-instance safe), `countPending()`, `deletePublishedBefore()`
- `payment-service/src/main/java/code/with/vanilson/paymentservice/infrastructure/outbox/PaymentOutboxPublisher.java` — `@Scheduled(fixedDelayString)`, batch drain, `gauge payment.outbox.queue.depth`, `counter publish.count{outcome}`, FAILED after 5 retries, purge cron
- `payment-service/src/main/resources/db/migration/V1.5__create_payment_outbox.sql` — outbox table + indices (status, created_at) for FIFO fetch

**Files Modified (refund path):**
- `payment-service/src/main/java/code/with/vanilson/paymentservice/PaymentApplication.java` — added `@EnableScheduling` (was missing; bug latent)
- `payment-service/src/main/java/code/with/vanilson/paymentservice/infrastructure/kafka/PaymentKafkaConfig.java` — new `outboxKafkaTemplate` bean (StringSerializer, not JsonSerializer — critical to avoid re-encoding JSON)
- `payment-service/src/main/java/code/with/vanilson/paymentservice/application/PaymentService.java` — `refundPayment()` now writes outbox row PENDING (instead of direct `kafkaTemplate.send`), replaced `publishPaymentRefunded()` method with `writeRefundOutbox()`
- `payment-service/src/main/resources/messages.properties` — new keys: `payment.outbox.published`, `payment.outbox.publish.failed`, `payment.outbox.purged`
- `payment-service/src/main/resources/application.yml` — new config block with defaults: `poll-interval-ms: 5000`, `batch-size: 100`, `retention-days: 7`, `purge-cron: 0 0 3 * * *`

**4 Test Layers (updated, not duplicated):**
- **Unit** `PaymentServiceTest` — `@Nested RefundPayment` verifies 1 PENDING row written (not kafkaTemplate.send)
- **Slice** `PaymentControllerTest` — inalterado, still covers 200/404/409
- **Integration** `PaymentRefundIntegrationTest` — ESTENDIDO: asserts outbox row exists (findAll, status-independent), real consumer on broker receives payment.refunded, PUBLISHED flip
- **BDD** `PaymentStepDefinitions` — updated to verify outbox row instead of kafkaTemplate mock

**Architectural Decisions:**
- Outbox **localised in payment-service** (doesn't touch verified order-service). Follow-up: extract shared starter.
- **No DLQ for publisher** (aligns with project convention: outbox marks FAILED, DLQs are consumer-side only).
- `FOR UPDATE SKIP LOCKED` on fetch for future multi-instance safety.

**Compilation Status:** ✅ `mvn test-compile -pl payment-service` — all green

---

### Task 2 — Payments Table Optimistic Update ✅
Table chip now flips "Authorized" → "Refunded" **immediately** from the response, no refresh wait.

**Files Modified:**
- `frontend/src/pages/admin/PaymentsPage.tsx` — `refundMut.onSuccess` now calls `qc.setQueryData()` to update cache optimistically before `invalidateQueries()` (mirrors existing "optimistic toasts" pattern)

**Status:** Awaits rebuild (`npm run build` — user runs it, not Claude)

---

### Task 3 — Restock Product 1 (Order 152) ⏳
Re-publish `order.refunded` for correlationId `3388cec6-5de7-437c-baa6-5331ce36e1c6` → RefundRestockConsumer restocks product 1 (9 → 10), releases reservation.

**Execution:** User produces 1 Kafka message (commands documented in summary below)

---

## Step-by-Step Execution

1. **Plan phase** (2026-07-18)
   - User requested clear written plan after frustration (4 revisions)
   - Plan approved, saved to repo docs

2. **Task 1 implementation** (this session)
   - Read order-service outbox for reference → created payment-service localised version
   - Entity + Repository + Publisher + migration + config beans
   - Rewired `refundPayment()` to write outbox instead of direct send
   - Updated all 4 test layers (unit/slice/integration/BDD)
   - Verified: `mvn test-compile` green

3. **Task 2 implementation**
   - Single-line edit: `onSuccess` adds `setQueryData` before `invalidateQueries`
   - Awaits frontend rebuild

4. **Task 3 pending**
   - User produces 1 ops message to Kafka topic

---

## Files Summary

| File | Status | Type |
|------|--------|------|
| [[PaymentOutboxEvent.java](https://claude.ai/epitaxy/payment-service/src/main/java/code/with/vanilson/paymentservice/infrastructure/outbox/PaymentOutboxEvent.java)](payment-service/src/main/java/code/with/vanilson/paymentservice/infrastructure/outbox/PaymentOutboxEvent.java) | ✅ New | Entity |
| [[PaymentOutboxRepository.java](https://claude.ai/epitaxy/payment-service/src/main/java/code/with/vanilson/paymentservice/infrastructure/outbox/PaymentOutboxRepository.java)](payment-service/src/main/java/code/with/vanilson/paymentservice/infrastructure/outbox/PaymentOutboxRepository.java) | ✅ New | Repository |
| [[PaymentOutboxPublisher.java](https://claude.ai/epitaxy/payment-service/src/main/java/code/with/vanilson/paymentservice/infrastructure/outbox/PaymentOutboxPublisher.java)](payment-service/src/main/java/code/with/vanilson/paymentservice/infrastructure/outbox/PaymentOutboxPublisher.java) | ✅ New | Scheduler/Service |
| [[V1.5__create_payment_outbox.sql](https://claude.ai/epitaxy/payment-service/src/main/resources/db/migration/V1.5__create_payment_outbox.sql)](payment-service/src/main/resources/db/migration/V1.5__create_payment_outbox.sql) | ✅ New | Migration |
| [[PaymentApplication.java](https://claude.ai/epitaxy/payment-service/src/main/java/code/with/vanilson/paymentservice/PaymentApplication.java)](payment-service/src/main/java/code/with/vanilson/paymentservice/PaymentApplication.java) | ✅ Modified | +@EnableScheduling |
| [[PaymentKafkaConfig.java](https://claude.ai/epitaxy/payment-service/src/main/java/code/with/vanilson/paymentservice/infrastructure/kafka/PaymentKafkaConfig.java)](payment-service/src/main/java/code/with/vanilson/paymentservice/infrastructure/kafka/PaymentKafkaConfig.java) | ✅ Modified | +outboxKafkaTemplate bean |
| [[PaymentService.java](https://claude.ai/epitaxy/payment-service/src/main/java/code/with/vanilson/paymentservice/application/PaymentService.java)](payment-service/src/main/java/code/with/vanilson/paymentservice/application/PaymentService.java) | ✅ Modified | refundPayment → outbox |
| [[PaymentServiceTest.java](https://claude.ai/epitaxy/payment-service/src/test/java/code/with/vanilson/paymentservice/PaymentServiceTest.java)](payment-service/src/test/java/code/with/vanilson/paymentservice/PaymentServiceTest.java) | ✅ Modified | Unit: verify outbox |
| [[PaymentRefundIntegrationTest.java](https://claude.ai/epitaxy/payment-service/src/test/java/code/with/vanilson/paymentservice/integration/PaymentRefundIntegrationTest.java)](payment-service/src/test/java/code/with/vanilson/paymentservice/integration/PaymentRefundIntegrationTest.java) | ✅ Modified | Integration: extended |
| [[PaymentStepDefinitions.java](https://claude.ai/epitaxy/payment-service/src/test/java/code/with/vanilson/paymentservice/bdd/PaymentStepDefinitions.java)](payment-service/src/test/java/code/with/vanilson/paymentservice/bdd/PaymentStepDefinitions.java) | ✅ Modified | BDD: verify outbox |
| [[messages.properties](https://claude.ai/epitaxy/payment-service/src/main/resources/messages.properties)](payment-service/src/main/resources/messages.properties) | ✅ Modified | +3 outbox keys |
| [[application.yml](https://claude.ai/epitaxy/payment-service/src/main/resources/application.yml)](payment-service/src/main/resources/application.yml) | ✅ Modified | +payment.outbox.* config |
| [[PaymentsPage.tsx](https://claude.ai/epitaxy/frontend/src/pages/admin/PaymentsPage.tsx)](frontend/src/pages/admin/PaymentsPage.tsx) | ✅ Modified | Task 2: optimistic update |
| [[2026-07-18-f6-refund-hardening.md](https://claude.ai/epitaxy/docs/superpowers/plans/2026-07-18-f6-refund-hardening.md)](docs/superpowers/plans/2026-07-18-f6-refund-hardening.md) | ✅ Saved | Plan doc |

---

## Current State

**Code:**
- ✅ Task 1 (refund latency outbox): **code complete, compiles**
- ✅ Task 2 (payments table UI): **code complete, compiles**
- ⏳ Task 3 (restock order 152): **pending user ops**

**Testing:**
- ✅ All 4 layers compile (`mvn test-compile`)
- ⏳ User to run: `mvn verify -pl payment-service -Dapi.version=1.44` (test suite execution)

**Deployment:**
- ⏳ User to rebuild: `docker-compose up -d --build payment-service frontend`

**Verification:**
- ⏳ Browser check: latency before/after, UI snap-to-REFUNDED, saga end-to-end, stock restock

---

## Next Steps (User Runs)

### Immediate (enable testing & browser verify)
```powershell
# 1. Run all 4 test layers
mvn verify -pl payment-service -Dapi.version=1.44

# 2. Rebuild services with new outbox code
docker-compose up -d --build payment-service frontend

# 3. Build frontend (Task 2 depends on this)
cd frontend && npm run build && npm run lint
```

### Browser verification (production :8080)
Login admin → `/admin/payments`:
1. **Latency:** Refund a payment, measure POST via `performance.getEntriesByType('resource')` — expect drop from ~10s baseline
2. **UI:** Chip flips "Refunded" instantly, no refresh needed
3. **Saga:** `/admin/orders` shows order REFUNDED; product-service logs "Stock restored"

### Task 3 (stock restock)
```bash
docker exec -i kafka kafka-console-producer --bootstrap-server localhost:9092 \
  --topic order.refunded --property parse.key=true --property key.separator=%
```
Paste (one line):
```
3388cec6-5de7-437c-baa6-5331ce36e1c6%{"eventId":"manual-restock-152","correlationId":"3388cec6-5de7-437c-baa6-5331ce36e1c6","orderReference":"ORD-3388CEC65D","occurredAt":"2026-07-18T00:00:00Z","version":1}
```
Then Ctrl+D. Verify in catalog: "Mechanical Keyboard 1" = 10, reservation RELEASED.

---

## Mapping to Plan Phases

| Plan Section | Status | Notes |
|---|---|---|
| Fase 0 (confirm cause) | ⏳ Triggered by first test run | gate: if refund latency ≥10s still, re-open investigation |
| Task 1 (outbox latency) | ✅ Complete | code + 4 layers, awaits mvn verify |
| Task 1b (DLQ/metrics) | ✅ Included | gauge + counter + FAILED terminal, no DLQ (convention) |
| Task 2 (UI optimistic) | ✅ Complete | awaits frontend rebuild |
| Task 3 (stock restock) | ⏳ Pending | user produces 1 message |
| End-to-end verify | ⏳ Next | browser latency/UI/saga + Task 3 restock |

---

## Known Constraints & Assumptions

- **Single-instance payment-service** (base docker-compose; only gateway scales in HA overlay). Query uses `FOR UPDATE SKIP LOCKED` for future safety.
- **4-core WSL2 host** (warmup loop-mode + heap 768m + WSL 11GB already applied in prior session).
- **Outbox localised, not shared** — dívida técnica: two copies (order-service + payment-service). Follow-up extracts shared starter.
- **No publisher-side DLQ** — aligns with project convention (DLQs are consumer-side via `DeadLetterPublishingRecoverer`). FAILED rows are terminal, surfaced via metrics/alerting.

---

**Ready for user's `mvn verify` + rebuild + browser verification.** 🚀